### PR TITLE
fix: avoid throwing type erros on inventory.add

### DIFF
--- a/lib/inventory.js
+++ b/lib/inventory.js
@@ -41,7 +41,7 @@ class Inventory extends Map {
     for (const [key, map] of this[_index].entries()) {
       const val_ = node[key] || (node.package && node.package[key])
       const val = typeof val_ === 'string' ? val_
-        : typeof val_ === 'object'
+        : (val_ && typeof val_ === 'object')
         ? ( key === 'license' ? val_.type
           : key === 'funding' ? val_.url
           : /* istanbul ignore next */ val_)

--- a/test/inventory.js
+++ b/test/inventory.js
@@ -70,5 +70,24 @@ t.test('basic operations', t => {
   t.equal(i.get('z'), undefined, 'node is not here')
   t.equal(i.has(z), false, 'i does not have z any more')
 
+  t.doesNotThrow(() =>
+    i.add({
+      location: 'f',
+      name: 'f',
+      'package': {
+        license: 'MIT',
+        funding: null
+      }
+    }) , 'doesnt throw on falsy funding info')
+
+  t.doesNotThrow(() =>
+    i.add({
+      location: 'l',
+      name: 'l',
+      'package': {
+        license: null
+      }
+    }) , 'doesnt throw on falsy license info')
+
   t.end()
 })


### PR DESCRIPTION
Trying to load mock malformed testing data from the cli resulted in an unexpected `TypeError`. The issue can be reproduced by having a falsy funding property in a package.json, as seen here: https://github.com/npm/cli/blob/abdf52879fcf0e0f534ad977931f6935f5d1dce3/test/tap/fund.js#L81

This commit fixes the problem by avoiding trying to retrieve the `type`and `url` properties when having a `null` object reference.

While I considered the alternative of throwing a more descriptive error instead of having `TypeError: Cannot read property 'url' of null` - I think in this case not blowing up is a much more convenient and reasonable behavior.