### PR TITLE
Refresh dep flags in virtualTree, prune extraneous from ideal

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -37,6 +37,7 @@ const _depsQueue = Symbol('depsQueue')
 const _currentDep = Symbol('currentDep')
 const _updateAll = Symbol('updateAll')
 const _mutateTree = Symbol('mutateTree')
+const _flagsSuspect = Symbol.for('flagsSuspect')
 const _prune = Symbol('prune')
 const _preferDedupe = Symbol('preferDedupe')
 const _legacyBundling = Symbol('legacyBundling')
@@ -1240,6 +1241,8 @@ This is a one-time fix-up, please be patient...
   [_fixDepFlags] () {
     process.emit('time', 'idealTree:fixDepFlags')
     const metaFromDisk = this.idealTree.meta.loadedFromDisk
+    const flagsSuspect = this[_flagsSuspect]
+    const mutateTree = this[_mutateTree]
     // if the options set prune:false, then we don't prune, but we still
     // mark the extraneous items in the tree if we modified it at all.
     // If we did no modifications, we just iterate over the extraneous nodes.
@@ -1247,7 +1250,7 @@ This is a one-time fix-up, please be patient...
     // all set to true, and there can be nothing extraneous, so there's
     // nothing to prune, because we built it from scratch.  if we didn't
     // add or remove anything, then also nothing to do.
-    if (metaFromDisk && this[_mutateTree])
+    if (metaFromDisk && mutateTree)
       this[_resetDepFlags]()
 
     // update all the dev/optional/etc flags in the tree
@@ -1256,7 +1259,7 @@ This is a one-time fix-up, please be patient...
     //
     // if we started from a blank slate, or changed something, then
     // the dep flags will be all set to true.
-    if (!metaFromDisk || this[_mutateTree])
+    if (!metaFromDisk || mutateTree)
       calcDepFlags(this.idealTree)
     else {
       // otherwise just unset all the flags on the root node
@@ -1272,9 +1275,9 @@ This is a one-time fix-up, please be patient...
     // if we started from a shrinkwrap, and then added/removed something,
     // then the tree is suspect.  Prune what is marked as extraneous.
     // otherwise, don't bother.
-    if (this[_prune] && metaFromDisk && this[_mutateTree]) {
+    const needPrune = metaFromDisk && (mutateTree || flagsSuspect)
+    if (this[_prune] && needPrune)
       this[_idealTreePrune]()
-    }
     process.emit('timeEnd', 'idealTree:fixDepFlags')
   }
 

--- a/lib/arborist/load-virtual.js
+++ b/lib/arborist/load-virtual.js
@@ -10,6 +10,7 @@ const Shrinkwrap = require('../shrinkwrap.js')
 const Node = require('../node.js')
 const Link = require('../link.js')
 const relpath = require('../relpath.js')
+const calcDepFlags = require('../calc-dep-flags.js')
 const rpj = require('read-package-json-fast')
 
 const loadFromShrinkwrap = Symbol('loadFromShrinkwrap')
@@ -20,6 +21,12 @@ const loadRoot = Symbol('loadRoot')
 const loadNode = Symbol('loadVirtualNode')
 const loadLink = Symbol('loadVirtualLink')
 const loadWorkspaces = Symbol('loadWorkspaces')
+const flagsSuspect = Symbol.for('flagsSuspect')
+const reCalcDepFlags = Symbol('reCalcDepFlags')
+const checkRootEdges = Symbol('checkRootEdges')
+
+const depsToEdges = (type, deps) =>
+  Object.entries(deps).map(d => [type, ...d])
 
 module.exports = cls => class VirtualLoader extends cls {
   constructor (options) {
@@ -27,6 +34,7 @@ module.exports = cls => class VirtualLoader extends cls {
 
     // the virtual tree we load from a shrinkwrap
     this.virtualTree = options.virtualTree
+    this[flagsSuspect] = false
   }
 
   // public method
@@ -71,12 +79,84 @@ module.exports = cls => class VirtualLoader extends cls {
     root.optional = false
     root.devOptional = false
     root.peer = false
+    this[checkRootEdges](s, root)
     s.add(root)
     this.virtualTree = root
     const {links, nodes} = this[resolveNodes](s, root)
     await this[resolveLinks](links, nodes)
     this[assignParentage](nodes)
+    if (this[flagsSuspect])
+      this[reCalcDepFlags]()
     return root
+  }
+
+  [reCalcDepFlags] () {
+    // reset all dep flags
+    for (const node of this.virtualTree.inventory.values()) {
+      node.extraneous = true
+      node.dev = true
+      node.optional = true
+      node.devOptional = true
+      node.peer = true
+    }
+    calcDepFlags(this.virtualTree, true)
+  }
+
+  // check the lockfile deps, and see if they match.  if they do not
+  // then we have to reset dep flags at the end.  for example, if the
+  // user manually edits their package.json file, then we need to know
+  // that the idealTree is no longer entirely trustworthy.
+  [checkRootEdges] (s, root) {
+    // loaded virtually from tree, no chance of being out of sync
+    // ancient lockfiles are critically damaged by this process,
+    // so we need to just hope for the best in those cases.
+    if (!s.loadedFromDisk || s.ancientLockfile)
+      return
+
+    const lock = s.get('')
+    const prod = lock.dependencies || {}
+    const dev = lock.devDependencies || {}
+    const optional = lock.optionalDependencies || {}
+    const peer = lock.peerDependencies || {}
+    const peerOptional = {}
+    if (lock.peerDependenciesMeta) {
+      for (const [name, meta] of Object.entries(lock.peerDependenciesMeta)) {
+        if (meta.optional && peer[name] !== undefined) {
+          peerOptional[name] = peer[name]
+          delete peer[name]
+        }
+      }
+    }
+    for (const name of Object.keys(optional)) {
+      delete prod[name]
+    }
+
+    const lockEdges = [
+      ...depsToEdges('prod', prod),
+      ...depsToEdges('dev', dev),
+      ...depsToEdges('optional', optional),
+      ...depsToEdges('peer', peer),
+      ...depsToEdges('peerOptional', peerOptional),
+    ].sort(([atype, aname], [btype, bname]) =>
+      atype.localeCompare(btype) || aname.localeCompare(bname))
+
+    const rootEdges = [...root.edgesOut.values()]
+      .map(e => [e.type, e.name, e.spec])
+      .sort(([atype, aname], [btype, bname]) =>
+        atype.localeCompare(btype) || aname.localeCompare(bname))
+
+    if (rootEdges.length !== lockEdges.length) {
+      // something added or removed
+      return this[flagsSuspect] = true
+    }
+
+    for (let i = 0; i < lockEdges.length; i++) {
+      if (rootEdges[i][0] !== lockEdges[i][0] ||
+          rootEdges[i][1] !== lockEdges[i][1] ||
+          rootEdges[i][2] !== lockEdges[i][2]) {
+        return this[flagsSuspect] = true
+      }
+    }
   }
 
   // separate out link metadatas, and create Node objects for nodes

--- a/tap-snapshots/test-arborist-load-virtual.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-load-virtual.js-TAP.test.js
@@ -5,6 +5,686 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/arborist/load-virtual.js TAP load a tree where package.json edited > changed, but re-using the same root that already has meta 1`] = `
+Node {
+  "children": Map {
+    "abbrev" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "abbrev",
+          "spec": "^1.1.0",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/abbrev",
+      "name": "abbrev",
+      "package": Object {
+        "name": "abbrev",
+        "version": "1.1.1",
+      },
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+    },
+    "json-parse-even-better-errors" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "json-parse-even-better-errors",
+          "spec": "",
+          "type": "optional",
+        },
+      },
+      "location": "node_modules/json-parse-even-better-errors",
+      "name": "json-parse-even-better-errors",
+      "optional": true,
+      "package": Object {
+        "name": "json-parse-even-better-errors",
+        "version": "2.3.1",
+      },
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+    },
+    "once" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "once",
+          "spec": "",
+          "type": "peer",
+        },
+      },
+      "edgesOut": Map {
+        "wrappy" => Edge {
+          "name": "wrappy",
+          "spec": "1",
+          "to": "node_modules/wrappy",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/once",
+      "name": "once",
+      "package": Object {
+        "name": "once",
+        "version": "1.4.0",
+      },
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+    },
+    "opener" => Node {
+      "dev": true,
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/walden",
+          "name": "opener",
+          "spec": "^1.4.2",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/opener",
+      "name": "opener",
+      "package": Object {
+        "name": "opener",
+        "version": "1.5.2",
+      },
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+    },
+    "semver" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "semver",
+          "spec": "",
+          "type": "peerOptional",
+        },
+      },
+      "location": "node_modules/semver",
+      "name": "semver",
+      "optional": true,
+      "package": Object {
+        "name": "semver",
+        "version": "7.3.2",
+      },
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+    },
+    "walden" => Node {
+      "dev": true,
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "walden",
+          "spec": "",
+          "type": "dev",
+        },
+      },
+      "edgesOut": Map {
+        "opener" => Edge {
+          "name": "opener",
+          "spec": "^1.4.2",
+          "to": "node_modules/opener",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/walden",
+      "name": "walden",
+      "package": Object {
+        "name": "walden",
+        "version": "1.0.3",
+      },
+      "resolved": "https://registry.npmjs.org/walden/-/walden-1.0.3.tgz",
+    },
+    "wrappy" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/once",
+          "name": "wrappy",
+          "spec": "1",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/wrappy",
+      "name": "wrappy",
+      "package": Object {
+        "name": "wrappy",
+        "version": "1.0.2",
+      },
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+    },
+  },
+  "edgesOut": Map {
+    "abbrev" => Edge {
+      "name": "abbrev",
+      "spec": "^1.1.0",
+      "to": "node_modules/abbrev",
+      "type": "prod",
+    },
+    "json-parse-even-better-errors" => Edge {
+      "name": "json-parse-even-better-errors",
+      "spec": "",
+      "to": "node_modules/json-parse-even-better-errors",
+      "type": "optional",
+    },
+    "once" => Edge {
+      "name": "once",
+      "spec": "",
+      "to": "node_modules/once",
+      "type": "peer",
+    },
+    "semver" => Edge {
+      "name": "semver",
+      "spec": "",
+      "to": "node_modules/semver",
+      "type": "peerOptional",
+    },
+    "walden" => Edge {
+      "name": "walden",
+      "spec": "",
+      "to": "node_modules/walden",
+      "type": "dev",
+    },
+  },
+  "location": "",
+  "name": "changed",
+  "package": Object {
+    "name": "changed",
+    "version": undefined,
+  },
+  "resolved": null,
+}
+`
+
+exports[`test/arborist/load-virtual.js TAP load a tree where package.json edited > deps changed 1`] = `
+Node {
+  "children": Map {
+    "abbrev" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "abbrev",
+          "spec": "^1.1.0",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/abbrev",
+      "name": "abbrev",
+      "package": Object {
+        "name": "abbrev",
+        "version": "1.1.1",
+      },
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+    },
+    "json-parse-even-better-errors" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "json-parse-even-better-errors",
+          "spec": "",
+          "type": "optional",
+        },
+      },
+      "location": "node_modules/json-parse-even-better-errors",
+      "name": "json-parse-even-better-errors",
+      "optional": true,
+      "package": Object {
+        "name": "json-parse-even-better-errors",
+        "version": "2.3.1",
+      },
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+    },
+    "once" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "once",
+          "spec": "",
+          "type": "peer",
+        },
+      },
+      "edgesOut": Map {
+        "wrappy" => Edge {
+          "name": "wrappy",
+          "spec": "1",
+          "to": "node_modules/wrappy",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/once",
+      "name": "once",
+      "package": Object {
+        "name": "once",
+        "version": "1.4.0",
+      },
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+    },
+    "opener" => Node {
+      "dev": true,
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/walden",
+          "name": "opener",
+          "spec": "^1.4.2",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/opener",
+      "name": "opener",
+      "package": Object {
+        "name": "opener",
+        "version": "1.5.2",
+      },
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+    },
+    "semver" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "semver",
+          "spec": "",
+          "type": "peerOptional",
+        },
+      },
+      "location": "node_modules/semver",
+      "name": "semver",
+      "optional": true,
+      "package": Object {
+        "name": "semver",
+        "version": "7.3.2",
+      },
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+    },
+    "walden" => Node {
+      "dev": true,
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "walden",
+          "spec": "",
+          "type": "dev",
+        },
+      },
+      "edgesOut": Map {
+        "opener" => Edge {
+          "name": "opener",
+          "spec": "^1.4.2",
+          "to": "node_modules/opener",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/walden",
+      "name": "walden",
+      "package": Object {
+        "name": "walden",
+        "version": "1.0.3",
+      },
+      "resolved": "https://registry.npmjs.org/walden/-/walden-1.0.3.tgz",
+    },
+    "wrappy" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/once",
+          "name": "wrappy",
+          "spec": "1",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/wrappy",
+      "name": "wrappy",
+      "package": Object {
+        "name": "wrappy",
+        "version": "1.0.2",
+      },
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+    },
+  },
+  "edgesOut": Map {
+    "abbrev" => Edge {
+      "name": "abbrev",
+      "spec": "^1.1.0",
+      "to": "node_modules/abbrev",
+      "type": "prod",
+    },
+    "json-parse-even-better-errors" => Edge {
+      "name": "json-parse-even-better-errors",
+      "spec": "",
+      "to": "node_modules/json-parse-even-better-errors",
+      "type": "optional",
+    },
+    "once" => Edge {
+      "name": "once",
+      "spec": "",
+      "to": "node_modules/once",
+      "type": "peer",
+    },
+    "semver" => Edge {
+      "name": "semver",
+      "spec": "",
+      "to": "node_modules/semver",
+      "type": "peerOptional",
+    },
+    "walden" => Edge {
+      "name": "walden",
+      "spec": "",
+      "to": "node_modules/walden",
+      "type": "dev",
+    },
+  },
+  "location": "",
+  "name": "changed",
+  "package": Object {
+    "name": "changed",
+    "version": undefined,
+  },
+  "resolved": null,
+}
+`
+
+exports[`test/arborist/load-virtual.js TAP load a tree where package.json edited > deps match 1`] = `
+Node {
+  "children": Map {
+    "abbrev" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "abbrev",
+          "spec": "^1.1.1",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/abbrev",
+      "name": "abbrev",
+      "package": Object {
+        "name": "abbrev",
+        "version": "1.1.1",
+      },
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+    },
+    "json-parse-even-better-errors" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "json-parse-even-better-errors",
+          "spec": "",
+          "type": "optional",
+        },
+      },
+      "location": "node_modules/json-parse-even-better-errors",
+      "name": "json-parse-even-better-errors",
+      "optional": true,
+      "package": Object {
+        "name": "json-parse-even-better-errors",
+        "version": "2.3.1",
+      },
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+    },
+    "once" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "once",
+          "spec": "",
+          "type": "peer",
+        },
+      },
+      "edgesOut": Map {
+        "wrappy" => Edge {
+          "name": "wrappy",
+          "spec": "1",
+          "to": "node_modules/wrappy",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/once",
+      "name": "once",
+      "package": Object {
+        "name": "once",
+        "version": "1.4.0",
+      },
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+    },
+    "opener" => Node {
+      "dev": true,
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/walden",
+          "name": "opener",
+          "spec": "^1.4.2",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/opener",
+      "name": "opener",
+      "package": Object {
+        "name": "opener",
+        "version": "1.5.2",
+      },
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+    },
+    "semver" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "semver",
+          "spec": "",
+          "type": "peerOptional",
+        },
+      },
+      "location": "node_modules/semver",
+      "name": "semver",
+      "optional": true,
+      "package": Object {
+        "name": "semver",
+        "version": "7.3.2",
+      },
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+    },
+    "walden" => Node {
+      "dev": true,
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "walden",
+          "spec": "",
+          "type": "dev",
+        },
+      },
+      "edgesOut": Map {
+        "opener" => Edge {
+          "name": "opener",
+          "spec": "^1.4.2",
+          "to": "node_modules/opener",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/walden",
+      "name": "walden",
+      "package": Object {
+        "name": "walden",
+        "version": "1.0.3",
+      },
+      "resolved": "https://registry.npmjs.org/walden/-/walden-1.0.3.tgz",
+    },
+    "wrappy" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/once",
+          "name": "wrappy",
+          "spec": "1",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/wrappy",
+      "name": "wrappy",
+      "package": Object {
+        "name": "wrappy",
+        "version": "1.0.2",
+      },
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+    },
+  },
+  "edgesOut": Map {
+    "abbrev" => Edge {
+      "name": "abbrev",
+      "spec": "^1.1.1",
+      "to": "node_modules/abbrev",
+      "type": "prod",
+    },
+    "json-parse-even-better-errors" => Edge {
+      "name": "json-parse-even-better-errors",
+      "spec": "",
+      "to": "node_modules/json-parse-even-better-errors",
+      "type": "optional",
+    },
+    "once" => Edge {
+      "name": "once",
+      "spec": "",
+      "to": "node_modules/once",
+      "type": "peer",
+    },
+    "semver" => Edge {
+      "name": "semver",
+      "spec": "",
+      "to": "node_modules/semver",
+      "type": "peerOptional",
+    },
+    "walden" => Edge {
+      "name": "walden",
+      "spec": "",
+      "to": "node_modules/walden",
+      "type": "dev",
+    },
+  },
+  "location": "",
+  "name": "ok",
+  "package": Object {
+    "name": "ok",
+    "version": undefined,
+  },
+  "resolved": null,
+}
+`
+
+exports[`test/arborist/load-virtual.js TAP load a tree where package.json edited > deps removed 1`] = `
+Node {
+  "children": Map {
+    "abbrev" => Node {
+      "extraneous": true,
+      "location": "node_modules/abbrev",
+      "name": "abbrev",
+      "package": Object {
+        "name": "abbrev",
+        "version": "1.1.1",
+      },
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+    },
+    "json-parse-even-better-errors" => Node {
+      "extraneous": true,
+      "location": "node_modules/json-parse-even-better-errors",
+      "name": "json-parse-even-better-errors",
+      "package": Object {
+        "name": "json-parse-even-better-errors",
+        "version": "2.3.1",
+      },
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+    },
+    "once" => Node {
+      "edgesOut": Map {
+        "wrappy" => Edge {
+          "name": "wrappy",
+          "spec": "1",
+          "to": "node_modules/wrappy",
+          "type": "prod",
+        },
+      },
+      "extraneous": true,
+      "location": "node_modules/once",
+      "name": "once",
+      "package": Object {
+        "name": "once",
+        "version": "1.4.0",
+      },
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+    },
+    "opener" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/walden",
+          "name": "opener",
+          "spec": "^1.4.2",
+          "type": "prod",
+        },
+      },
+      "extraneous": true,
+      "location": "node_modules/opener",
+      "name": "opener",
+      "package": Object {
+        "name": "opener",
+        "version": "1.5.2",
+      },
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+    },
+    "semver" => Node {
+      "extraneous": true,
+      "location": "node_modules/semver",
+      "name": "semver",
+      "package": Object {
+        "name": "semver",
+        "version": "7.3.2",
+      },
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+    },
+    "walden" => Node {
+      "edgesOut": Map {
+        "opener" => Edge {
+          "name": "opener",
+          "spec": "^1.4.2",
+          "to": "node_modules/opener",
+          "type": "prod",
+        },
+      },
+      "extraneous": true,
+      "location": "node_modules/walden",
+      "name": "walden",
+      "package": Object {
+        "name": "walden",
+        "version": "1.0.3",
+      },
+      "resolved": "https://registry.npmjs.org/walden/-/walden-1.0.3.tgz",
+    },
+    "wrappy" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/once",
+          "name": "wrappy",
+          "spec": "1",
+          "type": "prod",
+        },
+      },
+      "extraneous": true,
+      "location": "node_modules/wrappy",
+      "name": "wrappy",
+      "package": Object {
+        "name": "wrappy",
+        "version": "1.0.2",
+      },
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+    },
+  },
+  "location": "",
+  "name": "removed",
+  "package": Object {
+    "name": "removed",
+    "version": undefined,
+  },
+  "resolved": null,
+}
+`
+
 exports[`test/arborist/load-virtual.js TAP load a tree with a bunch of bundles > virtual tree with multiple bundles 1`] = `
 Node {
   "children": Map {

--- a/tap-snapshots/test-arborist-reify.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-reify.js-TAP.test.js
@@ -44423,7 +44423,7 @@ Node {
         Edge {
           "from": "",
           "name": "tap",
-          "spec": "^12.7.0",
+          "spec": "12",
           "type": "prod",
         },
       },
@@ -45587,7 +45587,7 @@ Node {
   "edgesOut": Map {
     "tap" => Edge {
       "name": "tap",
-      "spec": "^12.7.0",
+      "spec": "12",
       "to": "node_modules/tap",
       "type": "prod",
     },

--- a/test/fixtures/dep-missing-resolved/package.json
+++ b/test/fixtures/dep-missing-resolved/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "tap": "^12.7.0"
+    "tap": "12"
   }
 }

--- a/test/fixtures/edit-package-json/changed/package-lock.json
+++ b/test/fixtures/edit-package-json/changed/package-lock.json
@@ -1,0 +1,138 @@
+{
+  "name": "edit-pj",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "json-parse-even-better-errors": "",
+        "abbrev": "^1.1.1"
+      },
+      "devDependencies": {
+        "walden": ""
+      },
+      "optionalDependencies": {
+        "json-parse-even-better-errors": ""
+      },
+      "peerDependencies": {
+        "once": "",
+        "semver": ""
+      },
+      "peerDependenciesMeta": {
+        "semver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "optional": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/walden": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/walden/-/walden-1.0.3.tgz",
+      "integrity": "sha512-hGGjhbNDqakQh9MzfCWMlS6FCgLE76HBUJUDHFlb0KiKBD3ovte3Zggh318Yf6XArv31GSurC/mplCZKXe8csA==",
+      "dev": true,
+      "dependencies": {
+        "opener": "^1.4.2"
+      },
+      "bin": {
+        "walden": "bin.js"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "peer": true
+    }
+  },
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "optional": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "peer": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
+    },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "optional": true,
+      "peer": true
+    },
+    "walden": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/walden/-/walden-1.0.3.tgz",
+      "integrity": "sha512-hGGjhbNDqakQh9MzfCWMlS6FCgLE76HBUJUDHFlb0KiKBD3ovte3Zggh318Yf6XArv31GSurC/mplCZKXe8csA==",
+      "dev": true,
+      "requires": {
+        "opener": "^1.4.2"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "peer": true
+    }
+  }
+}

