### PR TITLE
Add {complete:true} buildIdealTree option to load sw/bundles

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -3,6 +3,7 @@
 const rpj = require('read-package-json-fast')
 const npa = require('npm-package-arg')
 const pacote = require('pacote')
+const cacache = require('cacache')
 const semver = require('semver')
 const pickManifest = require('npm-pick-manifest')
 const mapWorkspaces = require('@npmcli/map-workspaces')
@@ -15,6 +16,8 @@ const Link = require('../link.js')
 const addRmPkgDeps = require('../add-rm-pkg-deps.js')
 const gatherDepSet = require('../gather-dep-set.js')
 const optionalSet = require('../optional-set.js')
+
+const loadBundle = require('../load-bundle-deps.js')
 
 // enum of return values for canPlaceDep.
 // No, this is a conflict, you may not put that package here
@@ -29,6 +32,7 @@ const REPLACE = Symbol('REPLACE')
 const {resolve} = require('path')
 const relpath = require('../relpath.js')
 
+const _complete = Symbol('complete')
 const _depsSeen = Symbol('depsSeen')
 const _depsQueue = Symbol('depsQueue')
 const _currentDep = Symbol('currentDep')
@@ -167,6 +171,7 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
     if (update.all || !Array.isArray(update.names))
       update.names = []
 
+    this[_complete] = !!options.complete
     this[_preferDedupe] = !!options.preferDedupe
     this[_legacyBundling] = !!options.legacyBundling
     this[_updateNames] = update.names
@@ -439,7 +444,7 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
       .then(() => process.emit('timeEnd', 'idealTree:buildDeps'))
   }
 
