### PR TITLE
further simplify adding new deps to the root

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,21 @@ arb.buildIdealTree(options).then(() => {
   // next step is to reify that ideal tree onto disk.
   // options can be:
   // rm: array of package names to remove at top level
-  // add: object with the following potential properties:
-  //   - dependencies
-  //   - peerDependencies
-  //   - optionalDependencies
-  //   - devDependencies
-  //   - peerDependenciesMeta
-  //   Each is an array of package specifiers, which would be passed to
-  //   `npm install`. They're added to the root node's requirements, and
-  //   then the tree is built.
+  // add: Array of package specifiers to add at the top level.  Each of
+  //   these will be resolved with pacote.manifest if the name can't be
+  //   determined from the spec.  (Eg, `github:foo/bar` vs `foo@somespec`.)
+  //   The dep will be saved in the location where it already exists,
+  //   (or pkg.dependencies) unless a different saveType is specified.
+  // saveType: Save added packages in a specific dependency set.
+  //   - null (default) Wherever they exist already, or 'dependencies'
+  //   - prod: definitely in 'dependencies'
+  //   - optional: in 'optionalDependencies'
+  //   - dev: devDependencies
+  //   - peer: save in peerDependencies, and remove any optional flag from
+  //     peerDependenciesMeta if one exists
+  //   - peerOptional: save in peerDependencies, and add a
+  //     peerDepsMeta[name].optional flag
+  // saveBundle: add newly added deps to the bundleDependencies list
   // update: Either `true` to just go ahead and update everything, or an
   //   object with any or all of the following fields:
   //   - all: boolean.  set to true to just update everything

--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -57,6 +57,7 @@ const _fixDepFlags = Symbol('fixDepFlags')
 const _resolveLinks = Symbol('resolveLinks')
 const _rootNodeFromPackage = Symbol('rootNodeFromPackage')
 const _add = Symbol('add')
+const _resolvedAdd = Symbol.for('resolvedAdd')
 const _queueNamedUpdates = Symbol('queueNamedUpdates')
 const _shouldUpdateNode = Symbol('shouldUpdateNode')
 const _resetDepFlags = Symbol('resetDepFlags')
@@ -71,7 +72,6 @@ const _globalRootNode = Symbol('globalRootNode')
 const _explicitRequests = Symbol.for('explicitRequests')
 const _global = Symbol.for('global')
 const _idealTreePrune = Symbol.for('idealTreePrune')
-const _resolvedAdd = Symbol.for('resolvedAdd')
 
 const Virtual = require('./load-virtual.js')
 const Actual = require('./load-actual.js')
@@ -240,68 +240,39 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
 
     // these just add and remove to/from the root node
     return (options.add)
-      ? this[_add](options.add).then(after)
+      ? this[_add](options).then(after)
       : after()
   }
 
 
   // This returns a promise because we might not have the name yet,
   // and need to call pacote.manifest to find the name.
-  [_add] (add) {
+  [_add] ({add, saveType = null, saveBundle = false}) {
     const promises = []
-    this[_resolvedAdd] = {}
 
-    // not going to work for:
-    // peerDepsMeta
-    // bundledDeps
-    for (const [type, specs] of Object.entries(add)) {
-      // get the name for each of the specs in the list.
-      // ie, doing `foo@bar` we just return foo
-      // but if it's a url or git, we don't know the name until we
-      // fetch it and look in its manifest.
-      const p = Promise.all(specs.map(s => {
-        const spec = npa(s, this.path)
-        if (spec.name) {
-          return spec
-        } else {
-          return pacote.manifest(spec).then(mani => {
-            spec.name = mani.name
-            return spec
-          })
-        }
-      })).then(specs => {
-        for (const spec of specs) {
-          if (type === 'bundleDependencies') {
-            this[_resolvedAdd][type] = this[_resolvedAdd][type] || []
-            this[_resolvedAdd][type].push(spec.name)
-          } else {
-            // XXX this is a bit inefficient.  we parse the spec, and then
-            // immediately throw it away and keep just the rawSpec.  Later,
-            // when creating the Node, we parse them AGAIN for the Edge objs
-            // and multiple other times when checking if a dep is valid.
-            // It'd be eleganter to parse it once, and keep the spec around as
-            // an object for all future uses, even though npa is pretty fast.
-            this[_resolvedAdd][type] = this[_resolvedAdd][type] || {}
-            this[_resolvedAdd][type][spec.name] = spec.rawSpec
-          }
-        }
+    // get the name for each of the specs in the list.
+    // ie, doing `foo@bar` we just return foo
+    // but if it's a url or git, we don't know the name until we
+    // fetch it and look in its manifest.
+    return Promise.all(add.map(s => {
+      const spec = npa(s, this.path)
+      return spec.name ? spec : pacote.manifest(spec).then(mani => {
+        spec.name = mani.name
+        return spec
       })
-      promises.push(p)
-    }
-
-    return Promise.all(promises).then(() => {
-      // get the list of deps that we're explicitly requesting, so that
-      // 'npm install foo' will reinstall, even if we already have it.
-      for (const [type, specs] of Object.entries(this[_resolvedAdd])) {
-        if (type === 'dependencies' || type === 'devDependencies' ||
-            type === 'optionalDependencies' || type === 'peerDependencies') {
-          for (const name of Object.keys(this[_resolvedAdd][type])) {
-            this[_explicitRequests].add(name)
-          }
-        }
+    })).then(add => {
+      this[_resolvedAdd] = add
+      // now add is a list of spec objects with names.
+      // find a home for each of them!
+      addRmPkgDeps.add({
+        pkg: this.idealTree.package,
+        add,
+        saveBundle,
+        saveType,
+      })
+      for (const spec of add) {
+        this[_explicitRequests].add(spec.name)
       }
-
-      addRmPkgDeps.add(this.idealTree.package, this[_resolvedAdd])
     })
   }
 

--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -361,7 +361,9 @@ module.exports = cls => class Reifier extends Ideal(cls) {
     const {meta} = this.idealTree
     return meta.loadedFromDisk && meta.originalLockfileVersion < 2 &&
       rpj(node.path + '/package.json').then(pkg => {
-        node.package = pkg
+        node.package.os = pkg.os
+        node.package.cpu = pkg.cpu
+        node.package.engines = pkg.engines
         return this[_checkEngineAndPlatform](node)
       })
   }
@@ -647,8 +649,8 @@ module.exports = cls => class Reifier extends Ideal(cls) {
         return
 
       return rpj(node.path + '/package.json').then(pkg => {
-        node.package = pkg
         if (pkg.scripts) {
+          node.package.scripts = pkg.scripts
           const val = [node, pkg]
           if (pkg.scripts.preinstall)
             preinstall.push(val)

--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -12,6 +12,7 @@ const binLinks = require('bin-links')
 const runScript = require('@npmcli/run-script')
 const rpj = require('read-package-json-fast')
 const {checkEngine, checkPlatform} = require('npm-install-checks')
+const updateDepSpec = require('../update-dep-spec.js')
 
 const boolEnv = b => b ? '1' : ''
 
@@ -728,30 +729,26 @@ module.exports = cls => class Reifier extends Ideal(cls) {
       return
 
     if (this[_resolvedAdd]) {
-      const pkg = this.idealTree.package
-      // need to save these more nicely, now that we know what they are
-      for (const [type, specs] of Object.entries(this[_resolvedAdd])) {
-        if (!specs || typeof specs !== 'object' || Array.isArray(specs))
-          continue
+      const root = this.idealTree
+      const pkg = root.package
+      for (const req of this[_resolvedAdd]) {
+        const {name} = req
+        const child = root.children.get(name)
+        const res = npa(child.resolved)
 
-        for (const [name, spec] of Object.entries(specs)) {
-          const child = this.idealTree.children.get(name)
-          const resolved = child.resolved
-          const req = npa(spec)
-          const res = npa(resolved)
+        if (req.registry) {
           const version = child.package.version
-          if (req.registry) {
-            const range = this[_savePrefix] + version
-            const pname = child.package.name
-            const alias = name !== pname
-            pkg[type][name] = (alias ? `npm:${pname}@` : '') + `${range}`
-          } else if (req.hosted) {
-            pkg[type][name] = req.hosted.shortcut({ noCommittish: false })
-          } else {
-            pkg[type][name] = req.saveSpec
-          }
+          const range = this[_savePrefix] + version
+          const pname = child.package.name
+          const alias = name !== pname
+          updateDepSpec(pkg, name, (alias ? `npm:${pname}@` : '') + range)
+        } else if (req.hosted) {
+          updateDepSpec(pkg, name, req.hosted.shortcut({ noCommittish: false }))
+        } else {
+          updateDepSpec(pkg, name, req.saveSpec)
         }
       }
+
       // refresh the edges so they have the correct specs
       this.idealTree.package = pkg
     }

--- a/lib/update-dep-spec.js
+++ b/lib/update-dep-spec.js
@@ -1,0 +1,24 @@
+// given a dep name and spec, update it wherever it exists in
+// the manifest, or add the spec to 'dependencies' if not found.
+
+module.exports = (pkg, name, newSpec) => {
+  const type = findType(pkg, name)
+  pkg[type] = pkg[type] || {}
+  pkg[type][name] = newSpec
+  return pkg
+}
+
+const types = [
+  'peerDependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'dependencies',
+]
+
+const findType = (pkg, name) => {
+  for (const t of types) {
+    if (pkg[t] && typeof pkg[t] === 'object' && pkg[t][name] !== undefined)
+      return t
+  }
+  return 'dependencies'
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -153,15 +153,23 @@
         "read-package-json-fast": "^1.1.3"
       }
     },
+    "@tootallnate/once": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.0.0.tgz",
+      "integrity": "sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "agent-base": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "agentkeepalive": {
       "version": "4.1.0",
@@ -467,9 +475,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -799,19 +807,6 @@
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1098,11 +1093,12 @@
       "integrity": "sha512-Z2EICWNJou7Tr9Bd2M2UqDJq3A9F2ePG9w3lIpjoyuSyXFP9QbniJVu3XQYytuw5ebmG7dXSXO9PgAjJG8DDKA=="
     },
     "http-proxy-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-3.0.0.tgz",
-      "integrity": "sha512-uGuJaBWQWDQCJI5ip0d/VTYZW0nRrlLWXA4A7P1jrsa+f77rW2yXz315oBt6zGCF6l8C2tlMxY7ffULCj+5FhA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
       "requires": {
-        "agent-base": "5",
+        "@tootallnate/once": "1",
+        "agent-base": "6",
         "debug": "4"
       }
     },
@@ -1117,11 +1113,11 @@
       }
     },
     "https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "requires": {
-        "agent-base": "5",
+        "agent-base": "6",
         "debug": "4"
       }
     },
@@ -1568,15 +1564,15 @@
       "dev": true
     },
     "make-fetch-happen": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.1.tgz",
-      "integrity": "sha512-oiK8xz6+IxaPqmOCW+rmlH922RTZ+fi4TAULGRih8ryqIju0x6WriDR3smm7Z+8NZRxDIK/iDLM096F/gLfiWg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.2.tgz",
+      "integrity": "sha512-jRqI9zjLyz8ufXfLSbEObJ6a8sv8geeKYEPFpI+b39JjYU14MZtCiJGazSWPZMjCm7161b4r57N/na5fBXpooQ==",
       "requires": {
         "agentkeepalive": "^4.1.0",
         "cacache": "^15.0.0",
         "http-cache-semantics": "^4.0.4",
-        "http-proxy-agent": "^3.0.0",
-        "https-proxy-agent": "^4.0.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",
         "lru-cache": "^5.1.1",
         "minipass": "^3.0.0",
@@ -1585,7 +1581,7 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.2",
         "promise-retry": "^1.1.1",
-        "socks-proxy-agent": "^4.0.0",
+        "socks-proxy-agent": "^5.0.0",
         "ssri": "^8.0.0"
       }
     },
@@ -1948,13 +1944,13 @@
       }
     },
     "npm-registry-fetch": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-7.0.0.tgz",
-      "integrity": "sha512-XABSG02i/03EfnXM8azGksxICQO8g5MSiaxIUBsNTLXnQLBcdQNS67aOZsF5Yn97RV9o9g+fBUUN2Sg8u7iCBw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-8.0.0.tgz",
+      "integrity": "sha512-975WwLvZjX97y9UWWQ8nAyr7bw02s9xKPHqvEm5T900LQsB1HXb8Gb9ebYtCBLSX+K8gSOrO5KS/9yV/naLZmQ==",
       "requires": {
         "@npmcli/ci-detect": "^1.0.0",
         "lru-cache": "^5.1.1",
-        "make-fetch-happen": "^8.0.1",
+        "make-fetch-happen": "^8.0.2",
         "minipass": "^3.0.0",
         "minipass-fetch": "^1.1.2",
         "minipass-json-stream": "^1.0.1",
@@ -2114,13 +2110,13 @@
       }
     },
     "pacote": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.0.0.tgz",
-      "integrity": "sha512-Q8H9lfzlZTZyWWtYNGETtFp2qmzd9XHfuF3gas5xd8T6vf/6E7BOmhybWU2PxSVeSYjIw4hLpaf7hCqY+T2TbQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.1.0.tgz",
+      "integrity": "sha512-JcMmHiK6h6rcncj2HLayiyJZg28iJXJafXcmEGw2NjKH3WE8ZgSwyMZs7+f+aliPD57PDhB31IEgUtLXp0YZxA==",
       "requires": {
         "@npmcli/installed-package-contents": "^1.0.5",
         "cacache": "^15.0.0",
-        "chownr": "^1.1.3",
+        "chownr": "^1.1.4",
         "fs-minipass": "^2.1.0",
         "infer-owner": "^1.0.4",
         "lru-cache": "^5.1.1",
@@ -2128,19 +2124,29 @@
         "minipass-fetch": "^1.2.1",
         "mkdirp": "^1.0.3",
         "npm-package-arg": "^8.0.0",
-        "npm-packlist": "^2.0.3",
+        "npm-packlist": "^2.1.0",
         "npm-pick-manifest": "^6.0.0",
-        "npm-registry-fetch": "^7.0.0",
+        "npm-registry-fetch": "^8.0.0",
         "osenv": "^0.1.5",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^1.1.1",
         "read-package-json-fast": "^1.1.3",
-        "semver": "^7.1.1",
+        "semver": "^7.1.3",
         "ssri": "^8.0.0",
-        "tar": "^6.0.0",
+        "tar": "^6.0.1",
         "which": "^2.0.2"
       },
       "dependencies": {
+        "chownr": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+        },
+        "semver": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
+        },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2547,22 +2553,13 @@
       }
     },
     "socks-proxy-agent": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
