### PR TITLE
track timing via process time/timeEnd events

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -119,6 +119,8 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
     if (this.idealTree)
       return Promise.resolve(this.idealTree)
 
+    process.emit('time', 'idealTree')
+
     if (!options.add && !options.rm && this[_global])
       return Promise.reject(new Error('global requires an add or rm option'))
 
@@ -139,6 +141,7 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
       .then(() => this[_fixDepFlags]())
       .then(() => this[_pruneFailedOptional]())
       .then(() => {
+        process.emit('timeEnd', 'idealTree')
         this.finishTracker('idealTree')
         return this.idealTree
       })
@@ -173,6 +176,7 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
   // load the initial tree, either the virtualTree from a shrinkwrap,
   // or just the root node from a package.json
   [_initTree] () {
+    process.emit('time', 'idealTree:init')
     return (
       this[_global] ? this[_globalRootNode]()
       : rpj(this.path + '/package.json')
@@ -194,6 +198,7 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
         // if you want another one, load another copy.
         this.idealTree = tree
         this.virtualTree = null
+        process.emit('timeEnd', 'idealTree:init')
       })
   }
 
@@ -224,6 +229,7 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
   // process the add/rm requests by modifying the root node, and the
   // update.names request by queueing nodes dependent on those named.
   [_applyUserRequests] (options) {
+    process.emit('time', 'idealTree:userRequests')
     // If we have a list of package names to update, and we know it's
     // going to update them wherever they are, add any paths into those
     // named nodes to the buildIdealTree queue.
@@ -237,7 +243,10 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
     }
 
     // triggers a refresh of all edgesOut
-    const after = () => this.idealTree.package = this.idealTree.package
+    const after = () => {
+      this.idealTree.package = this.idealTree.package
+      process.emit('timeEnd', 'idealTree:userRequests')
+    }
 
     // these just add and remove to/from the root node
     return (options.add)
@@ -309,16 +318,20 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
   // package deps, which may be partly or entirely incomplete, invalid
   // or extraneous.
   [_buildDeps] (node) {
+    process.emit('time', 'idealTree:buildDeps')
     this[_depsQueue].push(this.idealTree)
     this.log.silly('idealTree', 'buildDeps')
     this.addTracker('idealTree', this.idealTree.name, '')
     return this[_buildDepStep]()
+      .then(() => process.emit('timeEnd', 'idealTree:buildDeps'))
   }
 
   [_buildDepStep] () {
     // removes tracker of previous dependency in the queue
     if (this[_currentDep])  {
-      this.finishTracker('idealTree', this[_currentDep].name, this[_currentDep].location)
+      const { location, name } = this[_currentDep]
+      process.emit('timeEnd', `idealTree:${location || '#root'}`)
+      this.finishTracker('idealTree', name, location)
       this[_currentDep] = null
     }
 
@@ -343,6 +356,7 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
 
     this[_depsSeen].add(node)
     this[_currentDep] = node
+    process.emit('time', `idealTree:${node.location || '#root'}`)
 
     // if any deps are missing or invalid, then we fetch the manifest for
     // the thing we want, and build a new dep node from that.
@@ -865,6 +879,7 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
   }
 
   [_fixDepFlags] () {
+    process.emit('time', 'idealTree:fixDepFlags')
     const metaFromDisk = this.idealTree.meta.loadedFromDisk
     // if the options set prune:false, then we don't prune, but we still
     // mark the extraneous items in the tree if we modified it at all.
@@ -901,6 +916,7 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
     if (this[_prune] && metaFromDisk && this[_mutateTree]) {
       this[_idealTreePrune]()
     }
+    process.emit('timeEnd', 'idealTree:fixDepFlags')
   }
 
   [_idealTreePrune] () {

--- a/lib/arborist/index.js
+++ b/lib/arborist/index.js
@@ -28,6 +28,7 @@ const Reify = require('./reify.js')
 const {resolve} = require('path')
 class Arborist extends Reify(require('events')) {
   constructor (options = {}) {
+    process.emit('time', 'arborist:ctor')
     super(options)
     this.options = {
       nodeVersion: process.version,
@@ -35,6 +36,7 @@ class Arborist extends Reify(require('events')) {
       path: options.path || '.',
     }
     this.path = resolve(this.options.path)
+    process.emit('timeEnd', 'arborist:ctor')
   }
 }
 

--- a/lib/arborist/load-actual.js
+++ b/lib/arborist/load-actual.js
@@ -80,6 +80,8 @@ module.exports = cls => class ActualLoader extends cls {
         })).then(node => {
           this.actualTree = node
           return this[_loadActualActually]()
+        }).then(tree => {
+          return tree
         })
     }
 

