### PR TITLE
Log script executions and exits

### DIFF
--- a/lib/arborist/rebuild.js
+++ b/lib/arborist/rebuild.js
@@ -184,14 +184,16 @@ module.exports = cls => class Builder extends cls {
         dev,
         devOptional,
         package: pkg,
+        location,
       } = node
 
       // skip any that we know we'll be deleting
       if (this[_trashList].has(path))
         return
 
-      const timer = `build:run:${event}:${node.location}`
+      const timer = `build:run:${event}:${location}`
       process.emit('time', timer)
+      this.log.info('run', pkg._id, event, location, pkg.scripts[event])
       const p = runScript({
         event,
         path,
@@ -208,11 +210,19 @@ module.exports = cls => class Builder extends cls {
             boolEnv(devOptional && !dev && !optional),
         },
         scriptShell: this[_scriptShell],
+      }).catch(er => {
+        const { code, signal } = er
+        this.log.info('run', pkg._id, event, {code, signal})
+        throw er
+      }).then(({code, signal}) => {
+        this.log.info('run', pkg._id, event, {code, signal})
       })
 
-      return (this[_doHandleOptionalFailure]
-        ? this[_handleOptionalFailure](node, p) : p)
-        .then(() => process.emit('timeEnd', timer))
+      await (this[_doHandleOptionalFailure]
+        ? this[_handleOptionalFailure](node, p)
+        : p)
+
+      process.emit('timeEnd', timer)
     }))
     process.emit('timeEnd', `build:run:${event}`)
   }


### PR DESCRIPTION
There have been a few reports from users who were concerned and
perplexed that their install scripts didn't seem to be run, looking at
the logs npm produces.  In fact, the install scripts WERE running, just
running quietly and successfully.

This logs the commands Arborist runs explicitly, along with exit code
and signal, so that it's more clear what ran when we look at the logs.

Close: #112