### PR TITLE
chore: Add github settings for labels & remove node 8 from travis

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,2 @@
+---
+_extends: 'open-source-project-boilerplate'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ language: node_js
 node_js:
   - '12'
   - '10'
-  - '8'


### PR DESCRIPTION
# What / Why
- Add `.github/settings.yml` to pick up our default OSS labels
- Remove **node** `8` from travis config (probably speeds up tests & **npm** `7` won't be supporting `8` either way)