--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -125,6 +125,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
 
     // start tracker block
     this.addTracker('reify')
+    process.emit('time', 'reify')
     return this[_loadTrees](options)
       .then(() => this[_diffTrees]())
       .then(() => this[_retireShallowNodes]())
@@ -140,6 +141,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
       .then(() => this[_copyIdealToActual]())
       .then(() => {
         this.finishTracker('reify')
+        process.emit('timeEnd', 'reify')
         return this.actualTree
       })
   }
@@ -147,8 +149,10 @@ module.exports = cls => class Reifier extends Ideal(cls) {
   // when doing a local install, we load everything and figure it all out.
   // when doing a global install, we *only* care about the explicit requests.
   [_loadTrees] (options) {
+    process.emit('time', 'reify:loadTrees')
     if (!this[_global])
       return Promise.all([this.loadActual(), this.buildIdealTree(options)])
+        .then(() => process.emit('timeEnd', 'reify:loadTrees'))
 
     // the global install space tends to have a lot of stuff in it.  don't
     // load all of it, just what we care about.  we won't be saving a
@@ -160,9 +164,11 @@ module.exports = cls => class Reifier extends Ideal(cls) {
     }
     return this.buildIdealTree(options)
       .then(() => this.loadActual(actualOpts))
+      .then(() => process.emit('timeEnd', 'reify:loadTrees'))
   }
 
   [_diffTrees] () {
+    process.emit('time', 'reify:diffTrees')
     // XXX if we have an existing diff already, there should be a way
     // to just invalidate the parts that changed, but avoid walking the
     // whole tree again.
@@ -176,6 +182,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
     for (const node of this.diff.removed) {
       this[_addNodeToTrashList](node)
     }
+    process.emit('timeEnd', 'reify:diffTrees')
   }
 
   // add the node and all its bins to the list of things to be
@@ -198,6 +205,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
   // move aside the shallowest nodes in the tree that have to be
   // changed or removed, so that we can rollback if necessary.
   [_retireShallowNodes] () {
+    process.emit('time', 'reify:retireShallow')
     const moves = this[_retiredPaths] = {}
     for (const diff of this.diff.children) {
       if (diff.action === 'CHANGE' || diff.action === 'REMOVE') {
@@ -210,6 +218,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
       .map(([from, to]) => this[_renamePath](from, to))
     return promiseAllRejectLate(movePromises)
       .catch(er => this[_rollbackRetireShallowNodes](er))
+      .then(() => process.emit('timeEnd', 'reify:retireShallow'))
   }
 
   [_renamePath] (from, to, didMkdirp = false) {
@@ -230,12 +239,14 @@ module.exports = cls => class Reifier extends Ideal(cls) {
   }
 
   [_rollbackRetireShallowNodes] (er) {
+    process.emit('time', 'reify:rollback:retireShallow')
     const moves = this[_retiredPaths]
     const movePromises = Object.entries(moves)
       .map(([from, to]) => this[_renamePath](to, from))
     return promiseAllRejectLate(movePromises)
       // ignore subsequent rollback errors
       .catch(er => {})
+      .then(() => process.emit('timeEnd', 'reify:rollback:retireShallow'))
       .then(() => { throw er })
   }
 
@@ -245,6 +256,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
     if (!this[_omitDev] && !this[_omitOptional] && !this[_omitPeer])
       return
 
+    process.emit('time', 'reify:trashOmits')
     const filter = node =>
       node.peer && this[_omitPeer] ||
       node.dev && this[_omitDev] ||
@@ -254,9 +266,11 @@ module.exports = cls => class Reifier extends Ideal(cls) {
     for (const node of this.idealTree.inventory.filter(filter)) {
       this[_trashList].add(node.path)
     }
+    process.emit('timeEnd', 'reify:trashOmits')
   }
 
   [_createSparseTree] () {
+    process.emit('time', 'reify:createSparse')
     // if we call this fn again, we look for the previous list
     // so that we can avoid making the same directory multiple times
     const dirs = this.diff.leaves
@@ -268,10 +282,12 @@ module.exports = cls => class Reifier extends Ideal(cls) {
 
     return promiseAllRejectLate(dirs.map(d => mkdirp(d)))
       .then(() => dirs.forEach(dir => this[_sparseTreeDirs].add(dir)))
+      .then(() => process.emit('timeEnd', 'reify:createSparse'))
       .catch(er => this[_rollbackCreateSparseTree](er))
   }
 
   [_rollbackCreateSparseTree] (er) {
+    process.emit('time', 'reify:rollback:createSparse')
     // cut the roots of the sparse tree, not the leaves
     const moves = this[_retiredPaths]
     const failures = []
@@ -282,6 +298,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
         if (failures.length)
           this.log.warn('Failed to clean up some directories', failures)
       })
+      .then(() => process.emit('timeEnd', 'reify:rollback:createSparse'))
       .then(() => this[_rollbackRetireShallowNodes](er))
   }
 
@@ -297,6 +314,8 @@ module.exports = cls => class Reifier extends Ideal(cls) {
     if (!shrinkwraps.length)
       return
 
+    process.emit('time', 'reify:loadShrinkwraps')
+
     const Arborist = this.constructor
     return promiseAllRejectLate(shrinkwraps.map(diff => {
       const node = diff.ideal
@@ -310,6 +329,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
       // reload the diff and sparse tree because the ideal tree changed
       .then(() => this[_diffTrees]())
       .then(() => this[_createSparseTree]())
+      .then(() => process.emit('timeEnd', 'reify:loadShrinkwraps'))
       .catch(er => this[_rollbackCreateSparseTree](er))
   }
 
@@ -324,6 +344,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
     if (this[_trashList].has(node.path))
       return node
 
+    process.emit('time', `reifyNode:${node.location}`)
     this.addTracker('reify', node.name, node.location)
 
     const p = this[_checkEngineAndPlatform](node)
@@ -335,6 +356,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
     return this[_handleOptionalFailure](node, p)
       .then(() => {
         this.finishTracker('reify', node.name, node.location)
+        process.emit('timeEnd', `reifyNode:${node.location}`)
         return node
       })
   }
@@ -460,6 +482,8 @@ module.exports = cls => class Reifier extends Ideal(cls) {
   [_loadBundlesAndUpdateTrees] (
     depth = 0, bundlesByDepth = this[_getBundlesByDepth]()
   ) {
+    if (depth === 0)
+      process.emit('time', 'reify:loadBundles')
     const maxBundleDepth = bundlesByDepth.get('maxBundleDepth')
     if (depth > maxBundleDepth) {
       // if we did something, then prune the tree and update the diffs
@@ -468,6 +492,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
         this[_idealTreePrune]()
         this[_diffTrees]()
       }
+      process.emit('timeEnd', 'reify:loadBundles')
       return
     }
 
@@ -547,6 +572,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
   // kicking off each unpack job.  If any fail, we rimraf the sparse
   // tree entirely and try to put everything back where it was.
   [_unpackNewModules] () {
+    process.emit('time', 'reify:unpack')
     const unpacks = []
     dfwalk({
       tree: this.diff,
@@ -563,6 +589,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
       getChildren: diff => diff.children,
     })
     return promiseAllRejectLate(unpacks)
+      .then(() => process.emit('timeEnd', 'reify:unpack'))
       .catch(er => this[_rollbackCreateSparseTree](er))
   }
 
@@ -578,6 +605,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
     // This is sort of an inverse diff tree, of all the nodes where
     // the actualTree and idealTree _don't_ differ, starting from the
     // shallowest nodes that we moved aside in the first place.
+    process.emit('time', 'reify:unretire')
     const moves = this[_retiredPaths]
     this[_retiredUnchanged] = {}
     return promiseAllRejectLate(this.diff.children.map(diff => {
@@ -605,6 +633,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
         return mkdirp(dir).then(() => this[_moveContents](node, fromPath))
       }))
     }))
+    .then(() => process.emit('timeEnd', 'reify:unretire'))
     .catch(er => this[_rollbackMoveBackRetiredUnchanged](er))
   }
 
@@ -639,6 +668,8 @@ module.exports = cls => class Reifier extends Ideal(cls) {
   [_runLifecycleScripts] () {
     if (this[_ignoreScripts])
       return
+
+    process.emit('time', 'reify:runScripts')
 
     // for all the things being installed, run their appropriate scripts
     // run in tip->root order, so as to be more likely to build a node's
@@ -691,6 +722,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
       .then(() => this[_runScriptQueue]('preinstall', preinstall))
       .then(() => this[_runScriptQueue]('install', install))
       .then(() => this[_runScriptQueue]('postinstall', postinstall))
+      .then(() => process.emit('timeEnd', 'reify:runScripts'))
       .catch(er => this[_rollbackMoveBackRetiredUnchanged](er))
   }
 
@@ -698,6 +730,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
     if (!queue.length)
       return
 
+    process.emit('time', `reify:runScripts:${event}`)
     return promiseCallLimit(queue.map(([node, pkg]) => () => {
       const {path} = node
       // skip any that we know we'll be deleting
@@ -722,6 +755,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
         scriptShell: this[_scriptShell],
       }))
     }))