--- a/test/fixtures/edit-package-json/changed/package.json
+++ b/test/fixtures/edit-package-json/changed/package.json
@@ -1,0 +1,21 @@
+{
+  "dependencies": {
+    "abbrev": "^1.1.0",
+    "json-parse-even-better-errors": ""
+  },
+  "peerDependencies": {
+    "semver": "",
+    "once": ""
+  },
+  "peerDependenciesMeta": {
+    "semver": {
+      "optional": true
+    }
+  },
+  "optionalDependencies": {
+    "json-parse-even-better-errors": ""
+  },
+  "devDependencies": {
+    "walden": ""
+  }
+}

--- a/test/fixtures/edit-package-json/ok/package-lock.json
+++ b/test/fixtures/edit-package-json/ok/package-lock.json
@@ -1,0 +1,138 @@
+{
+  "name": "ok",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "json-parse-even-better-errors": "",
+        "abbrev": "^1.1.1"
+      },
+      "devDependencies": {
+        "walden": ""
+      },
+      "optionalDependencies": {
+        "json-parse-even-better-errors": ""
+      },
+      "peerDependencies": {
+        "once": "",
+        "semver": ""
+      },
+      "peerDependenciesMeta": {
+        "semver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "optional": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/walden": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/walden/-/walden-1.0.3.tgz",
+      "integrity": "sha512-hGGjhbNDqakQh9MzfCWMlS6FCgLE76HBUJUDHFlb0KiKBD3ovte3Zggh318Yf6XArv31GSurC/mplCZKXe8csA==",
+      "dev": true,
+      "dependencies": {
+        "opener": "^1.4.2"
+      },
+      "bin": {
+        "walden": "bin.js"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "peer": true
+    }
+  },
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "optional": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "peer": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
+    },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "optional": true,
+      "peer": true
+    },
+    "walden": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/walden/-/walden-1.0.3.tgz",
+      "integrity": "sha512-hGGjhbNDqakQh9MzfCWMlS6FCgLE76HBUJUDHFlb0KiKBD3ovte3Zggh318Yf6XArv31GSurC/mplCZKXe8csA==",
+      "dev": true,
+      "requires": {
+        "opener": "^1.4.2"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "peer": true
+    }
+  }
+}

