### PR TITLE
test: fix links-all-over fixture

### DIFF
--- a/tap-snapshots/test-arborist-load-actual.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-load-actual.js-TAP.test.js
@@ -3417,11 +3417,18 @@ Node {
                           "type": "prod",
                         },
                       },
-                      "extraneous": true,
                       "location": "node_modules/nest/node_modules/a/node_modules/b/node_modules/c/node_modules/d",
                       "name": "d",
                       "realpath": "links-all-over/node_modules/nest/node_modules/a/node_modules/b/node_modules/c/node_modules/d",
                       "top": "links-all-over",
+                    },
+                  },
+                  "edgesIn": Set {
+                    Edge {
+                      "from": "links-all-over/node_modules/nest/node_modules/a/node_modules/b",
+                      "name": "c",
+                      "spec": "",
+                      "type": "prod",
                     },
                   },
                   "edgesOut": Map {
@@ -3432,7 +3439,6 @@ Node {
                       "type": "prod",
                     },
                   },
-                  "extraneous": true,
                   "location": "node_modules/nest/node_modules/a/node_modules/b/node_modules/c",
                   "name": "c",
                   "realpath": "links-all-over/node_modules/nest/node_modules/a/node_modules/b/node_modules/c",
@@ -3447,12 +3453,14 @@ Node {
                   "type": "prod",
                 },
               },
-              "errors": Array [
-                Object {
-                  "code": "EJSONPARSE",
-                  "path": "../fixtures/links-all-over/node_modules/nest/node_modules/a/node_modules/b/package.json",
+              "edgesOut": Map {
+                "c" => Edge {
+                  "name": "c",
+                  "spec": "",
+                  "to": "links-all-over/node_modules/nest/node_modules/a/node_modules/b/node_modules/c",
+                  "type": "prod",
                 },
-              ],
+              },
               "location": "node_modules/nest/node_modules/a/node_modules/b",
               "name": "b",
               "realpath": "links-all-over/node_modules/nest/node_modules/a/node_modules/b",
@@ -3618,20 +3626,22 @@ Node {
                             "version": "1.2.3",
                           },
                         },
-                        "extraneous": true,
                         "requires": Object {
                           "deep": "",
                         },
                         "version": "1.2.3",
                       },
                     },
-                    "extraneous": true,
                     "requires": Object {
                       "d": "",
                     },
                     "version": "1.2.3",
                   },
                 },
+                "requires": Object {
+                  "c": "",
+                },
+                "version": "1.2.3",
               },
             },
             "requires": Object {
@@ -3690,19 +3700,22 @@ Node {
         },
         "version": "1.2.3",
       },
-      "node_modules/nest/node_modules/a/node_modules/b": Object {},
+      "node_modules/nest/node_modules/a/node_modules/b": Object {
+        "dependencies": Object {
+          "c": "",
+        },
+        "version": "1.2.3",
+      },
       "node_modules/nest/node_modules/a/node_modules/b/node_modules/c": Object {
         "dependencies": Object {
           "d": "",
         },
-        "extraneous": true,
         "version": "1.2.3",
       },
       "node_modules/nest/node_modules/a/node_modules/b/node_modules/c/node_modules/d": Object {
         "dependencies": Object {
           "deep": "",
         },
-        "extraneous": true,
         "version": "1.2.3",
       },
       "node_modules/nest/node_modules/a/node_modules/b/node_modules/c/node_modules/d/node_modules/deep": Object {

--- a/tap-snapshots/test-shrinkwrap.js-TAP.test.js
+++ b/tap-snapshots/test-shrinkwrap.js-TAP.test.js
@@ -2722,20 +2722,22 @@ Object {
                           "version": "1.2.3",
                         },
                       },
-                      "extraneous": true,
                       "requires": Object {
                         "deep": "",
                       },
                       "version": "1.2.3",
                     },
                   },
-                  "extraneous": true,
                   "requires": Object {
                     "d": "",
                   },
                   "version": "1.2.3",
                 },
               },
+              "requires": Object {
+                "c": "",
+              },
+              "version": "1.2.3",
             },
           },
           "requires": Object {
@@ -2794,19 +2796,22 @@ Object {
       },
       "version": "1.2.3",
     },
-    "node_modules/nest/node_modules/a/node_modules/b": Object {},
+    "node_modules/nest/node_modules/a/node_modules/b": Object {
+      "dependencies": Object {
+        "c": "",
+      },
+      "version": "1.2.3",
+    },
     "node_modules/nest/node_modules/a/node_modules/b/node_modules/c": Object {
       "dependencies": Object {
         "d": "",
       },
-      "extraneous": true,
       "version": "1.2.3",
     },
     "node_modules/nest/node_modules/a/node_modules/b/node_modules/c/node_modules/d": Object {
       "dependencies": Object {
         "deep": "",
       },
-      "extraneous": true,
       "version": "1.2.3",
     },
     "node_modules/nest/node_modules/a/node_modules/b/node_modules/c/node_modules/d/node_modules/deep": Object {

--- a/tap-snapshots/test-yarn-lock.js-TAP.test.js
+++ b/tap-snapshots/test-yarn-lock.js-TAP.test.js
@@ -219,6 +219,14 @@ exports[`test/yarn-lock.js TAP load a yarn lock from an actual tree links-all-ov
     "b" ""
 
 "b@":
+  "version" "1.2.3"
+  dependencies:
+    "c" ""
+
+"c@":
+  "version" "1.2.3"
+  dependencies:
+    "d" ""
 
 "d@":
   "version" "1.2.3"

--- a/test/fixtures/links-all-over/node_modules/nest/node_modules/a/node_modules/b/package.json
+++ b/test/fixtures/links-all-over/node_modules/nest/node_modules/a/node_modules/b/package.json
@@ -1,2 +1,1 @@
-
-{"name":"bversion":"1.2.3","dependencies":{"c":""}}
+{"name":"b", "version":"1.2.3","dependencies":{"c":""}}


### PR DESCRIPTION
`links-all-over` fixtures had a nested malformed `package.json` file, this change only fixes that and updates related snapshots.