-      "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
       "requires": {
-        "agent-base": "~4.2.1",
-        "socks": "~2.3.2"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-          "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        }
+        "agent-base": "6",
+        "debug": "4",
+        "socks": "^2.3.3"
       }
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mkdirp-infer-owner": "^1.0.2",
     "npm-install-checks": "^4.0.0",
     "npm-package-arg": "^8.0.0",
-    "pacote": "^11.0.0",
+    "pacote": "^11.1.0",
     "parse-conflict-json": "^1.0.0",
     "promise-all-reject-late": "^1.0.0",
     "promise-call-limit": "^1.0.1",

--- a/tap-snapshots/test-arborist-build-ideal-tree.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-build-ideal-tree.js-TAP.test.js
@@ -933,20 +933,6 @@ Node {
       "peer": true,
       "resolved": "https://registry.npmjs.org/@isaacs/peer-dep-cycle-c/-/peer-dep-cycle-c-2.0.0.tgz",
     },
-    "abbrev" => Node {
-      "dev": true,
-      "edgesIn": Set {
-        Edge {
-          "from": "",
-          "name": "abbrev",
-          "spec": "",
-          "type": "dev",
-        },
-      },
-      "location": "node_modules/abbrev",
-      "name": "abbrev",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-    },
   },
   "edgesOut": Map {
     "@isaacs/peer-dep-cycle-a" => Edge {
@@ -954,12 +940,6 @@ Node {
       "spec": "2.x",
       "to": "node_modules/@isaacs/peer-dep-cycle-a",
       "type": "prod",
-    },
-    "abbrev" => Edge {
-      "name": "abbrev",
-      "spec": "",
-      "to": "node_modules/abbrev",
-      "type": "dev",
     },
   },
   "location": "",
@@ -1317,20 +1297,6 @@ Node {
       "peer": true,
       "resolved": "https://registry.npmjs.org/@isaacs/peer-dep-cycle-c/-/peer-dep-cycle-c-2.0.0.tgz",
     },
-    "abbrev" => Node {
-      "dev": true,
-      "edgesIn": Set {
-        Edge {
-          "from": "",
-          "name": "abbrev",
-          "spec": "",
-          "type": "dev",
-        },
-      },
-      "location": "node_modules/abbrev",
-      "name": "abbrev",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-    },
   },
   "edgesOut": Map {
     "@isaacs/peer-dep-cycle-a" => Edge {
@@ -1338,12 +1304,6 @@ Node {
       "spec": "2.x",
       "to": "node_modules/@isaacs/peer-dep-cycle-a",
       "type": "prod",
-    },
-    "abbrev" => Edge {
-      "name": "abbrev",
-      "spec": "",
-      "to": "node_modules/abbrev",
-      "type": "dev",
     },
   },
   "location": "",
@@ -2062,7 +2022,7 @@ Node {
         Edge {
           "from": "",
           "name": "rimraf",
-          "spec": "",
+          "spec": "*",
           "type": "prod",
         },
       },
@@ -2082,7 +2042,7 @@ Node {
   "edgesOut": Map {
     "rimraf" => Edge {
       "name": "rimraf",
-      "spec": "",
+      "spec": "*",
       "to": "node_modules/rimraf",
       "type": "prod",
     },
@@ -2340,7 +2300,7 @@ Node {
         Edge {
           "from": "",
           "name": "rimraf",
-          "spec": "",
+          "spec": "*",
           "type": "prod",
         },
       },
@@ -2360,7 +2320,7 @@ Node {
   "edgesOut": Map {
     "rimraf" => Edge {
       "name": "rimraf",
-      "spec": "",
+      "spec": "*",
       "to": "node_modules/rimraf",
       "type": "prod",
     },

--- a/tap-snapshots/test-arborist-reify.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-reify.js-TAP.test.js
@@ -13364,36 +13364,6 @@ Node {
       "dev": true,
       "edgesIn": Set {
         Edge {
-          "from": "node_modules/@babel/plugin-proposal-object-rest-spread",
-          "name": "@babel/core",
-          "spec": "^7.0.0-0",
-          "type": "peer",
-        },
-        Edge {
-          "from": "node_modules/@babel/plugin-syntax-jsx",
-          "name": "@babel/core",
-          "spec": "^7.0.0-0",
-          "type": "peer",
-        },
-        Edge {
-          "from": "node_modules/@babel/plugin-syntax-object-rest-spread",
-          "name": "@babel/core",
-          "spec": "^7.0.0-0",
-          "type": "peer",
-        },
-        Edge {
-          "from": "node_modules/@babel/plugin-transform-destructuring",
-          "name": "@babel/core",
-          "spec": "^7.0.0-0",
-          "type": "peer",
-        },
-        Edge {
-          "from": "node_modules/@babel/plugin-transform-react-jsx",
-          "name": "@babel/core",
-          "spec": "^7.0.0-0",
-          "type": "peer",
-        },
-        Edge {
           "from": "node_modules/import-jsx",
           "name": "@babel/core",
           "spec": "^7.5.5",
@@ -13813,12 +13783,6 @@ Node {
         },
       },
       "edgesOut": Map {
-        "@babel/core" => Edge {
-          "name": "@babel/core",
-          "spec": "^7.0.0-0",
-          "to": "node_modules/@babel/core",
-          "type": "peer",
-        },
         "@babel/helper-plugin-utils" => Edge {
           "name": "@babel/helper-plugin-utils",
           "spec": "^7.0.0",
@@ -13847,12 +13811,6 @@ Node {
         },
       },
       "edgesOut": Map {
-        "@babel/core" => Edge {
-          "name": "@babel/core",
-          "spec": "^7.0.0-0",
-          "to": "node_modules/@babel/core",
-          "type": "peer",
-        },
         "@babel/helper-plugin-utils" => Edge {
           "name": "@babel/helper-plugin-utils",
           "spec": "^7.0.0",
@@ -13875,12 +13833,6 @@ Node {
         },
       },
       "edgesOut": Map {
-        "@babel/core" => Edge {
-          "name": "@babel/core",
-          "spec": "^7.0.0-0",
-          "to": "node_modules/@babel/core",
-          "type": "peer",
-        },
         "@babel/helper-plugin-utils" => Edge {
           "name": "@babel/helper-plugin-utils",
           "spec": "^7.0.0",
@@ -13903,12 +13855,6 @@ Node {
         },
       },
       "edgesOut": Map {
-        "@babel/core" => Edge {
-          "name": "@babel/core",
-          "spec": "^7.0.0-0",
-          "to": "node_modules/@babel/core",
-          "type": "peer",
-        },
         "@babel/helper-plugin-utils" => Edge {
           "name": "@babel/helper-plugin-utils",
           "spec": "^7.0.0",
@@ -13931,12 +13877,6 @@ Node {
         },
       },
       "edgesOut": Map {
-        "@babel/core" => Edge {
-          "name": "@babel/core",
-          "spec": "^7.0.0-0",
-          "to": "node_modules/@babel/core",
-          "type": "peer",
-        },
         "@babel/helper-builder-react-jsx" => Edge {
           "name": "@babel/helper-builder-react-jsx",
           "spec": "^7.7.4",
@@ -14617,14 +14557,6 @@ Node {
           "name": "auto-bind",
           "spec": "^3.0.0",
           "type": "prod",
-        },
-      },
-      "edgesOut": Map {
-        "@types/react" => Edge {
-          "name": "@types/react",
-          "spec": ">=16.8.0",
-          "to": null,
-          "type": "peerOptional",
         },
       },
       "location": "node_modules/auto-bind",
@@ -17182,13 +17114,6 @@ Node {
         },
       },
       "edgesOut": Map {
-        "@types/react" => Edge {
-          "error": "MISSING",
-          "name": "@types/react",
-          "spec": ">=16.8.0",
-          "to": null,
-          "type": "peer",
-        },
         "ansi-escapes" => Edge {
           "name": "ansi-escapes",
           "spec": "^4.2.1",
@@ -17248,13 +17173,6 @@ Node {
           "spec": "^15.6.2",
           "to": "node_modules/prop-types",
           "type": "prod",
-        },
-        "react" => Edge {
-          "error": "INVALID",
-          "name": "react",
-          "spec": ">=16.8.0",
-          "to": "node_modules/react",
-          "type": "peer",
         },
         "react-reconciler" => Edge {
           "name": "react-reconciler",
@@ -20039,27 +19957,6 @@ Node {
           "spec": "15",
           "type": "prod",
         },
-        Edge {
-          "error": "INVALID",
-          "from": "node_modules/ink",
-          "name": "react",
-          "spec": ">=16.8.0",
-          "type": "peer",
-        },
-        Edge {
-          "error": "INVALID",
-          "from": "node_modules/react-reconciler",
-          "name": "react",
-          "spec": "^16.0.0",
-          "type": "peer",
-        },
-        Edge {
-          "error": "INVALID",
-          "from": "node_modules/treport",
-          "name": "react",
-          "spec": "^16.8.6",
-          "type": "peer",
-        },
       },
       "edgesOut": Map {
         "create-react-class" => Edge {
@@ -20138,13 +20035,6 @@ Node {
           "spec": "^15.6.2",
           "to": "node_modules/prop-types",
           "type": "prod",
-        },
-        "react" => Edge {
-          "error": "INVALID",
-          "name": "react",
-          "spec": "^16.0.0",
-          "to": "node_modules/react",
-          "type": "peer",
         },
         "scheduler" => Edge {
           "name": "scheduler",
@@ -25911,13 +25801,6 @@ Node {
           "to": "node_modules/ms",
           "type": "prod",
         },
-        "react" => Edge {
-          "error": "INVALID",
-          "name": "react",
-          "spec": "^16.8.6",
-          "to": "node_modules/react",
-          "type": "peer",
-        },
         "string-length" => Edge {
           "name": "string-length",
           "spec": "^3.1.0",
@@ -25989,12 +25872,6 @@ Node {
           "spec": "^0.5.6",
           "to": "node_modules/source-map-support",
           "type": "prod",
-        },
-        "typescript" => Edge {
-          "name": "typescript",
-          "spec": ">=2.0",
-          "to": "node_modules/typescript",
-          "type": "peer",
         },
         "yn" => Edge {
           "name": "yn",
@@ -26093,12 +25970,6 @@ Node {
           "name": "typescript",
           "spec": "^3.7.2",
           "type": "prod",
-        },
-        Edge {
-          "from": "node_modules/ts-node",
-          "name": "typescript",
-          "spec": ">=2.0",
-          "type": "peer",
         },
       },
       "location": "node_modules/typescript",

--- a/test/add-rm-pkg-deps.js
+++ b/test/add-rm-pkg-deps.js
@@ -3,48 +3,121 @@ addRm = require('../lib/add-rm-pkg-deps.js')
 
 t.test('add', t => {
   const {add} = addRm
+  const npa = require('npm-package-arg')
+  const foo = npa('foo')
+  const foo1 = npa('foo@1')
+  const foo2 = npa('foo@2')
+  const bar = npa('bar')
+  const bar1 = npa('bar@1')
+  const bar2 = npa('bar@2')
+
   t.strictSame(add({
-    dependencies: { bar: '1' },
-    devDependencies: { foo: '2' },
-  }, {
-    dependencies: { foo: '1', bar: '' },
+    pkg: {
+      dependencies: { bar: '1' },
+      devDependencies: { foo: '2' },
+    },
+    add: [
+      foo1,
+      bar,
+    ],
+    saveType: 'prod',
   }), {
     dependencies: { foo: '1', bar: '1' },
   }, 'move foo to prod, leave bar as-is')
+
   t.strictSame(add({
-    dependencies: { bar: '1' },
-    devDependencies: { foo: '2' },
-  }, {
-    dependencies: { foo: '1', bar: '' },
-    bundleDependencies: ['bar'],
+    pkg: {
+      dependencies: { bar: '1' },
+      devDependencies: { foo: '2' },
+    },
+    add: [ foo1, bar ],
+    saveBundle: true,
+    saveType: 'prod',
   }), {
     dependencies: { foo: '1', bar: '1' },
-    bundleDependencies: ['bar'],
-  }, 'move bar to bundle deps, foo to deps, leave bar version unchanged')
-  t.strictSame(add({}, {
-    dependencies: { foo: '1', bar: '' },
-    bundleDependencies: ['bar'],
-  }), {
-    dependencies: { foo: '1', bar: '' },
-    bundleDependencies: ['bar'],
-  }, 'add all new stuff')
+    bundleDependencies: ['bar', 'foo'],
+  }, 'move to bundle deps, foo to deps, leave bar version unchanged')
+
   t.strictSame(add({
-    peerDependencies: { foo: '1' },
-    peerDependenciesMeta: { foo: { optional: true }},
-  }, {
-    optionalDependencies: { foo: '1' },
+    pkg: {},
+    add: [ foo1, bar ],
+    saveBundle: true,
+  }), {
+    dependencies: { foo: '1', bar: '*' },
+    bundleDependencies: ['bar', 'foo'],
+  }, 'add all new stuff')
+
+  t.strictSame(add({
+    pkg: {
+      peerDependencies: { foo: '1' },
+      peerDependenciesMeta: { foo: { optional: true }},
+    },
+    add: [ foo1 ],
+    saveType: 'optional',
   }), {
     optionalDependencies: { foo: '1' },
   }, 'move from peerOptional to optional')
+
   t.strictSame(add({
-    optionalDependencies: { foo: '1' },
-  }, {
-    peerDependencies: { foo: '1' },
-    peerDependenciesMeta: { foo: { optional: true }},
+    pkg: {
+      optionalDependencies: { foo: '1' },
+    },
+    add: [ foo1 ],
+    saveType: 'peerOptional',
   }), {
     peerDependencies: { foo: '1' },
     peerDependenciesMeta: { foo: { optional: true }},
   }, 'move from optional to peerOptional')
+
+  t.strictSame(add({
+    pkg: {
+      peerDependencies: { foo: '1' },
+      peerDependenciesMeta: { foo: { optional: true }},
+    },
+    add: [ foo1 ],
+    saveType: 'peer',
+  }), {
+    peerDependencies: { foo: '1' },
+    peerDependenciesMeta: { foo: { optional: false }},
+  }, 'move from peerOptional to peer')
+
+  t.strictSame(add({
+    pkg: {
+      peerDependencies: { foo: '1' },
+      peerDependenciesMeta: { foo: { optional: true }},
+    },
+    add: [ foo2 ],
+  }), {
+    peerDependencies: { foo: '2' },
+    peerDependenciesMeta: { foo: { optional: true }},
+  }, 'update peerOptional')
+
+  t.strictSame(add({
+    pkg: {
+      peerDependencies: { foo: '1' },
+    },
+    add: [ foo2 ],
+  }), {
+    peerDependencies: { foo: '2' },
+  }, 'update peer')
+
+  t.strictSame(add({
+    pkg: {
+      optionalDependencies: { foo: '1' },
+    },
+    add: [ foo2 ],
+  }), {
+    optionalDependencies: { foo: '2' },
+  }, 'update optional')
+
+  t.strictSame(add({
+    pkg: {
+      devDependencies: { foo: '1' },
+    },
+    add: [ foo2 ],
+  }), {
+    devDependencies: { foo: '2' },
+  }, 'update dev')
 
   t.end()
 })
@@ -67,7 +140,7 @@ t.test('rm', t => {
   t.strictSame(rm({
     dependencies: { bar: '1' },
     devDependencies: { foo: '2' },
-    bundleDependencies: [ 'foo', 'bar' ],
+    bundleDependencies: ['bar', 'foo'],
   }, ['foo']), {
     dependencies: { bar: '1' },
     bundleDependencies: [ 'bar' ],

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -133,34 +133,17 @@ t.test('cyclical peer deps', t => {
     t.resolveMatchSnapshot(printIdeal(path), 'cyclical peer deps')
       .then(() => t.resolveMatchSnapshot(printIdeal(path, {
         // just reload the dep at its current required version
-        add: { dependencies: [ '@isaacs/peer-dep-cycle-a' ] },
+        add: [ '@isaacs/peer-dep-cycle-a' ],
       }), 'cyclical peer deps - reload a dependency'))
       .then(() => t.resolveMatchSnapshot(printIdeal(path, {
-        add: {
-          // also add a devDep just to verify it works when adding
-          // a type that isn't already in the root's package
-          devDependencies: [
-            'abbrev',
-          ],
-          dependencies: [
-            '@isaacs/peer-dep-cycle-a@2.x',
-          ]
-        },
+        add: [ '@isaacs/peer-dep-cycle-a@2.x' ],
       }), 'cyclical peer deps - upgrade a package'))
       .then(() => t.rejects(printIdeal(path, {
-        add: {
-          dependencies: [
-            // this conflicts with the direct dep on a@1 PEER-> b@1
-            '@isaacs/peer-dep-cycle-b@2.x',
-          ],
-        },
+        // this conflicts with the direct dep on a@1 PEER-> b@1
+        add: [ '@isaacs/peer-dep-cycle-b@2.x' ],
       })))
       .then(() => t.resolveMatchSnapshot(printIdeal(path, {
-        add: {
-          dependencies: [
-            '@isaacs/peer-dep-cycle-b@2.x',
-          ],
-        },
+        add: [ '@isaacs/peer-dep-cycle-b@2.x' ],
         rm: [ '@isaacs/peer-dep-cycle-a' ],
       }), 'can add b@2 if we remove a@1 dep'))
       .then(() => t.resolveMatchSnapshot(printIdeal(path, {
@@ -178,33 +161,23 @@ t.test('nested cyclical peer deps', t => {
   paths.forEach(path => t.test(basename(path), t =>
     t.resolveMatchSnapshot(printIdeal(path), 'nested peer deps cycle')
       .then(() => t.resolveMatchSnapshot(printIdeal(path, {
-        add: {
-          dependencies: [
-            npa('@isaacs/peer-dep-cycle-a@2.x'),
-          ],
-        },
+        // just make sure it works if it gets a spec object
+        add: [ npa('@isaacs/peer-dep-cycle-a@2.x') ],
       }), 'upgrade a'))
       .then(() => t.resolveMatchSnapshot(printIdeal(path, {
-        add: {
-          dependencies: [
-            `${registry}@isaacs/peer-dep-cycle-b/-/peer-dep-cycle-b-2.0.0.tgz`,
-          ],
-        },
+        // a dep whose name we don't yet know
+        add: [
+          `${registry}@isaacs/peer-dep-cycle-b/-/peer-dep-cycle-b-2.0.0.tgz`,
+        ],
       }), 'upgrade b'))
       .then(() => t.resolveMatchSnapshot(printIdeal(path, {
-        add: {
-          dependencies: [
-            '@isaacs/peer-dep-cycle-c@2.x',
-          ],
-        },
+        add: [ '@isaacs/peer-dep-cycle-c@2.x' ],
       }), 'upgrade c'))
       .then(() => t.rejects(printIdeal(path, {
-        add: {
-          dependencies: [
-            '@isaacs/peer-dep-cycle-a@1.x',
-            '@isaacs/peer-dep-cycle-c@2.x',
-          ],
-        },
+        add: [
+          '@isaacs/peer-dep-cycle-a@1.x',
+          '@isaacs/peer-dep-cycle-c@2.x',
+        ],
       }), 'try (and fail) to upgrade c and a incompatibly'))
   ))
 })
@@ -239,9 +212,8 @@ t.test('bundle deps example 1', t => {
   const path = resolve(__dirname, '../fixtures/testing-bundledeps')
   return t.resolveMatchSnapshot(printIdeal(path), 'bundle deps testing')
     .then(() => t.resolveMatchSnapshot(printIdeal(path, {
-      add: {
-        bundleDependencies: [ '@isaacs/testing-bundledeps' ],
-      },
+      saveBundle: true,
+      add: [ '@isaacs/testing-bundledeps' ],
     }), 'bundle the bundler'))
 })
 
@@ -250,9 +222,8 @@ t.test('bundle deps example 2', t => {
   const path = resolve(__dirname, '../fixtures/testing-bundledeps-2')
   return t.resolveMatchSnapshot(printIdeal(path), 'bundle deps testing')
     .then(() => t.resolveMatchSnapshot(printIdeal(path, {
-      add: {
-        bundleDependencies: [ '@isaacs/testing-bundledeps-c' ],
-      },
+      saveBundle: true,
+      add: [ '@isaacs/testing-bundledeps-c' ],
     }), 'add new bundled dep c'))
     .then(() => t.resolveMatchSnapshot(printIdeal(path, {
       rm: ['@isaacs/testing-bundledeps-a'],
@@ -892,12 +863,12 @@ t.test('contrived dep placement tests', t => {
 
 t.test('global style', t => t.resolveMatchSnapshot(printIdeal(t.testdir(), {
   globalStyle: true,
-  add: { dependencies: [ 'rimraf' ] },
+  add: [ 'rimraf' ],
 })))
 
 t.test('global', t => t.resolveMatchSnapshot(printIdeal(t.testdir(), {
   global: true,
-  add: { dependencies: [ 'rimraf' ] },
+  add: [ 'rimraf' ],
 })))
 
 t.test('global has to add or remove', t => t.rejects(printIdeal(t.testdir(), {

--- a/test/update-dep-spec.js
+++ b/test/update-dep-spec.js
@@ -1,0 +1,38 @@
+const t = require('tap')
+const updateDepSpec = require('../lib/update-dep-spec.js')
+
+t.test('updates existing record if found', t => {
+  t.strictSame(updateDepSpec({
+    dependencies: { foo: '' },
+  }, 'foo', '1.2.3'), {
+    dependencies: { foo: '1.2.3' },
+  })
+
+  t.strictSame(updateDepSpec({
+    devDependencies: { foo: '' },
+  }, 'foo', '1.2.3'), {
+    devDependencies: { foo: '1.2.3' },
+  })
+
+  t.strictSame(updateDepSpec({
+    optionalDependencies: { foo: '' },
+  }, 'foo', '1.2.3'), {
+    optionalDependencies: { foo: '1.2.3' },
+  })
+
+  t.strictSame(updateDepSpec({
+    peerDependencies: { foo: '' },
+  }, 'foo', '1.2.3'), {
+    peerDependencies: { foo: '1.2.3' },
+  })
+
+  t.end()
+})
+
+t.test('adds to pkg.dependencies if not', t => {
+  t.strictSame(updateDepSpec({}, 'foo', '1.2.3'), {
+    dependencies: { foo: '1.2.3' },
+  })
+
+  t.end()
+})


### PR DESCRIPTION
The previous revision of the buildIdealTree/reify `add` option converted
the package.json-esque data structure into instead passing a list of
specs for each location in the package, since the name couldn't be known
100% of the time up front.

However, that still puts too much of the burden of placing deps onto the
caller.

When you run `npm install foo`, if `foo` is already a devDependency,
then the updated save spec gets added there, unless specified otherwise.
Since we aren't guaranteed to know the _name_ of the dep until we've
resolved it, how is the caller (ie, the npm CLI) supposed to know where
to put it in the objecet?

At the expense of a slight amount of flexibility, this changes things
further so that the `add` option mirrors exactly the positional
arguments passed to the `npm install` command: it's just a list of
specs, that's it.

Two more options were added:

- saveType
- saveBundle

If the saveType is not set, then added deps are added wherever they
already exist, or to `dependencies` if they're not already present.
Otherwise, it should be set to one of the edge type values:

- 'prod'
- 'dev'
- 'optional'
- 'peer'
- 'peerOptional'

If `saveBundle` is true, then newly added deps are added to the
`bundleDependencies` list as well.