+    .then(() => process.emit('timeEnd', `reify:runScripts:${event}`))
   }
 
   // the tree is pretty much built now, so it's cleanup time.
@@ -729,6 +763,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
   // If this fails, there isn't much we can do but tell the user about it.
   // Thankfully, it's pretty unlikely that it'll fail, since rimraf is a tank.
   [_removeTrash] () {
+    process.emit('time', 'reify:trash')
     const promises = []
     const failures = []
     const rm = path => rimraf(path).catch(er => failures.push([path, er]))
@@ -741,6 +776,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
       if (failures.length)
         this.log.warn('Failed to clean up some directories', failures)
     })
+    .then(() => process.emit('timeEnd', 'reify:trash'))
   }
 
   // last but not least, we save the ideal tree metadata to the package-lock
@@ -754,6 +790,8 @@ module.exports = cls => class Reifier extends Ideal(cls) {
     // support save=false option
     if (options.save === false || this[_global])
       return
+
+    process.emit('time', 'reify:save')
 
     if (this[_resolvedAdd]) {
       const root = this.idealTree
@@ -788,7 +826,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
         ...this.idealTree.package,
         _id: undefined,
       }, null, 2) + '\n'),
-    ])
+    ]).then(() => process.emit('timeEnd', 'reify:save'))
   }
 
   [_copyIdealToActual] () {

--- a/lib/calc-dep-flags.js
+++ b/lib/calc-dep-flags.js
@@ -5,12 +5,13 @@ const calcDepFlags = tree => {
   tree.optional = false
   tree.devOptional = false
   tree.peer = false
-  return depth({
+  const ret = depth({
     tree,
     visit: node => calcDepFlagsStep(node),
     filter: node => node,
     getChildren: node => [...node.edgesOut.values()].map(edge => edge.to),
   })
+  return ret
 }
 
 const calcDepFlagsStep = (node) => {

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -256,6 +256,7 @@ class Shrinkwrap {
   }
 
   load () {
+    const timer = `shrinkwrap:${this.path}${this.hiddenLockfile ? ':hidden' : ''}`
     // we don't need to load package-lock.json except for top of tree nodes,
     // only npm-shrinkwrap.json.
     return this[_maybeRead]().then(([sw, lock, yarn]) => {
@@ -299,12 +300,9 @@ class Shrinkwrap {
           .then(pkg => {
             this[_loadAll]('', null, this.data)
             this[_fixDependencies](pkg)
-            return this
           })
       }
-
-      return this
-    })
+    }).then(() => this)
   }
 
 

--- a/tap-snapshots/test-arborist-reify.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-reify.js-TAP.test.js
@@ -12086,6 +12086,39 @@ Node {
 }
 `
 
+exports[`test/arborist/reify.js TAP omit peer deps > finished timers 1`] = `
+Array [
+  "arborist:ctor",
+  "idealTree",
+  "idealTree:#root",
+  "idealTree:buildDeps",
+  "idealTree:fixDepFlags",
+  "idealTree:init",
+  "idealTree:node_modules/@isaacs/testing-peer-deps-b",
+  "idealTree:node_modules/@isaacs/testing-peer-deps-c",
+  "idealTree:node_modules/@isaacs/testing-peer-deps-d",
+  "idealTree:node_modules/@isaacs/testing-peer-deps-d/node_modules/@isaacs/testing-peer-deps-a",
+  "idealTree:node_modules/@isaacs/testing-peer-deps-d/node_modules/@isaacs/testing-peer-deps-b",
+  "idealTree:node_modules/@isaacs/testing-peer-deps-d/node_modules/@isaacs/testing-peer-deps-c",
+  "idealTree:userRequests",
+  "reify",
+  "reify:createSparse",
+  "reify:diffTrees",
+  "reify:loadBundles",
+  "reify:loadTrees",
+  "reify:retireShallow",
+  "reify:runScripts",
+  "reify:save",
+  "reify:trash",
+  "reify:trashOmits",
+  "reify:unpack",
+  "reify:unretire",
+  "reifyNode:node_modules/@isaacs/testing-peer-deps-b",
+  "reifyNode:node_modules/@isaacs/testing-peer-deps-d",
+  "reifyNode:node_modules/@isaacs/testing-peer-deps-d/node_modules/@isaacs/testing-peer-deps-a",
+]
+`
+
 exports[`test/arborist/reify.js TAP omits when both dev and optional flags are set dev > expect resolving Promise 1`] = `
 Node {
   "edgesOut": Map {


### PR DESCRIPTION
Emit a 'time' event for various things, and then a timeEnd event when that
thing is completed.  This is picked up by the CLI in its logger when the
loglevel is set to 'timing', but can also be consumed by any module using
arborist in a generic way.

Close #55
