### PR TITLE
Logging and progress bar for Arborist

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -11,6 +11,7 @@ const semver = require('semver')
 
 const calcDepFlags = require('../calc-dep-flags.js')
 const Shrinkwrap = require('../shrinkwrap.js')
+const Tracker = require('../tracker.js')
 const Node = require('../node.js')
 const Link = require('../link.js')
 const addRmPkgDeps = require('../add-rm-pkg-deps.js')
@@ -27,6 +28,7 @@ const REPLACE = Symbol('REPLACE')
 
 const _depsSeen = Symbol('depsSeen')
 const _depsQueue = Symbol('depsQueue')
+const _currentDep = Symbol('currentDep')
 const _updateAll = Symbol('updateAll')
 const _mutateTree = Symbol('mutateTree')
 const _prune = Symbol('prune')
@@ -60,7 +62,7 @@ const _idealTreePrune = Symbol.for('idealTreePrune')
 const Virtual = require('./load-virtual.js')
 const Actual = require('./load-actual.js')
 
-module.exports = cls => class IdealTreeBuilder extends Virtual(Actual(cls)) {
+module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cls))) {
   constructor (options) {
     super(options)
 
@@ -75,6 +77,7 @@ module.exports = cls => class IdealTreeBuilder extends Virtual(Actual(cls)) {
     this[_legacyBundling] = false
     this[_depsSeen] = new Set()
     this[_depsQueue] = []
+    this[_currentDep] = null
     this[_updateNames] = []
     this[_updateAll] = false
     this[_mutateTree] = false
@@ -90,11 +93,17 @@ module.exports = cls => class IdealTreeBuilder extends Virtual(Actual(cls)) {
 
     this[_parseSettings](options)
 
+    // start tracker block
+    this.addTracker('idealTree')
+
     return this[_initTree]()
       .then(() => this[_applyUserRequests](options))
       .then(() => this[_buildDeps]())
       .then(() => this[_fixDepFlags]())
-      .then(() => this.idealTree)
+      .then(() => {
+        this.finishTracker('idealTree')
+        return this.idealTree 
+      })
   }
 
   [_parseSettings] (options) {
@@ -212,6 +221,7 @@ module.exports = cls => class IdealTreeBuilder extends Virtual(Actual(cls)) {
       .filter(n => this[_shouldUpdateNode](n))
     for (const node of set) {
       for (const edge of node.edgesIn) {
+        this.addTracker('buildIdealTree', edge.from.name, edge.from.location)
         this[_depsQueue].push(edge.from)
       }
     }
@@ -230,11 +240,18 @@ module.exports = cls => class IdealTreeBuilder extends Virtual(Actual(cls)) {
   // or extraneous.
   [_buildDeps] (node) {
     this[_depsQueue].push(this.idealTree)
-
+    this.log.silly('idealTree', 'buildDeps')
+    this.addTracker('idealTree', this.idealTree.name, '')
     return this[_buildDepStep]()
   }
 
   [_buildDepStep] () {
+    // removes tracker of previous dependency in the queue
+    if (this[_currentDep])  {
+      this.finishTracker('idealTree', this[_currentDep].name, this[_currentDep].location)
+      this[_currentDep] = null
+    }
+
     if (!this[_depsQueue].length)
       return
 
@@ -255,6 +272,7 @@ module.exports = cls => class IdealTreeBuilder extends Virtual(Actual(cls)) {
       return this[_buildDepStep]()
 
     this[_depsSeen].add(node)
+    this[_currentDep] = node
 
     // if any deps are missing or invalid, then we fetch the manifest for
     // the thing we want, and build a new dep node from that.
@@ -332,6 +350,7 @@ module.exports = cls => class IdealTreeBuilder extends Virtual(Actual(cls)) {
       for (const set of placed) {
         for (const node of set) {
           this[_mutateTree] = true
+          this.addTracker('idealTree', node.name, node.location)
           this[_depsQueue].push(node)
         }
       }
@@ -462,8 +481,10 @@ module.exports = cls => class IdealTreeBuilder extends Virtual(Actual(cls)) {
 
     // visit any dependents who are upset by this change
     for (const edge of dep.edgesIn) {
-      if (!edge.valid)
+      if (!edge.valid) {
+        this.addTracker('idealTree', edge.from.name, edge.from.location)
         this[_depsQueue].push(edge.from)
+      }
     }
 
     // in case we just made some duplicates that can be removed,

--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -65,6 +65,8 @@ module.exports = cls => class Reifier extends Ideal(cls) {
 
   // public method
   reify (options) {
+    // start tracker block
+    this.addTracker('reify')
     return Promise.all([this.loadActual(), this.buildIdealTree(options)])
       .then(() => this[_diffTrees]())
       .then(() => this[_retireShallowNodes]())
@@ -75,7 +77,10 @@ module.exports = cls => class Reifier extends Ideal(cls) {
       .then(() => this[_moveBackRetiredUnchanged]())
       .then(() => this[_removeRetiredAndDeletedNodes]())
       .then(() => this[_saveIdealTree](options))
-      .then(() => this.actualTree)
+      .then(() => {
+        this.finishTracker('reify')
+        return this.actualTree
+      })
   }
 
   [_diffTrees] () {
@@ -188,6 +193,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
   // create a symlink for Links, extract for Nodes
   // return the node object, since we usually want that
   [_reifyNode] (node) {
+    this.addTracker('reify', node.name, node.location)
     return (node.isLink
       ? rimraf(node.path).then(() => symlink(node.realpath, node.path, 'dir'))
       : pacote.extract(this[_registryResolved](node.resolved), node.path, {
@@ -199,7 +205,10 @@ module.exports = cls => class Reifier extends Ideal(cls) {
         ...this.options,
         pkgId: node.package._id,
       }))
-      .then(() => node)
+      .then(() => {
+        this.finishTracker('reify', node.name, node.location)
+        return node
+      })
   }
 
   [_registryResolved] (resolved) {
@@ -243,6 +252,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
 
     const Arborist = this.constructor
     // extract all the nodes with bundles
+    this.log.silly('reify', 'reifyNode')
     return promiseAllRejectLate(set.map(node => this[_reifyNode](node)))
     // then load their unpacked children and move into the ideal tree
     .then(nodes => promiseAllRejectLate(nodes.map(node =>

--- a/lib/proc-log.js
+++ b/lib/proc-log.js
@@ -1,0 +1,24 @@
+// default logger.
+// emits 'log' events on the process
+const LEVELS = [
+  'notice',
+  'error',
+  'warn',
+  'info',
+  'verbose',
+  'http',
+  'silly',
+  'pause',
+  'resume'
+]
+
+const log = level => (...args) => process.emit('log', level, ...args)
+
+const logger = {}
+for (const level of LEVELS) {
+  logger[level] = log(level)
+}
+
+process.on('log', (level, ...args) => {console.log('LOG EVENT:', level, args)})
+
+module.exports = logger

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -15,6 +15,9 @@ module.exports = cls => class Tracker extends cls {
     if (!this.log.newGroup)
       return
 
+    if (section === null || section === undefined)
+      this[_onError](`Tracker can't be null or undefined`)
+
     if (key === null)
       key = subsection
 
@@ -49,12 +52,10 @@ module.exports = cls => class Tracker extends cls {
 
     // 4. existing parent tracker, no subsection tracker
     // Create a new subtracker in this[_progress] from parent tracker
-    else if (hasTracker && !hasSubtracker) {
+    else {
       this[_progress].set(`${section}:${key}`,
         this[_progress].get(section).newGroup(`${section}:${subsection}`)
       )
-    } else {
-      this[_onError]('There was an error adding the tracker')
     }
   }
 
@@ -62,6 +63,9 @@ module.exports = cls => class Tracker extends cls {
     // TrackerGroup type object not found
     if (!this.log.newGroup)
       return
+
+    if (section === null || section === undefined)
+      this[_onError](`Tracker can't be null or undefined`)
 
     if (key === null)
       key = subsection
@@ -104,11 +108,9 @@ module.exports = cls => class Tracker extends cls {
 
     // 3. subtracker exists
     // Finish subtracker and remove from this[_progress]
-    else if (hasTracker && hasSubtracker) {
+    else {
       this[_progress].get(`${section}:${key}`).finish()
       this[_progress].delete(`${section}:${key}`)
-    } else {
-        this[_onError]('There was an error finishing the tracker')
     }
   }
 

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -1,0 +1,119 @@
+const procLog = require('./proc-log.js')
+
+const _progress = Symbol('_progress')
+const _onError = Symbol('_onError')
+
+module.exports = cls => class Tracker extends cls {
+  constructor (options = {}) {
+    super(options)
+    this[_progress] = new Map()
+    this.log = options.log || procLog
+  }
+
+  addTracker (section, subsection = null, key = null) {
+    // TrackerGroup type object not found
+    if (!this.log.newGroup)
+      return
+
+    if (key === null)
+      key = subsection
+
+    const hasTracker = this[_progress].has(section)
+    const hasSubtracker = this[_progress].has(`${section}:${key}`)
+
+    // 0. existing tracker, no subsection
+    if (hasTracker && subsection === null) {
+      this[_onError](`Tracker "${section}" already exists`)
+    }
+
+    // 1. no existing tracker, no subsection
+    // Create a new tracker from this.log
+     else if (!hasTracker && subsection === null) {
+      // starts progress bar
+      if(this[_progress].size === 0) {
+        this.log.enableProgress()
+      }
+      this[_progress].set(section, this.log.newGroup(section))
+    }
+
+    // 2. no parent tracker and subsection 
+    else if (!hasTracker && subsection !== null) {
+      this[_onError](`Parent tracker "${section}" does not exist`)
+    }
+
+    // 3. existing parent tracker, existing subsection tracker
+    // skip it
+    else if (hasTracker && hasSubtracker) {
+      return
+    }
+
+    // 4. existing parent tracker, no subsection tracker
+    // Create a new subtracker in this[_progress] from parent tracker
+    else if (hasTracker && !hasSubtracker) {
+      this[_progress].set(`${section}:${key}`,
+        this[_progress].get(section).newGroup(`${section}:${subsection}`)
+      )
+    } else {
+      this[_onError]('There was an error adding the tracker')
+    }
+  }
+
+  finishTracker (section, subsection = null, key = null) {
+    // TrackerGroup type object not found
+    if (!this.log.newGroup)
+      return
+
+    if (key === null)
+      key = subsection
+
+    const hasTracker = this[_progress].has(section)
+    const hasSubtracker = this[_progress].has(`${section}:${key}`)
+
+    // 0. parent tracker exists, no subsection
+    // Finish parent tracker and remove from this[_progress]
+    if (hasTracker && subsection === null) {
+      // check if parent tracker does
+      // not have any remaining children
+      const keys = this[_progress].keys()
+      for (const key of keys) {
+        if (key.match(new RegExp(section + ':'))) {
+          this[_onError](`Tracker "${section}" contains unfinished child: ${key}`)
+        }
+      }
+
+      // remove parent tracker
+      this[_progress].get(section).finish()
+      this[_progress].delete(section)
+
+      // remove progress bar if all
+      // trackers are finished
+      if(this[_progress].size === 0) {
+        this.log.disableProgress()
+      }
+    }
+
+    // 1. no existing parent tracker, no subsection
+    else if (!hasTracker && subsection === null) {
+      this[_onError](`Tracker "${section}" does not exist`)
+    }
+
+    // 2. existing parent tracker, no subsection
+    else if (hasTracker && !hasSubtracker) {
+      this[_onError](`Subtracker "${subsection}" does not exist`)
+    }
+
+    // 3. subtracker exists
+    // Finish subtracker and remove from this[_progress]
+    else if (hasTracker && hasSubtracker) {
+      this[_progress].get(`${section}:${key}`).finish()
+      this[_progress].delete(`${section}:${key}`)
+    } else {
+        this[_onError]('There was an error finishing the tracker')
+    }
+  }
+
+  [_onError] (msg) {
+    this.log.disableProgress()
+    throw new Error(msg)
+  }
+}

--- a/test/tracker.js
+++ b/test/tracker.js
@@ -1,0 +1,112 @@
+const Tracker = require('../lib/tracker.js')(class {})
+const t = require('tap')
+
+const npmlog = {
+  newGroup: () => ({ 
+    newGroup: () => ({ finish: () => {} }), 
+    finish: () => {} 
+  }),
+  enableProgress: () => {},
+  disableProgress: () => {}
+}
+
+t.test('no npmlog', t => {
+  const tr = new Tracker()
+  t.notThrow(() => { tr.addTracker('testTracker') })
+  t.notThrow(() => { tr.finishTracker('testTracker') })
+
+  t.end()
+})
+
+t.test('adds tracker', t => {
+  t.notThrow(() => { 
+    const tr = new Tracker({ log: npmlog })
+    tr.addTracker('testTracker') 
+  })
+  t.notThrow(() => { 
+    const tr = new Tracker({ log: npmlog })
+    tr.addTracker('testTracker') 
+    tr.addTracker('testTracker', 'subTracker') 
+  })
+  t.notThrow(() => { 
+    const tr = new Tracker({ log: npmlog })
+    tr.addTracker('testTracker')
+    tr.addTracker('testTracker', 'subTracker')
+    tr.addTracker('testTracker', 'subTracker') 
+  })
+  t.notThrow(() => { 
+    const tr = new Tracker({ log: npmlog })
+    tr.addTracker('testTracker') 
+    tr.addTracker('testTracker', 'subTracker.name', 'subTracker.key') 
+  })
+
+  const tr = new Tracker({ log: npmlog })
+  t.throws(() => { tr.addTracker() }, Error, `Tracker can't be null or undefined`)
+  t.throws(() => { tr.addTracker(null) }, Error, `Tracker can't be null or undefined`)
+  t.throws(() => { tr.addTracker(undefined) }, Error, `Tracker can't be null or undefined`)
+
+  t.throws(() => { 
+    tr.addTracker('testTracker')
+    tr.addTracker('testTracker')
+  }, Error, 'Tracker "testTracker" already exists')
+
+  t.throws(() => { tr.addTracker('nonExistentTracker', 'tracker') }, 
+    Error, 'Parent tracker "nonExistentTracker" does not exist')
+
+  t.end()
+})
+
+t.test('finishes tracker', t => {
+
+  t.notThrow(() => { 
+    const tr = new Tracker({ log: npmlog })
+    tr.addTracker('testTracker') 
+    tr.finishTracker('testTracker')
+  })
+  t.notThrow(() => { 
+    const tr = new Tracker({ log: npmlog })
+    tr.addTracker('testTracker') 
+    tr.addTracker('testTracker', 'subTracker')
+    tr.finishTracker('testTracker', 'subTracker')
+    tr.finishTracker('testTracker')
+  })
+  t.notThrow(() => { 
+    const tr = new Tracker({ log: npmlog })
+    tr.addTracker('testTracker') 
+    tr.addTracker('testTracker', 'subTracker.name', 'subTracker.key')
+    tr.finishTracker('testTracker', 'subTracker.name', 'subTracker.key')
+    tr.finishTracker('testTracker')
+  })
+
+  t.notThrow(() => {
+    const tr = new Tracker({ log: npmlog })
+    tr.addTracker('firstTracker')
+    tr.addTracker('secondTracker')
+    tr.finishTracker('firstTracker')
+    tr.finishTracker('secondTracker')
+  })
+
+  const tr = new Tracker({ log: npmlog })
+  t.throws(() => { tr.finishTracker() }, Error, `Tracker can't be null or undefined`)
+  t.throws(() => { tr.finish(null) }, Error, `Tracker can't be null or undefined`)
+  t.throws(() => { tr.finish(undefined) }, Error, `Tracker can't be null or undefined`)
+
+  t.throws(() => { 
+    const tr = new Tracker({ log: npmlog })
+    tr.addTracker('testTracker')
+    tr.addTracker('testTracker', 'testChild')
+    tr.finishTracker('testTracker') 
+  }, Error, 'Tracker "testTracker" contains unfinished child: testChild')
+
+  t.throws(() => { 
+    const tr = new Tracker({ log: npmlog })
+    tr.finishTracker('testTracker') }, Error, 'Tracker "testTracker" does not exist')
+
+  t.throws(() => { 
+    const tr = new Tracker({ log: npmlog })
+    tr.addTracker('testTracker')
+    tr.finishTracker('testTracker', 'nonExistentSubTracker') 
+  }, Error, 'Subtracker "nonExistentSubTracker" does not exist')
+
+  t.end()
+})


### PR DESCRIPTION
This is PR adds:
- new `Tracker` class that expects a `npmlog` object, otherwise it will default to a fallback logger
- tracker blocks for dependency progress in `Arborist.buildIdealTree` 
- tracker blocks for reify nodes in `Arborist.reify`
- 100% test coverage for `Tracker` class