--- a/test/fixtures/edit-package-json/ok/package.json
+++ b/test/fixtures/edit-package-json/ok/package.json
@@ -1,0 +1,21 @@
+{
+  "dependencies": {
+    "abbrev": "^1.1.1",
+    "json-parse-even-better-errors": ""
+  },
+  "peerDependencies": {
+    "semver": "",
+    "once": ""
+  },
+  "peerDependenciesMeta": {
+    "semver": {
+      "optional": true
+    }
+  },
+  "optionalDependencies": {
+    "json-parse-even-better-errors": ""
+  },
+  "devDependencies": {
+    "walden": ""
+  }
+}

--- a/test/fixtures/edit-package-json/removed/package-lock.json
+++ b/test/fixtures/edit-package-json/removed/package-lock.json
@@ -1,0 +1,137 @@
+{
+  "name": "edit-pj",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "json-parse-even-better-errors": "",
+        "abbrev": "^1.1.1"
+      },
+      "devDependencies": {
+        "walden": ""
+      },
+      "optionalDependencies": {
+        "json-parse-even-better-errors": ""
+      },
+      "peerDependencies": {
+        "once": ""
+      },
+      "peerDependenciesMeta": {
+        "semver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "optional": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/walden": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/walden/-/walden-1.0.3.tgz",
+      "integrity": "sha512-hGGjhbNDqakQh9MzfCWMlS6FCgLE76HBUJUDHFlb0KiKBD3ovte3Zggh318Yf6XArv31GSurC/mplCZKXe8csA==",
+      "dev": true,
+      "dependencies": {
+        "opener": "^1.4.2"
+      },
+      "bin": {
+        "walden": "bin.js"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "peer": true
+    }
+  },
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "optional": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "peer": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
+    },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "optional": true,
+      "peer": true
+    },
+    "walden": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/walden/-/walden-1.0.3.tgz",
+      "integrity": "sha512-hGGjhbNDqakQh9MzfCWMlS6FCgLE76HBUJUDHFlb0KiKBD3ovte3Zggh318Yf6XArv31GSurC/mplCZKXe8csA==",
+      "dev": true,
+      "requires": {
+        "opener": "^1.4.2"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "peer": true
+    }
+  }
+}

--- a/test/fixtures/edit-package-json/removed/package.json
+++ b/test/fixtures/edit-package-json/removed/package.json
@@ -1,0 +1,7 @@
+{
+  "peerDependenciesMeta": {
+    "semver": {
+      "optional": true
+    }
+  }
+}

--- a/test/fixtures/reify-cases/dep-missing-resolved.js
+++ b/test/fixtures/reify-cases/dep-missing-resolved.js
@@ -3535,7 +3535,7 @@ module.exports = t => {
   }),
   "package.json": JSON.stringify({
     "dependencies": {
-      "tap": "^12.7.0"
+      "tap": "12"
     }
   })
 })


### PR DESCRIPTION
This fixes a situation where the root node's package.json is manually
edited, resulting in a package-lock.json which contains extraneous
dependencies.  If we don't mark those as extraneous, we end up reifying
them back to disk, even though they should be pruned.

This performs a fresh calcDepFlags step only in the case where the root
node's package does not match the edges defined in the package-lock.json,
to handle these cases thoroughly and completely, but only in when it's
truly necessary to do the full tree-walk.

cc: @d3lm