-  [_buildDepStep] () {
+  async [_buildDepStep] () {
     // removes tracker of previous dependency in the queue
     if (this[_currentDep])  {
       const { location, name } = this[_currentDep]
@@ -464,12 +469,37 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
     // satisfied by whatever's in that file anyway.
     if (this[_depsSeen].has(node) ||
         node.root !== this.idealTree ||
-        node.hasShrinkwrap)
+        node.hasShrinkwrap && !this[_complete])
       return this[_buildDepStep]()
 
     this[_depsSeen].add(node)
     this[_currentDep] = node
     process.emit('time', `idealTree:${node.location || '#root'}`)
+
+    // if we're loading a _complete_ ideal tree, for a --package-lock-only
+    // installation for example, we have to crack open the tarball and
+    // look inside if it has bundle deps or shrinkwraps.  note that this is
+    // not necessary during a reification, because we just update the
+    // ideal tree by reading bundles/shrinkwraps in place.
+    if (this[_complete] && node !== this.idealTree) {
+      const Arborist = this.constructor
+      const bd = node.package.bundleDependencies
+      const hasBundle = bd && Array.isArray(bd) && bd.length
+      const { hasShrinkwrap } = node
+      if (hasBundle || hasShrinkwrap) {
+        const opt = { ...this.options }
+        await cacache.tmp.withTmp(this.cache, opt, async path => {
+          await pacote.extract(node.resolved, path, opt)
+
+          if (hasShrinkwrap)
+            await new Arborist({ ...this.options, path })
+              .loadVirtual({ root: node })
+
+          if (hasBundle)
+            await loadBundle(node, this, { path })
+        })
+      }
+    }
 
     // if any deps are missing or invalid, then we fetch the manifest for
     // the thing we want, and build a new dep node from that.
@@ -512,7 +542,7 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
     // Set `preferDedupe: true` in the options to replace the shallower
     // dep if allowed.
 
-    return Promise.all(
+    const tasks = await Promise.all(
       // resolve all the edges into nodes using pacote.manifest
       // return a {dep,edge} object so that we can track the reason
       // for this node through the parallelized async operation.
@@ -523,30 +553,29 @@ module.exports = cls => class IdealTreeBuilder extends Tracker(Virtual(Actual(cl
         .then(dep => ({edge, dep})))
     )
 
-    .then(tasks =>
-      tasks.sort((a, b) => a.edge.name.localeCompare(b.edge.name))
-        .map(({ edge, dep }) => this[_placeDep](dep, node, edge)))
+    const placed = tasks
+      .sort((a, b) => a.edge.name.localeCompare(b.edge.name))
+      .map(({ edge, dep }) => this[_placeDep](dep, node, edge))
 
-    .then(placed => {
-      const promises = []
-      for (const set of placed) {
-        for (const node of set) {
-          this[_mutateTree] = true
-          this.addTracker('idealTree', node.name, node.location)
-          this[_depsQueue].push(node)
+    const promises = []
+    for (const set of placed) {
+      for (const node of set) {
+        this[_mutateTree] = true
+        this.addTracker('idealTree', node.name, node.location)
+        this[_depsQueue].push(node)
 
-          // we're certainly going to need these soon, fetch them asap
-          // if it fails at this point, though, dont' worry because it
-          // may well be an optional dep that has gone missing.  it'll
-          // fail later anyway.
-          promises.push(...this[_problemEdges](node).map(e =>
-            this[_fetchManifest](npa.resolve(e.name, e.spec, node.path))
-              .catch(er => null)))
-        }
+        // we're certainly going to need these soon, fetch them asap
+        // if it fails at this point, though, dont' worry because it
+        // may well be an optional dep that has gone missing.  it'll
+        // fail later anyway.
+        promises.push(...this[_problemEdges](node).map(e =>
+          this[_fetchManifest](npa.resolve(e.name, e.spec, node.path))
+            .catch(er => null)))
       }
-      return Promise.all(promises)
-    })
-    .then(() => this[_buildDepStep]())
+    }
+    await Promise.all(promises)
+
+    return this[_buildDepStep]()
   }
 
   // loads a node from an edge, and then loads its peer deps (and their

--- a/lib/arborist/index.js
+++ b/lib/arborist/index.js
@@ -26,6 +26,7 @@
 // and path, and call out to the others.
 const Auditor = require('./audit.js')
 const {resolve} = require('path')
+const {homedir} = require('os')
 class Arborist extends Auditor(require('events')) {
   constructor (options = {}) {
     process.emit('time', 'arborist:ctor')
@@ -34,7 +35,9 @@ class Arborist extends Auditor(require('events')) {
       nodeVersion: process.version,
       ...options,
       path: options.path || '.',
+      cache: options.cache || `${homedir()}/.npm/_cacache`,
     }
+    this.cache = resolve(this.options.cache)
     this.path = resolve(this.options.path)
     process.emit('timeEnd', 'arborist:ctor')
   }

--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -8,6 +8,7 @@ const rpj = require('read-package-json-fast')
 const {checkEngine, checkPlatform} = require('npm-install-checks')
 const updateDepSpec = require('../update-dep-spec.js')
 const AuditReport = require('../audit-report.js')
+const loadBundle = require('../load-bundle-deps.js')
 
 const boolEnv = b => b ? '1' : ''
 
@@ -147,8 +148,9 @@ module.exports = cls => class Reifier extends Ideal(cls) {
   // when doing a global install, we *only* care about the explicit requests.
   [_loadTrees] (options) {
     process.emit('time', 'reify:loadTrees')
+    const bitOpt = { ...options, complete: false }
     if (!this[_global])
-      return Promise.all([this.loadActual(), this.buildIdealTree(options)])
+      return Promise.all([this.loadActual(), this.buildIdealTree(bitOpt)])
         .then(() => process.emit('timeEnd', 'reify:loadTrees'))
 
     // the global install space tends to have a lot of stuff in it.  don't
@@ -159,7 +161,7 @@ module.exports = cls => class Reifier extends Ideal(cls) {
       filter: (node, kid) => !node.isRoot ? true
         : this[_explicitRequests].has(kid),
     }
-    return this.buildIdealTree(options)
+    return this.buildIdealTree(bitOpt)
       .then(() => this.loadActual(actualOpts))
       .then(() => process.emit('timeEnd', 'reify:loadTrees'))
   }
@@ -507,38 +509,12 @@ module.exports = cls => class Reifier extends Ideal(cls) {
       return this[_loadBundlesAndUpdateTrees](depth + 1, bundlesByDepth)
     }
 
-    const Arborist = this.constructor
     // extract all the nodes with bundles
     return promiseAllRejectLate(set.map(node => this[_reifyNode](node)))
     // then load their unpacked children and move into the ideal tree
-    .then(nodes => promiseAllRejectLate(nodes.map(node =>
-      new Arborist({
-        ...this.options,
-        path: node.path,
-      }).loadActual().then(tree => {
-        for (const child of tree.children.values()) {
-          // skip the empty sparse tree folders
-          if (child.package._id)
-            child.parent = node
-        }
-        return node
-      }).then(node => {
-        // link the bins for any bundled deps in its tree.
-        // these are often required for build scripts.
-        const set = new Set()
-        dfwalk({
-          tree: node,
-          visit: node => set.add(node),
-          getChildren: node => [...node.children.values()],
-          filter: node => node.inBundle,
-        })
-        const promises = []
-        for (const node of set) {
-          promises.push(this[_binLinks](node))
-        }
-        return promiseAllRejectLate(promises)
-      }).then(() => node)
-    )))
+    .then(nodes =>
+      promiseAllRejectLate(nodes.map(node =>
+        loadBundle(node, this, { ...this.options, path: node.path }))))
     // move onto the next level of bundled items
     .then(() => this[_loadBundlesAndUpdateTrees](depth + 1, bundlesByDepth))
     .catch(er => this[_rollbackCreateSparseTree](er))
@@ -701,7 +677,22 @@ module.exports = cls => class Reifier extends Ideal(cls) {
     const installedNodes = []
     dfwalk({
       tree: this.diff,
-      leave: diff => installedNodes.push(diff.ideal),
+      leave: diff => {
+        installedNodes.push(diff.ideal)
+
+        // also have to include anything included in the bundle for any
+        // nodes that were added or changed, or they may not work on the
+        // current system.
+        const bd = diff.ideal.package.bundleDependencies
+        if (bd && bd.length) {
+          dfwalk({
+            tree: diff.ideal,
+            leave: node => installedNodes.push(node),
+            getChildren: node => [...node.children.values()],
+            filter: node => node.inBundle,
+          })
+        }
+      },
       // process adds before changes, ignore removals
       getChildren: diff => diff && diff.children,
       filter: diff => diff.action === 'ADD' || diff.action === 'CHANGE'

--- a/lib/load-bundle-deps.js
+++ b/lib/load-bundle-deps.js
@@ -1,0 +1,58 @@
+// unpack a module with bundleDependencies, and update a tree
+// This is used by reify, and buildIdealTree({complete:true})
+
+const binLinks = require('bin-links')
+const {depth: dfwalk} = require('treeverse')
+const promiseAllRejectLate = require('promise-all-reject-late')
+
+// pass in the Arborist object so we don't have a require() cycle,
+// which does weird things in our tests using require-inject, and
+// is less future-proof if we ever want to transpile or move to esm
+const loadBundleDeps = async (node, arb, options) => {
+  const {
+    path = node.path,
+    binLinks = true,
+    force = false
+  } = options
+
+  const Arborist = arb.constructor
+  const tree = await new Arborist({ ...arb.options, path }).loadActual()
+  for (const child of tree.children.values()) {
+    // skip any empty sparse folders that might be present, which
+    // is common during reification.
+    if (child.package._id)
+      child.parent = node
+  }
+
+  // only create the bin links if we're loading in the node's actual location
+  // if it's just in a temp dir for an ideal tree, don't bother.
+  if (path === node.path && binLinks)
+    await createBinLinks(node, force)
+
+  return node
+}
+
+const createBinLinks = async (node, force) => {
+  // link the bins for any bundled deps in its tree.
+  // these are often required for build scripts.
+  const set = new Set()
+  dfwalk({
+    tree: node,
+    visit: node => set.add(node),
+    getChildren: node => [...node.children.values()],
+    filter: node => node.inBundle,
+  })
+  const promises = []
+  for (const node of set) {
+    promises.push(binLinks({
+      pkg: node.package,
+      path: node.path,
+      top: node.isTop || node.globalTop,
+      force,
+      global: node.globalTop,
+    }))
+  }
+  await promiseAllRejectLate(promises)
+}
+
+module.exports = loadBundleDeps

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@npmcli/name-from-folder": "^1.0.1",
     "@npmcli/run-script": "^1.3.1",
     "bin-links": "^2.1.2",
+    "cacache": "^15.0.3",
     "json-stringify-nice": "^1.1.1",
     "mkdirp-infer-owner": "^1.0.2",
     "npm-install-checks": "^4.0.0",

--- a/tap-snapshots/test-arborist-build-ideal-tree.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-build-ideal-tree.js-TAP.test.js
@@ -454,6 +454,243 @@ Node {
 }
 `
 
+exports[`test/arborist/build-ideal-tree.js TAP bundle deps example 1, complete:true > bundle deps testing 1`] = `
+Node {
+  "children": Map {
+    "@isaacs/testing-bundledeps" => Node {
+      "children": Map {
+        "@isaacs/testing-bundledeps-a" => Node {
+          "bundled": true,
+          "edgesIn": Set {
+            Edge {
+              "from": "node_modules/@isaacs/testing-bundledeps",
+              "name": "@isaacs/testing-bundledeps-a",
+              "spec": "*",
+              "type": "prod",
+            },
+          },
+          "edgesOut": Map {
+            "@isaacs/testing-bundledeps-b" => Edge {
+              "name": "@isaacs/testing-bundledeps-b",
+              "spec": "*",
+              "to": "node_modules/@isaacs/testing-bundledeps/node_modules/@isaacs/testing-bundledeps-b",
+              "type": "prod",
+            },
+          },
+          "location": "node_modules/@isaacs/testing-bundledeps/node_modules/@isaacs/testing-bundledeps-a",
+          "name": "@isaacs/testing-bundledeps-a",
+          "resolved": "https://registry.npmjs.org/@isaacs/testing-bundledeps-a/-/testing-bundledeps-a-1.0.0.tgz",
+        },
+        "@isaacs/testing-bundledeps-b" => Node {
+          "bundled": true,
+          "edgesIn": Set {
+            Edge {
+              "from": "node_modules/@isaacs/testing-bundledeps/node_modules/@isaacs/testing-bundledeps-a",
+              "name": "@isaacs/testing-bundledeps-b",
+              "spec": "*",
+              "type": "prod",
+            },
+          },
+          "location": "node_modules/@isaacs/testing-bundledeps/node_modules/@isaacs/testing-bundledeps-b",
+          "name": "@isaacs/testing-bundledeps-b",
+          "resolved": "https://registry.npmjs.org/@isaacs/testing-bundledeps-b/-/testing-bundledeps-b-1.0.0.tgz",
+        },
+      },
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "@isaacs/testing-bundledeps",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-bundledeps-a" => Edge {
+          "name": "@isaacs/testing-bundledeps-a",
+          "spec": "*",
+          "to": "node_modules/@isaacs/testing-bundledeps/node_modules/@isaacs/testing-bundledeps-a",
+          "type": "prod",
+        },
+        "@isaacs/testing-bundledeps-c" => Edge {
+          "name": "@isaacs/testing-bundledeps-c",
+          "spec": "*",
+          "to": "node_modules/@isaacs/testing-bundledeps-c",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-bundledeps",
+      "name": "@isaacs/testing-bundledeps",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-bundledeps/-/testing-bundledeps-1.0.0.tgz",
+    },
+    "@isaacs/testing-bundledeps-b" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@isaacs/testing-bundledeps-c",
+          "name": "@isaacs/testing-bundledeps-b",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-bundledeps-b",
+      "name": "@isaacs/testing-bundledeps-b",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-bundledeps-b/-/testing-bundledeps-b-1.0.0.tgz",
+    },
+    "@isaacs/testing-bundledeps-c" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@isaacs/testing-bundledeps",
+          "name": "@isaacs/testing-bundledeps-c",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-bundledeps-b" => Edge {
+          "name": "@isaacs/testing-bundledeps-b",
+          "spec": "*",
+          "to": "node_modules/@isaacs/testing-bundledeps-b",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-bundledeps-c",
+      "name": "@isaacs/testing-bundledeps-c",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-bundledeps-c/-/testing-bundledeps-c-2.0.0.tgz",
+    },
+  },
+  "edgesOut": Map {
+    "@isaacs/testing-bundledeps" => Edge {
+      "name": "@isaacs/testing-bundledeps",
+      "spec": "*",
+      "to": "node_modules/@isaacs/testing-bundledeps",
+      "type": "prod",
+    },
+  },
+  "location": "",
+  "name": "testing-bundledeps",
+  "resolved": null,
+}
+`
+
+exports[`test/arborist/build-ideal-tree.js TAP bundle deps example 1, complete:true > bundle the bundler 1`] = `
+Node {
+  "children": Map {
+    "@isaacs/testing-bundledeps" => Node {
+      "bundled": true,
+      "children": Map {
+        "@isaacs/testing-bundledeps-a" => Node {
+          "bundled": true,
+          "edgesIn": Set {
+            Edge {
+              "from": "node_modules/@isaacs/testing-bundledeps",
+              "name": "@isaacs/testing-bundledeps-a",
+              "spec": "*",
+              "type": "prod",
+            },
+          },
+          "edgesOut": Map {
+            "@isaacs/testing-bundledeps-b" => Edge {
+              "name": "@isaacs/testing-bundledeps-b",
+              "spec": "*",
+              "to": "node_modules/@isaacs/testing-bundledeps/node_modules/@isaacs/testing-bundledeps-b",
+              "type": "prod",
+            },
+          },
+          "location": "node_modules/@isaacs/testing-bundledeps/node_modules/@isaacs/testing-bundledeps-a",
+          "name": "@isaacs/testing-bundledeps-a",
+          "resolved": "https://registry.npmjs.org/@isaacs/testing-bundledeps-a/-/testing-bundledeps-a-1.0.0.tgz",
+        },
+        "@isaacs/testing-bundledeps-b" => Node {
+          "bundled": true,
+          "edgesIn": Set {
+            Edge {
+              "from": "node_modules/@isaacs/testing-bundledeps/node_modules/@isaacs/testing-bundledeps-a",
+              "name": "@isaacs/testing-bundledeps-b",
+              "spec": "*",
+              "type": "prod",
+            },
+          },
+          "location": "node_modules/@isaacs/testing-bundledeps/node_modules/@isaacs/testing-bundledeps-b",
+          "name": "@isaacs/testing-bundledeps-b",
+          "resolved": "https://registry.npmjs.org/@isaacs/testing-bundledeps-b/-/testing-bundledeps-b-1.0.0.tgz",
+        },
+      },
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "@isaacs/testing-bundledeps",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-bundledeps-a" => Edge {
+          "name": "@isaacs/testing-bundledeps-a",
+          "spec": "*",
+          "to": "node_modules/@isaacs/testing-bundledeps/node_modules/@isaacs/testing-bundledeps-a",
+          "type": "prod",
+        },
+        "@isaacs/testing-bundledeps-c" => Edge {
+          "name": "@isaacs/testing-bundledeps-c",
+          "spec": "*",
+          "to": "node_modules/@isaacs/testing-bundledeps-c",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-bundledeps",
+      "name": "@isaacs/testing-bundledeps",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-bundledeps/-/testing-bundledeps-1.0.0.tgz",
+    },
+    "@isaacs/testing-bundledeps-b" => Node {
+      "bundled": true,
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@isaacs/testing-bundledeps-c",
+          "name": "@isaacs/testing-bundledeps-b",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-bundledeps-b",
+      "name": "@isaacs/testing-bundledeps-b",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-bundledeps-b/-/testing-bundledeps-b-1.0.0.tgz",
+    },
+    "@isaacs/testing-bundledeps-c" => Node {
+      "bundled": true,
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@isaacs/testing-bundledeps",
+          "name": "@isaacs/testing-bundledeps-c",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-bundledeps-b" => Edge {
+          "name": "@isaacs/testing-bundledeps-b",
+          "spec": "*",
+          "to": "node_modules/@isaacs/testing-bundledeps-b",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-bundledeps-c",
+      "name": "@isaacs/testing-bundledeps-c",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-bundledeps-c/-/testing-bundledeps-c-2.0.0.tgz",
+    },
+  },
+  "edgesOut": Map {
+    "@isaacs/testing-bundledeps" => Edge {
+      "name": "@isaacs/testing-bundledeps",
+      "spec": "*",
+      "to": "node_modules/@isaacs/testing-bundledeps",
+      "type": "prod",
+    },
+  },
+  "location": "",
+  "name": "testing-bundledeps",
+  "resolved": null,
+}
+`
+
 exports[`test/arborist/build-ideal-tree.js TAP bundle deps example 2 > add new bundled dep c 1`] = `
 Node {
   "children": Map {
@@ -2011,6 +2248,60 @@ Node {
 }
 `
 
+exports[`test/arborist/build-ideal-tree.js TAP do add shrinkwrapped deps when complete:true is set > expect resolving Promise 1`] = `
+Node {
+  "children": Map {
+    "@isaacs/shrinkwrapped-dependency" => Node {
+      "children": Map {
+        "abbrev" => Node {
+          "edgesIn": Set {
+            Edge {
+              "from": "node_modules/@isaacs/shrinkwrapped-dependency",
+              "name": "abbrev",
+              "spec": "^1.0.4",
+              "type": "prod",
+            },
+          },
+          "location": "node_modules/@isaacs/shrinkwrapped-dependency/node_modules/abbrev",
+          "name": "abbrev",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.4.tgz",
+        },
+      },
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "@isaacs/shrinkwrapped-dependency",
+          "spec": "^1.0.0",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "abbrev" => Edge {
+          "name": "abbrev",
+          "spec": "^1.0.4",
+          "to": "node_modules/@isaacs/shrinkwrapped-dependency/node_modules/abbrev",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@isaacs/shrinkwrapped-dependency",
+      "name": "@isaacs/shrinkwrapped-dependency",
+      "resolved": "https://registry.npmjs.org/@isaacs/shrinkwrapped-dependency/-/shrinkwrapped-dependency-1.0.0.tgz",
+    },
+  },
+  "edgesOut": Map {
+    "@isaacs/shrinkwrapped-dependency" => Edge {
+      "name": "@isaacs/shrinkwrapped-dependency",
+      "spec": "^1.0.0",
+      "to": "node_modules/@isaacs/shrinkwrapped-dependency",
+      "type": "prod",
+    },
+  },
+  "location": "",
+  "name": "shrinkwrapped-dep-no-lock",
+  "resolved": null,
+}
+`
+
 exports[`test/arborist/build-ideal-tree.js TAP do not add shrinkwrapped deps > expect resolving Promise 1`] = `
 Node {
   "children": Map {
@@ -2052,6 +2343,60 @@ Node {
 `
 
 exports[`test/arborist/build-ideal-tree.js TAP do not update shrinkwrapped deps > expect resolving Promise 1`] = `
+Node {
+  "children": Map {
+    "@isaacs/shrinkwrapped-dependency" => Node {
+      "children": Map {
+        "abbrev" => Node {
+          "edgesIn": Set {
+            Edge {
+              "from": "node_modules/@isaacs/shrinkwrapped-dependency",
+              "name": "abbrev",
+              "spec": "^1.0.4",
+              "type": "prod",
+            },
+          },
+          "location": "node_modules/@isaacs/shrinkwrapped-dependency/node_modules/abbrev",
+          "name": "abbrev",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.4.tgz",
+        },
+      },
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "@isaacs/shrinkwrapped-dependency",
+          "spec": "^1.0.0",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "abbrev" => Edge {
+          "name": "abbrev",
+          "spec": "^1.0.4",
+          "to": "node_modules/@isaacs/shrinkwrapped-dependency/node_modules/abbrev",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@isaacs/shrinkwrapped-dependency",
+      "name": "@isaacs/shrinkwrapped-dependency",
+      "resolved": "https://registry.npmjs.org/@isaacs/shrinkwrapped-dependency/-/shrinkwrapped-dependency-1.0.0.tgz",
+    },
+  },
+  "edgesOut": Map {
+    "@isaacs/shrinkwrapped-dependency" => Edge {
+      "name": "@isaacs/shrinkwrapped-dependency",
+      "spec": "^1.0.0",
+      "to": "node_modules/@isaacs/shrinkwrapped-dependency",
+      "type": "prod",
+    },
+  },
+  "location": "",
+  "name": "shrinkwrapped-dep-with-lock",
+  "resolved": null,
+}
+`
+
+exports[`test/arborist/build-ideal-tree.js TAP do not update shrinkwrapped deps when complete:true is set > expect resolving Promise 1`] = `
 Node {
   "children": Map {
     "@isaacs/shrinkwrapped-dependency" => Node {

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -257,6 +257,20 @@ t.test('bundle deps example 1', t => {
     }), 'bundle the bundler'))
 })
 
+t.test('bundle deps example 1, complete:true', t => {
+  // When complete:true is set, we extract into a temp dir to read
+  // the bundled deps, so they ARE included, just like during reify()
+  const path = resolve(fixtures, 'testing-bundledeps')
+  return t.resolveMatchSnapshot(printIdeal(path, {
+    complete: true,
+  }), 'bundle deps testing')
+    .then(() => t.resolveMatchSnapshot(printIdeal(path, {
+      saveBundle: true,
+      add: [ '@isaacs/testing-bundledeps' ],
+      complete: true,
+    }), 'bundle the bundler'))
+})
+
 t.test('bundle deps example 2', t => {
   // bundled deps at the root level are NOT ignored when building ideal trees
   const path = resolve(fixtures, 'testing-bundledeps-2')
@@ -286,10 +300,21 @@ t.test('do not add shrinkwrapped deps', t => {
   return t.resolveMatchSnapshot(printIdeal(path))
 })
 
+t.test('do add shrinkwrapped deps when complete:true is set', t => {
+  const path = resolve(fixtures, 'shrinkwrapped-dep-no-lock')
+  return t.resolveMatchSnapshot(printIdeal(path, { complete: true }))
+})
+
 t.test('do not update shrinkwrapped deps', t => {
   const path = resolve(fixtures, 'shrinkwrapped-dep-with-lock')
   return t.resolveMatchSnapshot(printIdeal(path,
     { update: { names: ['abbrev']}}))
+})
+
+t.test('do not update shrinkwrapped deps when complete:true is set', t => {
+  const path = resolve(fixtures, 'shrinkwrapped-dep-with-lock')
+  return t.resolveMatchSnapshot(printIdeal(path,
+    { update: { names: ['abbrev']}, complete: true}))
 })
 
 t.test('deduped transitive deps with asymmetrical bin declaration', t => {

--- a/test/load-bundle-deps.js
+++ b/test/load-bundle-deps.js
@@ -1,0 +1,70 @@
+const t = require('tap')
+const loadBundle = require('../lib/load-bundle-deps.js')
+const Node = require('../lib/node.js')
+const Arborist = require('../lib/arborist/index.js')
+
+const pkg = {
+  name: 'root',
+  dependencies: { xyz: '', ijk: '' },
+  bundleDependencies: ['xyz'],
+}
+
+const fixture = {
+  node_modules: {
+    // simulating the presence of a sparse folder during reification
+    empty: {},
+    xyz: {
+      'package.json': JSON.stringify({
+        name: 'xyz',
+        version: '1.2.3',
+        bin: 'xyz.js',
+        dependencies: {
+          abc: '',
+        },
+      }),
+      'xyz.js': '#!/usr/bin/env node\nconsole.log("xyz")',
+    },
+    abc: {
+      'package.json': JSON.stringify({
+        name: 'abc',
+        version: '1.2.3',
+        bin: 'abc.js',
+      }),
+      'abc.js': '#!/usr/bin/env node\nconsole.log("abc")',
+    },
+  },
+  'package.json': JSON.stringify(pkg),
+}
+
+const { existsSync } = require('fs')
+
+t.test('read bundling dep in its current position', async t => {
+  const path = t.testdir(fixture)
+  const node = new Node({ path, pkg })
+  const arb = new Arborist({ path })
+  await loadBundle(node, arb, {})
+  t.strictSame([...node.children.keys()].sort((a, b) => a.localeCompare(b)), ['abc', 'xyz'])
+  t.equal(existsSync(path + '/node_modules/.bin/xyz'), true, 'xyz bin exists')
+  t.equal(existsSync(path + '/node_modules/.bin/abc'), true, 'abc bin exists')
+})
+
+t.test('read bundling dep in current position, binLinks false', async t => {
+  const path = t.testdir(fixture)
+  const node = new Node({ path, pkg })
+  const arb = new Arborist({ path })
+  await loadBundle(node, arb, { binLinks: false })
+  t.strictSame([...node.children.keys()].sort((a, b) => a.localeCompare(b)), ['abc', 'xyz'])
+  t.equal(existsSync(path + '/node_modules/.bin/xyz'), false, 'xyz bin not present')
+  t.equal(existsSync(path + '/node_modules/.bin/abc'), false, 'abc bin not present')
+})
+
+t.test('read bundling dep in temp folder', async t => {
+  const path = t.testdir(fixture)
+  const node = new Node({ path: '/some/other/path', pkg })
+  const arb = new Arborist({ path })
+  // doesn't load binLinks unless it's a build-in-place
+  await loadBundle(node, arb, { binLinks: true, path })
+  t.strictSame([...node.children.keys()].sort((a, b) => a.localeCompare(b)), ['abc', 'xyz'])
+  t.equal(existsSync(path + '/node_modules/.bin/xyz'), false, 'xyz bin not present')
+  t.equal(existsSync(path + '/node_modules/.bin/abc'), false, 'abc bin not present')
+})


### PR DESCRIPTION
Needed for implementing 'npm install --package-lock-only'
