### PR TITLE
fix: saveSpec should follow symlinks

### DIFF
--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -6,6 +6,7 @@ const rpj = require('read-package-json-fast')
 const {checkEngine, checkPlatform} = require('npm-install-checks')
 const updateDepSpec = require('../update-dep-spec.js')
 const AuditReport = require('../audit-report.js')
+const realpath = require('../realpath.js')
 
 const {dirname, resolve, relative} = require('path')
 const {depth: dfwalk} = require('treeverse')
@@ -75,6 +76,10 @@ const _omitPeer = Symbol('omitPeer')
 const _global = Symbol.for('global')
 const _scriptShell = Symbol('scriptShell')
 
+const _rpcache = Symbol('realpathCache')
+const _stcache = Symbol('statCache')
+const _replaceSymlinkRealpath = Symbol('replaceSymlinkRealpath')
+
 // defined by Ideal mixin
 const _force = Symbol.for('force')
 const _pruneBundledMetadeps = Symbol.for('pruneBundledMetadeps')
@@ -104,6 +109,12 @@ module.exports = cls => class Reifier extends cls {
     this[_retiredUnchanged] = {}
     this[_sparseTreeDirs] = new Set()
     this[_trashList] = new Set()
+
+    // caches for cached realpath calls
+    const cwd = process.cwd()
+    // assume that the cwd is real enough for our purposes
+    this[_rpcache] = new Map([[ cwd, cwd ]])
+    this[_stcache] = new Map()
   }
 
   // public method
@@ -809,7 +820,7 @@ module.exports = cls => class Reifier extends cls {
 
   // last but not least, we save the ideal tree metadata to the package-lock
   // or shrinkwrap file, and any additions or removals to package.json
-  [_saveIdealTree] (options) {
+  async [_saveIdealTree] (options) {
     // the ideal tree is actualized now, hooray!
     // it still contains all the references to optional nodes that were removed
     // for install failures.  Those still end up in the shrinkwrap, so we
@@ -828,6 +839,8 @@ module.exports = cls => class Reifier extends cls {
         const {name} = req
         const child = root.children.get(name)
         const res = npa(child.resolved)
+
+        await this[_replaceSymlinkRealpath](req)
 
         if (req.registry) {
           const version = child.version
@@ -862,10 +875,27 @@ module.exports = cls => class Reifier extends cls {
       .replace(/\n/g, eol)
 
     const saveOpt = { format: this[_formatPackageLock] }
-    return Promise.all([
+    await Promise.all([
       this[_usePackageLock] && this.idealTree.meta.save(saveOpt),
       writeFile(pj, json),
-    ]).then(() => process.emit('timeEnd', 'reify:save'))
+    ])
+
+    process.emit('timeEnd', 'reify:save')
+  }
+
+  async [_replaceSymlinkRealpath] (req) {
+    if (req.type === 'directory') {
+      // Follow symlinks realpaths and update saveSpec
+      // in order to store that on package.json
+      const child = this.idealTree.children.get(req.name)
+      const real = await (
+        realpath(child.path, this[_rpcache], this[_stcache])
+          .catch(() => null)
+      )
+
+      if (real)
+        req.saveSpec = `file:${relpath(this.path, real)}`
+    }
   }
 
   [_copyIdealToActual] () {

--- a/tap-snapshots/test-arborist-reify.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-reify.js-TAP.test.js
@@ -27030,9 +27030,17 @@ Object {
       "resolved": "https://registry.npmjs.org/c/-/c-1.2.3.tgz",
       "version": "npm:c@1.2.3",
     },
+    "e": Object {
+      "extraneous": true,
+      "version": "1.0.0",
+    },
+    "f": Object {
+      "extraneous": true,
+      "version": "1.0.0",
+    },
   },
   "lockfileVersion": 2,
-  "name": "reify-saving-the-ideal-tree-save-some-stuff",
+  "name": "project",
   "packages": Object {
     "": Object {
       "bundleDependencies": Array [
@@ -27044,10 +27052,17 @@ Object {
         "a": "github:foo/bar#baz",
         "b": "^1.2.3",
         "d": "npm:c@^1.2.3",
+        "e": "file:../linked-pkg",
+        "f": "file:../foo",
       },
       "devDependencies": Object {
         "c": "git+ssh://git@githost.com:a/b/c.git#master",
       },
+    },
+    "../linked-pkg": Object {
+      "extraneous": true,
+      "name": "e",
+      "version": "1.0.0",
     },
     "node_modules/a": Object {
       "extraneous": true,
@@ -27070,6 +27085,16 @@ Object {
       "name": "c",
       "resolved": "https://registry.npmjs.org/c/-/c-1.2.3.tgz",
       "version": "1.2.3",
+    },
+    "node_modules/e": Object {
+      "extraneous": true,
+      "resolved": "file:node_modules/global-prefix/lib/node_modules/e",
+      "version": "1.0.0",
+    },
+    "node_modules/f": Object {
+      "extraneous": true,
+      "resolved": "file:node_modules/foo",
+      "version": "1.0.0",
     },
   },
   "requires": true,


### PR DESCRIPTION
When saving the ideal tree metadata any installed directory provenant
from a `file:` protocol was using the given filepath to store. This
causes all future calls to `loadActual` to return invalid edges for
loaded links since their fetchSpec won't match what was put in the
stored metadata.

This changes fixes it by making sure we properly follow symlink
realpaths prior to saving the tree metadata.
