### PR TITLE
fix: always parse spec from cwd

### DIFF
--- a/lib/add-rm-pkg-deps.js
+++ b/lib/add-rm-pkg-deps.js
@@ -1,7 +1,5 @@
 // add and remove dependency specs to/from pkg manifest
 
-const relpath = require('./relpath.js')
-
 const removeFromOthers = (name, type, pkg) => {
   const others = new Set([
     'dependencies',
@@ -33,14 +31,14 @@ const removeFromOthers = (name, type, pkg) => {
   }
 }
 
-const add = ({pkg, add, saveBundle, saveType, path}) => {
+const add = ({pkg, add, saveBundle, saveType}) => {
   for (const spec of add) {
-    addSingle({pkg, spec, saveBundle, saveType, path})
+    addSingle({pkg, spec, saveBundle, saveType})
   }
   return pkg
 }
 
-const addSingle = ({pkg, spec, saveBundle, saveType, path}) => {
+const addSingle = ({pkg, spec, saveBundle, saveType}) => {
   if (!saveType)
     saveType = getSaveType(pkg, spec)
 
@@ -54,11 +52,7 @@ const addSingle = ({pkg, spec, saveBundle, saveType, path}) => {
 
   pkg[type] = pkg[type] || {}
   if (rawSpec !== '' || pkg[type][name] === undefined) {
-    // file specs are based on arb path, directories specs
-    // are normalized during build-ideal-tree instead
-    pkg[type][name] = specType === 'file'
-      ? `file:${relpath(path, fetchSpec)}`
-      : (rawSpec || '*')
+    pkg[type][name] = rawSpec || '*'
   }
 
   if (saveType === 'peer' || saveType === 'peerOptional') {

--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -82,7 +82,9 @@ const _isVulnerable = Symbol.for('isVulnerable')
 const _usePackageLock = Symbol.for('usePackageLock')
 const _rpcache = Symbol.for('realpathCache')
 const _stcache = Symbol.for('statCache')
+const _updateFilePath = Symbol('updateFilePath')
 const _followSymlinkPath = Symbol('followSymlinkPath')
+const _getRelpathSpec = Symbol('getRelpathSpec')
 const _retrieveSpecName = Symbol('retrieveSpecName')
 
 // used for the ERESOLVE error to show the last peer conflict encountered
@@ -334,15 +336,11 @@ module.exports = cls => class IdealTreeBuilder extends cls {
     // ie, doing `foo@bar` we just return foo
     // but if it's a url or git, we don't know the name until we
     // fetch it and look in its manifest.
-    return Promise.all(add.map(s => {
-      // in global mode, `npm i foo.tgz` needs to be resolved from
-      // the current working dir, NOT /usr/local/lib!
-      const currpath = this[_global] ? process.cwd() : this.path
-      const spec = npa(s, currpath)
-
-      return this[_retrieveSpecName](spec)
-        .then(add => this[_followSymlinkPath](add, currpath))
-    })).then(add => {
+    return Promise.all(add.map(rawSpec =>
+      this[_retrieveSpecName](npa(rawSpec))
+        .then(add => this[_updateFilePath](add))
+        .then(add => this[_followSymlinkPath](add))
+    )).then(add => {
       this[_resolvedAdd] = add
       // now add is a list of spec objects with names.
       // find a home for each of them!
@@ -376,7 +374,14 @@ module.exports = cls => class IdealTreeBuilder extends cls {
     return spec
   }
 
-  async [_followSymlinkPath] (spec, currpath) {
+  async [_updateFilePath] (spec) {
+    if (spec.type === 'file') {
+      spec = this[_getRelpathSpec](spec, spec.fetchSpec)
+    }
+    return spec
+  }
+
+  async [_followSymlinkPath] (spec) {
     if (spec.type === 'directory') {
       const real = await (
         realpath(spec.fetchSpec, this[_rpcache], this[_stcache])
@@ -384,12 +389,17 @@ module.exports = cls => class IdealTreeBuilder extends cls {
           .catch(/* istanbul ignore next */() => null)
       )
 
-      /* istanbul ignore else - same as the ignored catch above */
-      if (real) {
-        const { name } = spec
-        spec = npa(`file:${relpath(this.path, real)}`, this.path)
-        spec.name = name
-      }
+      spec = this[_getRelpathSpec](spec, real)
+    }
+    return spec
+  }
+
+  [_getRelpathSpec] (spec, filepath) {
+    /* istanbul ignore else - should also be covered by realpath failure */
+    if (filepath) {
+      const { name } = spec
+      spec = npa(`file:${relpath(this.path, filepath)}`, this.path)
+      spec.name = name
     }
     return spec
   }

--- a/test/add-rm-pkg-deps.js
+++ b/test/add-rm-pkg-deps.js
@@ -10,7 +10,7 @@ t.test('add', t => {
   const bar = npa('bar')
   const bar1 = npa('bar@1')
   const bar2 = npa('bar@2')
-  const file = npa('file@foo.tgz', '/some/path')
+  const file = npa('file@file:/some/path/foo.tgz', '/')
 
   t.strictSame(add({
     pkg: {
@@ -23,26 +23,10 @@ t.test('add', t => {
       file,
     ],
     saveType: 'prod',
-    path: '/some/other/path',
+    path: '/',
   }), {
-    dependencies: { foo: '1', bar: '1', file: 'file:../../path/foo.tgz' },
-  }, 'move foo to prod, leave bar as-is, file is elsewhere')
-
-  t.strictSame(add({
-    pkg: {
-      dependencies: { bar: '1' },
-      devDependencies: { foo: '2' },
-    },
-    add: [
-      foo1,
-      bar,
-      file,
-    ],
-    saveType: 'prod',
-    path: '/some/path',
-  }), {
-    dependencies: { foo: '1', bar: '1', file: 'file:foo.tgz' },
-  }, 'move foo to prod, leave bar as-is, file is local')
+    dependencies: { foo: '1', bar: '1', file: 'file:/some/path/foo.tgz' },
+  }, 'move foo to prod, leave bar as-is')
 
   t.strictSame(add({
     pkg: {

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -1347,7 +1347,9 @@ t.test('add symlink that points to a symlink', t => {
   })
   return arb.buildIdealTree({
     add: [
-      'file:../global-prefix/lib/node_modules/a'
+      // simulates the string used by `npm link <pkg>` when
+      // installing a package available in the global space
+      `file:${resolve(fixt, 'global-prefix/lib/node_modules/a')}`
     ]
   }).then(tree =>
     t.matchSnapshot(


### PR DESCRIPTION
Always parse specs from added deps using the cwd as reference. Also
refactored lib/add-rm-pkg-deps.js to only used rawSpec now that
build-ideal-tree does the heavy lifting of parsing relative paths.