### PR TITLE
fix: install workspaces on update.all=true

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -5,6 +5,7 @@ const pacote = require('pacote')
 const cacache = require('cacache')
 const semver = require('semver')
 const pickManifest = require('npm-pick-manifest')
+const mapWorkspaces = require('@npmcli/map-workspaces')
 const promiseCallLimit = require('promise-call-limit')
 const getPeerSet = require('../peer-set.js')
 
@@ -52,6 +53,7 @@ const _nodeFromSpec = Symbol('nodeFromSpec')
 const _fetchManifest = Symbol('fetchManifest')
 const _problemEdges = Symbol('problemEdges')
 const _manifests = Symbol('manifests')
+const _mapWorkspaces = Symbol('mapWorkspaces')
 const _linkFromSpec = Symbol('linkFromSpec')
 const _loadPeerSet = Symbol('loadPeerSet')
 const _updateNames = Symbol.for('updateNames')
@@ -239,6 +241,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
         return root
       })
 
+      .then(tree => this[_mapWorkspaces](tree))
       .then(tree => {
         // null the virtual tree, because we're about to hack away at it
         // if you want another one, load another copy.
@@ -271,6 +274,15 @@ module.exports = cls => class IdealTreeBuilder extends cls {
       global: this[_global],
       legacyPeerDeps: this.legacyPeerDeps,
     })
+  }
+
+  [_mapWorkspaces] (node) {
+    return mapWorkspaces({ cwd: node.path, pkg: node.package })
+      .then(workspaces => {
+        if (workspaces.size)
+          node.workspaces = workspaces
+        return node
+      })
   }
 
   // process the add/rm requests by modifying the root node, and the

--- a/tap-snapshots/test-arborist-build-ideal-tree.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-build-ideal-tree.js-TAP.test.js
@@ -69706,6 +69706,90 @@ Node {
 }
 `
 
+exports[`test/arborist/build-ideal-tree.js TAP workspaces should update a simple example > expect resolving Promise 1`] = `
+Node {
+  "children": Map {
+    "a" => Link {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "a",
+          "spec": "file:{CWD}/test/fixtures/workspaces-simple/a",
+          "type": "workspace",
+        },
+      },
+      "location": "node_modules/a",
+      "name": "a",
+      "resolved": "file:../a",
+      "target": Object {
+        "name": "a",
+        "parent": null,
+      },
+    },
+    "b" => Link {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "b",
+          "spec": "file:{CWD}/test/fixtures/workspaces-simple/b",
+          "type": "workspace",
+        },
+        Edge {
+          "from": "a",
+          "name": "b",
+          "spec": "^1.0.0",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/b",
+      "name": "b",
+      "resolved": "file:../b",
+      "target": Object {
+        "name": "b",
+        "parent": null,
+      },
+    },
+  },
+  "edgesOut": Map {
+    "a" => Edge {
+      "name": "a",
+      "spec": "file:{CWD}/test/fixtures/workspaces-simple/a",
+      "to": "node_modules/a",
+      "type": "workspace",
+    },
+    "b" => Edge {
+      "name": "b",
+      "spec": "file:{CWD}/test/fixtures/workspaces-simple/b",
+      "to": "node_modules/b",
+      "type": "workspace",
+    },
+  },
+  "fsChildren": Set {
+    Node {
+      "edgesOut": Map {
+        "b" => Edge {
+          "name": "b",
+          "spec": "^1.0.0",
+          "to": "node_modules/b",
+          "type": "prod",
+        },
+      },
+      "location": "a",
+      "name": "a",
+      "resolved": null,
+    },
+    Node {
+      "location": "b",
+      "name": "b",
+      "resolved": null,
+    },
+  },
+  "location": "",
+  "name": "workspaces-simple",
+  "resolved": null,
+}
+`
+
 exports[`test/arborist/build-ideal-tree.js TAP workspaces should work with files spec > expect resolving Promise 1`] = `
 Node {
   "children": Map {

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -1262,6 +1262,11 @@ t.test('workspaces', t => {
     return t.resolveMatchSnapshot(printIdeal(path))
   })
 
+  t.test('should update a simple example', t => {
+    const path = resolve(__dirname, '../fixtures/workspaces-simple')
+    return t.resolveMatchSnapshot(printIdeal(path, { update: { all: true }}))
+  })
+
   t.test('should install a simple scoped pkg example', t => {
     const path = resolve(__dirname, '../fixtures/workspaces-scoped-pkg')
     return t.resolveMatchSnapshot(printIdeal(path))


### PR DESCRIPTION
build-ideal-tree is missing info on workspaces when update.all=true
since the mapping of workspaces got moved to load-actual.

This commit fixes it by reinstating the mapWorkspaces logic to
build-ideal-tree.

fix: https://github.com/npm/cli/issues/1763
