### PR TITLE
feat: reuse created ideal and actual trees

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -82,6 +82,10 @@ module.exports = cls => class IdealTreeBuilder extends Virtual(Actual(cls)) {
 
   // public method
   buildIdealTree (options = {}) {
+    if (this.idealTree) {
+      return this.idealTree
+    }
+
     // first get the virtual tree, if possible.  If there's a lockfile, then
     // that defines the ideal tree, unless the root package.json is not
     // satisfied by what the ideal tree provides.

--- a/lib/arborist/load-actual.js
+++ b/lib/arborist/load-actual.js
@@ -57,6 +57,10 @@ module.exports = cls => class ActualLoader extends cls {
 
   // public method
   loadActual () {
+    if (this.actualTree) {
+      return this.actualTree
+    }
+
     // mostly realpath to throw if the root doesn't exist
     return realpath(this.path, this[_rpcache], this[_stcache])
       .then(real => this[loadFSNode]({ path: this.path, real }))


### PR DESCRIPTION
# What / Why
When the arborist instance already has `idealTree` or `actualTree`, use them instead of re-creating them.

## References

Discussed in Tools Slack: https://node-tooling.slack.com/archives/CMB9C398C/p1578531295046400