### PR TITLE
feature/catch failed write of hidden lockfile

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -30,6 +30,7 @@ const {promisify} = require('util')
 const fs = require('fs')
 const readFile = promisify(fs.readFile)
 const writeFile = promisify(fs.writeFile)
+const mkdirp = require('mkdirp-infer-owner')
 const link = promisify(fs.link)
 const { resolve, dirname, basename } = require('path')
 const specFromLock = require('./spec-from-lock.js')
@@ -654,7 +655,21 @@ class Shrinkwrap {
 
     const json = stringify(this.commit(), swKeyOrder, this.indent)
     return Promise.all([
-      writeFile(this.filename, json),
+      writeFile(this.filename, json).catch(err => {
+        if (
+          /\/node_modules\//.test(this.filename) &&
+          err.code === 'ENOENT'
+        ) {
+          // We tried to save the `.package-lock.json` meta file into the
+          // node_modules/ folder but it doesn't exist. Reason for this is
+          // we tried to install into a folder with a `package.json` with no
+          // dependencies, so no actions in the node_modules/ folder were
+          // needed.
+          return mkdirp(dirname(this.filename))
+            .then(() => writeFile(this.filename, json))
+        }
+        throw err
+      }),
       this.yarnLock && this.yarnLock.entries.size &&
         writeFile(this.path + '/yarn.lock', this.yarnLock.toString())
     ])

--- a/test/shrinkwrap.js
+++ b/test/shrinkwrap.js
@@ -367,6 +367,42 @@ t.test('construct metadata from node and package data', t => {
   t.end()
 })
 
+t.test('saving shrinkwrap object', t => {
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'badsave',
+      version: '1.0.0',
+      description: 'no node_modules/ will fail'
+    })
+  })
+
+  t.test('save meta lockfile into node_modules directory', async t => {
+    const sw = await Shrinkwrap.load({ path: dir, hiddenLockfile: true })
+    t.equal(
+      sw.filename,
+      `${dir}/node_modules/.package-lock.json`,
+      'correct filepath on shrinkwrap instance'
+    )
+    await sw.save()
+    t.ok(sw, 'able to save with no deps')
+    t.end()
+  })
+
+  t.test('save lockfile to root directory', async t => {
+    const sw = await Shrinkwrap.load({ path: dir })
+    t.equal(
+      sw.filename,
+      `${dir}/package-lock.json`,
+      'correct filepath on shrinkwrap instance'
+    )
+    await sw.save()
+    t.ok(sw, 'able to save with no deps')
+    t.end()
+  })
+
+  t.end()
+})
+
 t.test('write the shrinkwrap back to disk', t => {
   const dir = t.testdir({})
   t.test('just read and write back', t =>


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
When you try and run `reify()` in a folder with a `package.json` which doesn't have any dependencies we get an `ENOENT` error because we're attempting to save the `.package-lock.json` file into the `node_modules/` folder which wasn't created because there are no deps.

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
- https://github.com/npm/cli/issues/1025
