### PR TITLE
Use @npmcli/metavuln-calculator for faster audits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@npmcli/installed-package-contents": "^1.0.5",
         "@npmcli/map-workspaces": "0.0.0-pre.1",
+        "@npmcli/metavuln-calculator": "^1.0.0",
         "@npmcli/name-from-folder": "^1.0.1",
         "@npmcli/run-script": "^1.3.1",
         "bin-links": "^2.1.2",
@@ -218,6 +219,16 @@
         "glob": "^7.1.6",
         "minimatch": "^3.0.4",
         "read-package-json-fast": "^1.1.3"
+      }
+    },
+    "node_modules/@npmcli/metavuln-calculator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-1.0.0.tgz",
+      "integrity": "sha512-BzFNWElLl99WqqkxBWHPBSZbKGbH4qJa0vICgRff+PWl0nIT0nDn0wJV3EBCDDWnrVqomH29ZENZc1SkRQ0C7A==",
+      "dependencies": {
+        "cacache": "^15.0.5",
+        "pacote": "^11.1.11",
+        "semver": "^7.3.2"
       }
     },
     "node_modules/@npmcli/move-file": {
@@ -5924,6 +5935,16 @@
         "glob": "^7.1.6",
         "minimatch": "^3.0.4",
         "read-package-json-fast": "^1.1.3"
+      }
+    },
+    "@npmcli/metavuln-calculator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-1.0.0.tgz",
+      "integrity": "sha512-BzFNWElLl99WqqkxBWHPBSZbKGbH4qJa0vICgRff+PWl0nIT0nDn0wJV3EBCDDWnrVqomH29ZENZc1SkRQ0C7A==",
+      "requires": {
+        "cacache": "^15.0.5",
+        "pacote": "^11.1.11",
+        "semver": "^7.3.2"
       }
     },
     "@npmcli/move-file": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "semver": "^7.1.2",
     "treeverse": "^1.0.4",
     "walk-up-path": "^1.0.0",
-    "json-parse-even-better-errors": "^2.3.1"
+    "json-parse-even-better-errors": "^2.3.1",
+    "@npmcli/metavuln-calculator": "^1.0.0"
   },
   "devDependencies": {
     "minify-registry-metadata": "^2.1.0",

--- a/scripts/ideal.js
+++ b/scripts/ideal.js
@@ -1,6 +1,29 @@
 const Arborist = require('../')
 const path = process.argv[2] || '.'
 
+const ms = require('ms')
+const timers = {}
+process.on('time', name => {
+  if (timers[name]) {
+    throw new Error('conflicting timer! ' + name)
+  }
+  timers[name] = process.hrtime()
+})
+process.on('timeEnd', name => {
+  if (!timers[name]) {
+    throw new Error('timer not started! ' + name)
+  }
+  const res = process.hrtime(timers[name])
+  delete timers[name]
+  console.error(name, res[0] * 1e3 + res[1] / 1e6)
+})
+process.on('exit', () => {
+  for (const name of Object.keys(timers)) {
+    console.error('Dangling timer: ', name)
+    process.exitCode = 1
+  }
+})
+
 const {format} = require('tcompare')
 const print = tree => console.log(format(printTree(tree), { style: 'js' }))
 const { inspect, format: fmt } = require('util')

--- a/scripts/reify.js
+++ b/scripts/reify.js
@@ -17,6 +17,12 @@ process.on('timeEnd', name => {
   delete timers[name]
   console.error(name, res[0] * 1e3 + res[1] / 1e6)
 })
+process.on('exit', () => {
+  for (const name of Object.keys(timers)) {
+    console.error('Dangling timer: ', name)
+    process.exitCode = 1
+  }
+})
 
 const {format} = require('tcompare')
 const print = tree => console.log(format(printTree(tree), { style: 'js' }))

--- a/tap-snapshots/test-audit-report.js-TAP.test.js
+++ b/tap-snapshots/test-audit-report.js-TAP.test.js
@@ -14,11 +14,13 @@ exports[`test/audit-report.js TAP a dep vuln that also has its own advisory agai
       "severity": "low",
       "via": [
         {
-          "id": 1179,
-          "url": "https://npmjs.com/advisories/1179",
+          "source": 1179,
+          "name": "minimist",
+          "dependency": "minimist",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1179",
           "severity": "low",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3"
+          "range": "<0.2.1 || >=1.0.0 <1.2.3"
         }
       ],
       "effects": [
@@ -35,11 +37,13 @@ exports[`test/audit-report.js TAP a dep vuln that also has its own advisory agai
       "severity": "high",
       "via": [
         {
-          "id": 42069,
-          "url": "https://npmjs.com/advisories/42069",
+          "source": 42069,
+          "name": "mkdirp",
+          "dependency": "mkdirp",
           "title": "File System Pollution",
+          "url": "https://npmjs.com/advisories/42069",
           "severity": "high",
-          "vulnerable_versions": "<0.5.5"
+          "range": "<0.5.5"
         },
         "minimist"
       ],
@@ -81,46 +85,49 @@ exports[`test/audit-report.js TAP all severity levels > json version 1`] = `
       "severity": "critical",
       "via": [
         {
-          "id": 755,
-          "url": "https://npmjs.com/advisories/755",
+          "source": 1164,
+          "name": "handlebars",
+          "dependency": "handlebars",
           "title": "Prototype Pollution",
-          "severity": "critical",
-          "vulnerable_versions": "<=4.0.13 || >=4.1.0 <4.1.2"
-        },
-        {
-          "id": 1164,
           "url": "https://npmjs.com/advisories/1164",
-          "title": "Prototype Pollution",
           "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.3.0"
+          "range": "<3.0.8 || >=4.0.0 <4.3.0"
         },
         {
-          "id": 1300,
-          "url": "https://npmjs.com/advisories/1300",
+          "source": 1300,
+          "name": "handlebars",
+          "dependency": "handlebars",
           "title": "Denial of Service",
+          "url": "https://npmjs.com/advisories/1300",
           "severity": "moderate",
-          "vulnerable_versions": ">=4.0.0 <4.4.5"
+          "range": ">=4.0.0 <4.4.5"
         },
         {
-          "id": 1316,
+          "source": 1316,
+          "name": "handlebars",
+          "dependency": "handlebars",
+          "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1316",
-          "title": "Arbitrary Code Execution",
           "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.2"
+          "range": "<3.0.8 || >=4.0.0 <4.5.2"
         },
         {
-          "id": 1324,
+          "source": 1324,
+          "name": "handlebars",
+          "dependency": "handlebars",
+          "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1324",
-          "title": "Arbitrary Code Execution",
           "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3"
+          "range": "<3.0.8 || >=4.0.0 <4.5.3"
         },
         {
-          "id": 1325,
-          "url": "https://npmjs.com/advisories/1325",
+          "source": 755,
+          "name": "handlebars",
+          "dependency": "handlebars",
           "title": "Prototype Pollution",
-          "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3"
+          "url": "https://npmjs.com/advisories/755",
+          "severity": "critical",
+          "range": "<=4.0.13 || >=4.1.0 <4.1.2"
         },
         "optimist"
       ],
@@ -131,23 +138,55 @@ exports[`test/audit-report.js TAP all severity levels > json version 1`] = `
       ],
       "fixAvailable": true
     },
+    "kind-of": {
+      "name": "kind-of",
+      "severity": "low",
+      "via": [
+        {
+          "source": 1490,
+          "name": "kind-of",
+          "dependency": "kind-of",
+          "title": "Validation Bypass",
+          "url": "https://npmjs.com/advisories/1490",
+          "severity": "low",
+          "range": ">=6.0.0 <6.0.3"
+        }
+      ],
+      "effects": [],
+      "range": "6.0.0 - 6.0.2",
+      "nodes": [
+        "node_modules/nyc/node_modules/base/node_modules/kind-of",
+        "node_modules/nyc/node_modules/define-property/node_modules/kind-of",
+        "node_modules/nyc/node_modules/extglob/node_modules/kind-of",
+        "node_modules/nyc/node_modules/micromatch/node_modules/kind-of",
+        "node_modules/nyc/node_modules/nanomatch/node_modules/kind-of",
+        "node_modules/nyc/node_modules/snapdragon-node/node_modules/kind-of",
+        "node_modules/nyc/node_modules/test-exclude/node_modules/kind-of",
+        "node_modules/nyc/node_modules/use/node_modules/kind-of"
+      ],
+      "fixAvailable": true
+    },
     "lodash": {
       "name": "lodash",
       "severity": "high",
       "via": [
         {
-          "id": 782,
-          "url": "https://npmjs.com/advisories/782",
+          "source": 1065,
+          "name": "lodash",
+          "dependency": "lodash",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1065",
           "severity": "high",
-          "vulnerable_versions": "<4.17.11"
+          "range": "<4.17.12"
         },
         {
-          "id": 1065,
-          "url": "https://npmjs.com/advisories/1065",
+          "source": 782,
+          "name": "lodash",
+          "dependency": "lodash",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/782",
           "severity": "high",
-          "vulnerable_versions": "<4.17.12"
+          "range": "<4.17.11"
         }
       ],
       "effects": [],
@@ -157,57 +196,18 @@ exports[`test/audit-report.js TAP all severity levels > json version 1`] = `
       ],
       "fixAvailable": true
     },
-    "set-value": {
-      "name": "set-value",
-      "severity": "high",
-      "via": [
-        {
-          "id": 1012,
-          "url": "https://npmjs.com/advisories/1012",
-          "title": "Prototype Pollution",
-          "severity": "high",
-          "vulnerable_versions": "<2.0.1 || >=3.0.0 <3.0.1"
-        }
-      ],
-      "effects": [
-        "union-value"
-      ],
-      "range": "<=2.0.0 || 3.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/set-value",
-        "node_modules/nyc/node_modules/union-value/node_modules/set-value"
-      ],
-      "fixAvailable": true
-    },
-    "mixin-deep": {
-      "name": "mixin-deep",
-      "severity": "high",
-      "via": [
-        {
-          "id": 1013,
-          "url": "https://npmjs.com/advisories/1013",
-          "title": "Prototype Pollution",
-          "severity": "high",
-          "vulnerable_versions": "<1.3.2 || >=2.0.0 <2.0.1"
-        }
-      ],
-      "effects": [],
-      "range": "<=1.3.1 || 2.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/mixin-deep"
-      ],
-      "fixAvailable": true
-    },
     "mem": {
       "name": "mem",
       "severity": "low",
       "via": [
         {
-          "id": 1084,
-          "url": "https://npmjs.com/advisories/1084",
+          "source": 1084,
+          "name": "mem",
+          "dependency": "mem",
           "title": "Denial of Service",
+          "url": "https://npmjs.com/advisories/1084",
           "severity": "low",
-          "vulnerable_versions": "<4.0.0"
+          "range": "<4.0.0"
         }
       ],
       "effects": [
@@ -223,49 +223,18 @@ exports[`test/audit-report.js TAP all severity levels > json version 1`] = `
         "isSemVerMajor": true
       }
     },
-    "subtext": {
-      "name": "subtext",
-      "severity": "high",
-      "via": [
-        {
-          "id": 1168,
-          "url": "https://npmjs.com/advisories/1168",
-          "title": "Denial of Service",
-          "severity": "high",
-          "vulnerable_versions": ">=0.0.0"
-        },
-        {
-          "id": 1478,
-          "url": "https://npmjs.com/advisories/1478",
-          "title": "Denial of Service",
-          "severity": "high",
-          "vulnerable_versions": ">=4.1.0"
-        },
-        {
-          "id": 1479,
-          "url": "https://npmjs.com/advisories/1479",
-          "title": "Prototype Pollution",
-          "severity": "high",
-          "vulnerable_versions": ">=0.0.0"
-        }
-      ],
-      "effects": [],
-      "range": "*",
-      "nodes": [
-        "node_modules/subtext"
-      ],
-      "fixAvailable": false
-    },
     "minimist": {
       "name": "minimist",
       "severity": "low",
       "via": [
         {
-          "id": 1179,
-          "url": "https://npmjs.com/advisories/1179",
+          "source": 1179,
+          "name": "minimist",
+          "dependency": "minimist",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1179",
           "severity": "low",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3"
+          "range": "<0.2.1 || >=1.0.0 <1.2.3"
         }
       ],
       "effects": [
@@ -283,101 +252,26 @@ exports[`test/audit-report.js TAP all severity levels > json version 1`] = `
         "isSemVerMajor": true
       }
     },
-    "kind-of": {
-      "name": "kind-of",
-      "severity": "low",
-      "via": [
-        {
-          "id": 1490,
-          "url": "https://npmjs.com/advisories/1490",
-          "title": "Validation Bypass",
-          "severity": "low",
-          "vulnerable_versions": ">=6.0.0 <6.0.3"
-        }
-      ],
-      "effects": [],
-      "range": "6.0.0 - 6.0.2",
-      "nodes": [
-        "node_modules/nyc/node_modules/base/node_modules/kind-of",
-        "node_modules/nyc/node_modules/define-property/node_modules/kind-of",
-        "node_modules/nyc/node_modules/extglob/node_modules/kind-of",
-        "node_modules/nyc/node_modules/micromatch/node_modules/kind-of",
-        "node_modules/nyc/node_modules/nanomatch/node_modules/kind-of",
-        "node_modules/nyc/node_modules/snapdragon-node/node_modules/kind-of",
-        "node_modules/nyc/node_modules/test-exclude/node_modules/kind-of",
-        "node_modules/nyc/node_modules/use/node_modules/kind-of"
-      ],
-      "fixAvailable": true
-    },
-    "sapper": {
-      "name": "sapper",
-      "severity": "critical",
-      "via": [
-        {
-          "id": 1494,
-          "url": "https://npmjs.com/advisories/1494",
-          "title": "Path Traversal",
-          "severity": "critical",
-          "vulnerable_versions": "<0.27.11"
-        }
-      ],
-      "effects": [],
-      "range": "<0.27.11",
-      "nodes": [
-        "node_modules/sapper"
-      ],
-      "fixAvailable": true
-    },
-    "node-weakauras-parser": {
-      "name": "node-weakauras-parser",
-      "severity": "moderate",
-      "via": [
-        {
-          "id": 1504,
-          "url": "https://npmjs.com/advisories/1504",
-          "title": "Buffer Overflow",
-          "severity": "moderate",
-          "vulnerable_versions": ">=1.0.4 <1.0.5 || >=2.0.0 <2.0.2 || >=3.0.0 <3.0.1"
-        }
-      ],
-      "effects": [],
-      "range": "1.0.4 || 2.0.1 || 3.0.0",
-      "nodes": [
-        "node_modules/node-weakauras-parser"
-      ],
-      "fixAvailable": true
-    },
-    "union-value": {
-      "name": "union-value",
+    "mixin-deep": {
+      "name": "mixin-deep",
       "severity": "high",
       "via": [
-        "set-value"
+        {
+          "source": 1013,
+          "name": "mixin-deep",
+          "dependency": "mixin-deep",
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1013",
+          "severity": "high",
+          "range": "<1.3.2 || >=2.0.0 <2.0.1"
+        }
       ],
       "effects": [],
-      "range": "<=1.0.0 || 2.0.0",
+      "range": "<=1.3.1 || 2.0.0",
       "nodes": [
-        "node_modules/nyc/node_modules/union-value"
+        "node_modules/nyc/node_modules/mixin-deep"
       ],
       "fixAvailable": true
-    },
-    "os-locale": {
-      "name": "os-locale",
-      "severity": "low",
-      "via": [
-        "mem"
-      ],
-      "effects": [
-        "yargs"
-      ],
-      "range": "2.0.0 - 3.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/os-locale"
-      ],
-      "fixAvailable": {
-        "name": "nyc",
-        "version": "15.0.0",
-        "isSemVerMajor": true
-      }
     },
     "mkdirp": {
       "name": "mkdirp",
@@ -392,6 +286,45 @@ exports[`test/audit-report.js TAP all severity levels > json version 1`] = `
       "nodes": [
         "node_modules/mkdirp",
         "node_modules/nyc/node_modules/mkdirp"
+      ],
+      "fixAvailable": {
+        "name": "nyc",
+        "version": "15.0.0",
+        "isSemVerMajor": true
+      }
+    },
+    "node-weakauras-parser": {
+      "name": "node-weakauras-parser",
+      "severity": "moderate",
+      "via": [
+        {
+          "source": 1504,
+          "name": "node-weakauras-parser",
+          "dependency": "node-weakauras-parser",
+          "title": "Buffer Overflow",
+          "url": "https://npmjs.com/advisories/1504",
+          "severity": "moderate",
+          "range": ">=1.0.4 <1.0.5 || >=2.0.0 <2.0.2 || >=3.0.0 <3.0.1"
+        }
+      ],
+      "effects": [],
+      "range": "1.0.4 || 2.0.1 || 3.0.0",
+      "nodes": [
+        "node_modules/node-weakauras-parser"
+      ],
+      "fixAvailable": true
+    },
+    "nyc": {
+      "name": "nyc",
+      "severity": "low",
+      "via": [
+        "mkdirp",
+        "yargs"
+      ],
+      "effects": [],
+      "range": "6.2.0-alpha - 13.1.0",
+      "nodes": [
+        "node_modules/nyc"
       ],
       "fixAvailable": {
         "name": "nyc",
@@ -414,6 +347,113 @@ exports[`test/audit-report.js TAP all severity levels > json version 1`] = `
       ],
       "fixAvailable": true
     },
+    "os-locale": {
+      "name": "os-locale",
+      "severity": "low",
+      "via": [
+        "mem"
+      ],
+      "effects": [
+        "yargs"
+      ],
+      "range": "2.0.0 - 3.0.0",
+      "nodes": [
+        "node_modules/nyc/node_modules/os-locale"
+      ],
+      "fixAvailable": {
+        "name": "nyc",
+        "version": "15.0.0",
+        "isSemVerMajor": true
+      }
+    },
+    "sapper": {
+      "name": "sapper",
+      "severity": "critical",
+      "via": [
+        {
+          "source": 1494,
+          "name": "sapper",
+          "dependency": "sapper",
+          "title": "Path Traversal",
+          "url": "https://npmjs.com/advisories/1494",
+          "severity": "critical",
+          "range": "<0.27.11"
+        }
+      ],
+      "effects": [],
+      "range": "<0.27.11",
+      "nodes": [
+        "node_modules/sapper"
+      ],
+      "fixAvailable": true
+    },
+    "set-value": {
+      "name": "set-value",
+      "severity": "high",
+      "via": [
+        {
+          "source": 1012,
+          "name": "set-value",
+          "dependency": "set-value",
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1012",
+          "severity": "high",
+          "range": "<2.0.1 || >=3.0.0 <3.0.1"
+        }
+      ],
+      "effects": [
+        "union-value"
+      ],
+      "range": "<=2.0.0 || 3.0.0",
+      "nodes": [
+        "node_modules/nyc/node_modules/set-value",
+        "node_modules/nyc/node_modules/union-value/node_modules/set-value"
+      ],
+      "fixAvailable": true
+    },
+    "subtext": {
+      "name": "subtext",
+      "severity": "high",
+      "via": [
+        {
+          "source": 1168,
+          "name": "subtext",
+          "dependency": "subtext",
+          "title": "Denial of Service",
+          "url": "https://npmjs.com/advisories/1168",
+          "severity": "high",
+          "range": ">=0.0.0"
+        },
+        {
+          "source": 1478,
+          "name": "subtext",
+          "dependency": "subtext",
+          "title": "Denial of Service",
+          "url": "https://npmjs.com/advisories/1478",
+          "severity": "high",
+          "range": ">=4.1.0"
+        }
+      ],
+      "effects": [],
+      "range": "*",
+      "nodes": [
+        "node_modules/subtext"
+      ],
+      "fixAvailable": false
+    },
+    "union-value": {
+      "name": "union-value",
+      "severity": "high",
+      "via": [
+        "set-value"
+      ],
+      "effects": [],
+      "range": "<=1.0.0 || 2.0.0",
+      "nodes": [
+        "node_modules/nyc/node_modules/union-value"
+      ],
+      "fixAvailable": true
+    },
     "yargs": {
       "name": "yargs",
       "severity": "low",
@@ -426,24 +466,6 @@ exports[`test/audit-report.js TAP all severity levels > json version 1`] = `
       "range": "8.0.1 - 11.1.0 || 12.0.0-candidate.0 - 12.0.1",
       "nodes": [
         "node_modules/nyc/node_modules/yargs"
-      ],
-      "fixAvailable": {
-        "name": "nyc",
-        "version": "15.0.0",
-        "isSemVerMajor": true
-      }
-    },
-    "nyc": {
-      "name": "nyc",
-      "severity": "low",
-      "via": [
-        "mkdirp",
-        "yargs"
-      ],
-      "effects": [],
-      "range": "6.2.0-alpha - 13.1.0",
-      "nodes": [
-        "node_modules/nyc"
       ],
       "fixAvailable": {
         "name": "nyc",
@@ -482,46 +504,49 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp > json version 1
       "severity": "critical",
       "via": [
         {
-          "id": 755,
-          "url": "https://npmjs.com/advisories/755",
+          "source": 1164,
+          "name": "handlebars",
+          "dependency": "handlebars",
           "title": "Prototype Pollution",
-          "severity": "critical",
-          "vulnerable_versions": "<=4.0.13 || >=4.1.0 <4.1.2"
-        },
-        {
-          "id": 1164,
           "url": "https://npmjs.com/advisories/1164",
-          "title": "Prototype Pollution",
           "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.3.0"
+          "range": "<3.0.8 || >=4.0.0 <4.3.0"
         },
         {
-          "id": 1300,
-          "url": "https://npmjs.com/advisories/1300",
+          "source": 1300,
+          "name": "handlebars",
+          "dependency": "handlebars",
           "title": "Denial of Service",
+          "url": "https://npmjs.com/advisories/1300",
           "severity": "moderate",
-          "vulnerable_versions": ">=4.0.0 <4.4.5"
+          "range": ">=4.0.0 <4.4.5"
         },
         {
-          "id": 1316,
+          "source": 1316,
+          "name": "handlebars",
+          "dependency": "handlebars",
+          "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1316",
-          "title": "Arbitrary Code Execution",
           "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.2"
+          "range": "<3.0.8 || >=4.0.0 <4.5.2"
         },
         {
-          "id": 1324,
+          "source": 1324,
+          "name": "handlebars",
+          "dependency": "handlebars",
+          "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1324",
-          "title": "Arbitrary Code Execution",
           "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3"
+          "range": "<3.0.8 || >=4.0.0 <4.5.3"
         },
         {
-          "id": 1325,
-          "url": "https://npmjs.com/advisories/1325",
+          "source": 755,
+          "name": "handlebars",
+          "dependency": "handlebars",
           "title": "Prototype Pollution",
-          "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3"
+          "url": "https://npmjs.com/advisories/755",
+          "severity": "critical",
+          "range": "<=4.0.13 || >=4.1.0 <4.1.2"
         },
         "optimist"
       ],
@@ -532,23 +557,55 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp > json version 1
       ],
       "fixAvailable": true
     },
+    "kind-of": {
+      "name": "kind-of",
+      "severity": "low",
+      "via": [
+        {
+          "source": 1490,
+          "name": "kind-of",
+          "dependency": "kind-of",
+          "title": "Validation Bypass",
+          "url": "https://npmjs.com/advisories/1490",
+          "severity": "low",
+          "range": ">=6.0.0 <6.0.3"
+        }
+      ],
+      "effects": [],
+      "range": "6.0.0 - 6.0.2",
+      "nodes": [
+        "node_modules/nyc/node_modules/base/node_modules/kind-of",
+        "node_modules/nyc/node_modules/define-property/node_modules/kind-of",
+        "node_modules/nyc/node_modules/extglob/node_modules/kind-of",
+        "node_modules/nyc/node_modules/micromatch/node_modules/kind-of",
+        "node_modules/nyc/node_modules/nanomatch/node_modules/kind-of",
+        "node_modules/nyc/node_modules/snapdragon-node/node_modules/kind-of",
+        "node_modules/nyc/node_modules/test-exclude/node_modules/kind-of",
+        "node_modules/nyc/node_modules/use/node_modules/kind-of"
+      ],
+      "fixAvailable": true
+    },
     "lodash": {
       "name": "lodash",
       "severity": "high",
       "via": [
         {
-          "id": 782,
-          "url": "https://npmjs.com/advisories/782",
+          "source": 1065,
+          "name": "lodash",
+          "dependency": "lodash",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1065",
           "severity": "high",
-          "vulnerable_versions": "<4.17.11"
+          "range": "<4.17.12"
         },
         {
-          "id": 1065,
-          "url": "https://npmjs.com/advisories/1065",
+          "source": 782,
+          "name": "lodash",
+          "dependency": "lodash",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/782",
           "severity": "high",
-          "vulnerable_versions": "<4.17.12"
+          "range": "<4.17.11"
         }
       ],
       "effects": [],
@@ -558,57 +615,18 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp > json version 1
       ],
       "fixAvailable": true
     },
-    "set-value": {
-      "name": "set-value",
-      "severity": "high",
-      "via": [
-        {
-          "id": 1012,
-          "url": "https://npmjs.com/advisories/1012",
-          "title": "Prototype Pollution",
-          "severity": "high",
-          "vulnerable_versions": "<2.0.1 || >=3.0.0 <3.0.1"
-        }
-      ],
-      "effects": [
-        "union-value"
-      ],
-      "range": "<=2.0.0 || 3.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/set-value",
-        "node_modules/nyc/node_modules/union-value/node_modules/set-value"
-      ],
-      "fixAvailable": true
-    },
-    "mixin-deep": {
-      "name": "mixin-deep",
-      "severity": "high",
-      "via": [
-        {
-          "id": 1013,
-          "url": "https://npmjs.com/advisories/1013",
-          "title": "Prototype Pollution",
-          "severity": "high",
-          "vulnerable_versions": "<1.3.2 || >=2.0.0 <2.0.1"
-        }
-      ],
-      "effects": [],
-      "range": "<=1.3.1 || 2.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/mixin-deep"
-      ],
-      "fixAvailable": true
-    },
     "mem": {
       "name": "mem",
       "severity": "low",
       "via": [
         {
-          "id": 1084,
-          "url": "https://npmjs.com/advisories/1084",
+          "source": 1084,
+          "name": "mem",
+          "dependency": "mem",
           "title": "Denial of Service",
+          "url": "https://npmjs.com/advisories/1084",
           "severity": "low",
-          "vulnerable_versions": "<4.0.0"
+          "range": "<4.0.0"
         }
       ],
       "effects": [
@@ -629,11 +647,13 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp > json version 1
       "severity": "low",
       "via": [
         {
-          "id": 1179,
-          "url": "https://npmjs.com/advisories/1179",
+          "source": 1179,
+          "name": "minimist",
+          "dependency": "minimist",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1179",
           "severity": "low",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3"
+          "range": "<0.2.1 || >=1.0.0 <1.2.3"
         }
       ],
       "effects": [
@@ -651,63 +671,26 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp > json version 1
         "isSemVerMajor": true
       }
     },
-    "kind-of": {
-      "name": "kind-of",
-      "severity": "low",
+    "mixin-deep": {
+      "name": "mixin-deep",
+      "severity": "high",
       "via": [
         {
-          "id": 1490,
-          "url": "https://npmjs.com/advisories/1490",
-          "title": "Validation Bypass",
-          "severity": "low",
-          "vulnerable_versions": ">=6.0.0 <6.0.3"
+          "source": 1013,
+          "name": "mixin-deep",
+          "dependency": "mixin-deep",
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1013",
+          "severity": "high",
+          "range": "<1.3.2 || >=2.0.0 <2.0.1"
         }
       ],
       "effects": [],
-      "range": "6.0.0 - 6.0.2",
+      "range": "<=1.3.1 || 2.0.0",
       "nodes": [
-        "node_modules/nyc/node_modules/base/node_modules/kind-of",
-        "node_modules/nyc/node_modules/define-property/node_modules/kind-of",
-        "node_modules/nyc/node_modules/extglob/node_modules/kind-of",
-        "node_modules/nyc/node_modules/micromatch/node_modules/kind-of",
-        "node_modules/nyc/node_modules/nanomatch/node_modules/kind-of",
-        "node_modules/nyc/node_modules/snapdragon-node/node_modules/kind-of",
-        "node_modules/nyc/node_modules/test-exclude/node_modules/kind-of",
-        "node_modules/nyc/node_modules/use/node_modules/kind-of"
+        "node_modules/nyc/node_modules/mixin-deep"
       ],
       "fixAvailable": true
-    },
-    "union-value": {
-      "name": "union-value",
-      "severity": "high",
-      "via": [
-        "set-value"
-      ],
-      "effects": [],
-      "range": "<=1.0.0 || 2.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/union-value"
-      ],
-      "fixAvailable": true
-    },
-    "os-locale": {
-      "name": "os-locale",
-      "severity": "low",
-      "via": [
-        "mem"
-      ],
-      "effects": [
-        "yargs"
-      ],
-      "range": "2.0.0 - 3.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/os-locale"
-      ],
-      "fixAvailable": {
-        "name": "nyc",
-        "version": "15.0.0",
-        "isSemVerMajor": true
-      }
     },
     "mkdirp": {
       "name": "mkdirp",
@@ -722,6 +705,24 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp > json version 1
       "nodes": [
         "node_modules/mkdirp",
         "node_modules/nyc/node_modules/mkdirp"
+      ],
+      "fixAvailable": {
+        "name": "nyc",
+        "version": "15.0.0",
+        "isSemVerMajor": true
+      }
+    },
+    "nyc": {
+      "name": "nyc",
+      "severity": "low",
+      "via": [
+        "mkdirp",
+        "yargs"
+      ],
+      "effects": [],
+      "range": "6.2.0-alpha - 13.1.0",
+      "nodes": [
+        "node_modules/nyc"
       ],
       "fixAvailable": {
         "name": "nyc",
@@ -744,6 +745,62 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp > json version 1
       ],
       "fixAvailable": true
     },
+    "os-locale": {
+      "name": "os-locale",
+      "severity": "low",
+      "via": [
+        "mem"
+      ],
+      "effects": [
+        "yargs"
+      ],
+      "range": "2.0.0 - 3.0.0",
+      "nodes": [
+        "node_modules/nyc/node_modules/os-locale"
+      ],
+      "fixAvailable": {
+        "name": "nyc",
+        "version": "15.0.0",
+        "isSemVerMajor": true
+      }
+    },
+    "set-value": {
+      "name": "set-value",
+      "severity": "high",
+      "via": [
+        {
+          "source": 1012,
+          "name": "set-value",
+          "dependency": "set-value",
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1012",
+          "severity": "high",
+          "range": "<2.0.1 || >=3.0.0 <3.0.1"
+        }
+      ],
+      "effects": [
+        "union-value"
+      ],
+      "range": "<=2.0.0 || 3.0.0",
+      "nodes": [
+        "node_modules/nyc/node_modules/set-value",
+        "node_modules/nyc/node_modules/union-value/node_modules/set-value"
+      ],
+      "fixAvailable": true
+    },
+    "union-value": {
+      "name": "union-value",
+      "severity": "high",
+      "via": [
+        "set-value"
+      ],
+      "effects": [],
+      "range": "<=1.0.0 || 2.0.0",
+      "nodes": [
+        "node_modules/nyc/node_modules/union-value"
+      ],
+      "fixAvailable": true
+    },
     "yargs": {
       "name": "yargs",
       "severity": "low",
@@ -756,24 +813,6 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp > json version 1
       "range": "8.0.1 - 11.1.0 || 12.0.0-candidate.0 - 12.0.1",
       "nodes": [
         "node_modules/nyc/node_modules/yargs"
-      ],
-      "fixAvailable": {
-        "name": "nyc",
-        "version": "15.0.0",
-        "isSemVerMajor": true
-      }
-    },
-    "nyc": {
-      "name": "nyc",
-      "severity": "low",
-      "via": [
-        "mkdirp",
-        "yargs"
-      ],
-      "effects": [],
-      "range": "6.2.0-alpha - 13.1.0",
-      "nodes": [
-        "node_modules/nyc"
       ],
       "fixAvailable": {
         "name": "nyc",
@@ -812,46 +851,49 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with before: opt
       "severity": "critical",
       "via": [
         {
-          "id": 755,
-          "url": "https://npmjs.com/advisories/755",
+          "source": 1164,
+          "name": "handlebars",
+          "dependency": "handlebars",
           "title": "Prototype Pollution",
-          "severity": "critical",
-          "vulnerable_versions": "<=4.0.13 || >=4.1.0 <4.1.2"
-        },
-        {
-          "id": 1164,
           "url": "https://npmjs.com/advisories/1164",
-          "title": "Prototype Pollution",
           "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.3.0"
+          "range": "<3.0.8 || >=4.0.0 <4.3.0"
         },
         {
-          "id": 1300,
-          "url": "https://npmjs.com/advisories/1300",
+          "source": 1300,
+          "name": "handlebars",
+          "dependency": "handlebars",
           "title": "Denial of Service",
+          "url": "https://npmjs.com/advisories/1300",
           "severity": "moderate",
-          "vulnerable_versions": ">=4.0.0 <4.4.5"
+          "range": ">=4.0.0 <4.4.5"
         },
         {
-          "id": 1316,
+          "source": 1316,
+          "name": "handlebars",
+          "dependency": "handlebars",
+          "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1316",
-          "title": "Arbitrary Code Execution",
           "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.2"
+          "range": "<3.0.8 || >=4.0.0 <4.5.2"
         },
         {
-          "id": 1324,
+          "source": 1324,
+          "name": "handlebars",
+          "dependency": "handlebars",
+          "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1324",
-          "title": "Arbitrary Code Execution",
           "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3"
+          "range": "<3.0.8 || >=4.0.0 <4.5.3"
         },
         {
-          "id": 1325,
-          "url": "https://npmjs.com/advisories/1325",
+          "source": 755,
+          "name": "handlebars",
+          "dependency": "handlebars",
           "title": "Prototype Pollution",
-          "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3"
+          "url": "https://npmjs.com/advisories/755",
+          "severity": "critical",
+          "range": "<=4.0.13 || >=4.1.0 <4.1.2"
         },
         "optimist"
       ],
@@ -862,23 +904,55 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with before: opt
       ],
       "fixAvailable": true
     },
+    "kind-of": {
+      "name": "kind-of",
+      "severity": "low",
+      "via": [
+        {
+          "source": 1490,
+          "name": "kind-of",
+          "dependency": "kind-of",
+          "title": "Validation Bypass",
+          "url": "https://npmjs.com/advisories/1490",
+          "severity": "low",
+          "range": ">=6.0.0 <6.0.3"
+        }
+      ],
+      "effects": [],
+      "range": "6.0.0 - 6.0.2",
+      "nodes": [
+        "node_modules/nyc/node_modules/base/node_modules/kind-of",
+        "node_modules/nyc/node_modules/define-property/node_modules/kind-of",
+        "node_modules/nyc/node_modules/extglob/node_modules/kind-of",
+        "node_modules/nyc/node_modules/micromatch/node_modules/kind-of",
+        "node_modules/nyc/node_modules/nanomatch/node_modules/kind-of",
+        "node_modules/nyc/node_modules/snapdragon-node/node_modules/kind-of",
+        "node_modules/nyc/node_modules/test-exclude/node_modules/kind-of",
+        "node_modules/nyc/node_modules/use/node_modules/kind-of"
+      ],
+      "fixAvailable": true
+    },
     "lodash": {
       "name": "lodash",
       "severity": "high",
       "via": [
         {
-          "id": 782,
-          "url": "https://npmjs.com/advisories/782",
+          "source": 1065,
+          "name": "lodash",
+          "dependency": "lodash",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1065",
           "severity": "high",
-          "vulnerable_versions": "<4.17.11"
+          "range": "<4.17.12"
         },
         {
-          "id": 1065,
-          "url": "https://npmjs.com/advisories/1065",
+          "source": 782,
+          "name": "lodash",
+          "dependency": "lodash",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/782",
           "severity": "high",
-          "vulnerable_versions": "<4.17.12"
+          "range": "<4.17.11"
         }
       ],
       "effects": [],
@@ -888,57 +962,18 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with before: opt
       ],
       "fixAvailable": true
     },
-    "set-value": {
-      "name": "set-value",
-      "severity": "high",
-      "via": [
-        {
-          "id": 1012,
-          "url": "https://npmjs.com/advisories/1012",
-          "title": "Prototype Pollution",
-          "severity": "high",
-          "vulnerable_versions": "<2.0.1 || >=3.0.0 <3.0.1"
-        }
-      ],
-      "effects": [
-        "union-value"
-      ],
-      "range": "<=2.0.0 || 3.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/set-value",
-        "node_modules/nyc/node_modules/union-value/node_modules/set-value"
-      ],
-      "fixAvailable": true
-    },
-    "mixin-deep": {
-      "name": "mixin-deep",
-      "severity": "high",
-      "via": [
-        {
-          "id": 1013,
-          "url": "https://npmjs.com/advisories/1013",
-          "title": "Prototype Pollution",
-          "severity": "high",
-          "vulnerable_versions": "<1.3.2 || >=2.0.0 <2.0.1"
-        }
-      ],
-      "effects": [],
-      "range": "<=1.3.1 || 2.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/mixin-deep"
-      ],
-      "fixAvailable": true
-    },
     "mem": {
       "name": "mem",
       "severity": "low",
       "via": [
         {
-          "id": 1084,
-          "url": "https://npmjs.com/advisories/1084",
+          "source": 1084,
+          "name": "mem",
+          "dependency": "mem",
           "title": "Denial of Service",
+          "url": "https://npmjs.com/advisories/1084",
           "severity": "low",
-          "vulnerable_versions": "<4.0.0"
+          "range": "<4.0.0"
         }
       ],
       "effects": [
@@ -959,11 +994,13 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with before: opt
       "severity": "low",
       "via": [
         {
-          "id": 1179,
-          "url": "https://npmjs.com/advisories/1179",
+          "source": 1179,
+          "name": "minimist",
+          "dependency": "minimist",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1179",
           "severity": "low",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3"
+          "range": "<0.2.1 || >=1.0.0 <1.2.3"
         }
       ],
       "effects": [
@@ -981,63 +1018,26 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with before: opt
         "isSemVerMajor": true
       }
     },
-    "kind-of": {
-      "name": "kind-of",
-      "severity": "low",
+    "mixin-deep": {
+      "name": "mixin-deep",
+      "severity": "high",
       "via": [
         {
-          "id": 1490,
-          "url": "https://npmjs.com/advisories/1490",
-          "title": "Validation Bypass",
-          "severity": "low",
-          "vulnerable_versions": ">=6.0.0 <6.0.3"
+          "source": 1013,
+          "name": "mixin-deep",
+          "dependency": "mixin-deep",
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1013",
+          "severity": "high",
+          "range": "<1.3.2 || >=2.0.0 <2.0.1"
         }
       ],
       "effects": [],
-      "range": "6.0.0 - 6.0.2",
+      "range": "<=1.3.1 || 2.0.0",
       "nodes": [
-        "node_modules/nyc/node_modules/base/node_modules/kind-of",
-        "node_modules/nyc/node_modules/define-property/node_modules/kind-of",
-        "node_modules/nyc/node_modules/extglob/node_modules/kind-of",
-        "node_modules/nyc/node_modules/micromatch/node_modules/kind-of",
-        "node_modules/nyc/node_modules/nanomatch/node_modules/kind-of",
-        "node_modules/nyc/node_modules/snapdragon-node/node_modules/kind-of",
-        "node_modules/nyc/node_modules/test-exclude/node_modules/kind-of",
-        "node_modules/nyc/node_modules/use/node_modules/kind-of"
+        "node_modules/nyc/node_modules/mixin-deep"
       ],
       "fixAvailable": true
-    },
-    "union-value": {
-      "name": "union-value",
-      "severity": "high",
-      "via": [
-        "set-value"
-      ],
-      "effects": [],
-      "range": "<=1.0.0 || 2.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/union-value"
-      ],
-      "fixAvailable": true
-    },
-    "os-locale": {
-      "name": "os-locale",
-      "severity": "low",
-      "via": [
-        "mem"
-      ],
-      "effects": [
-        "yargs"
-      ],
-      "range": "2.0.0 - 3.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/os-locale"
-      ],
-      "fixAvailable": {
-        "name": "nyc",
-        "version": "15.0.0",
-        "isSemVerMajor": true
-      }
     },
     "mkdirp": {
       "name": "mkdirp",
@@ -1052,6 +1052,24 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with before: opt
       "nodes": [
         "node_modules/mkdirp",
         "node_modules/nyc/node_modules/mkdirp"
+      ],
+      "fixAvailable": {
+        "name": "nyc",
+        "version": "15.0.0",
+        "isSemVerMajor": true
+      }
+    },
+    "nyc": {
+      "name": "nyc",
+      "severity": "low",
+      "via": [
+        "mkdirp",
+        "yargs"
+      ],
+      "effects": [],
+      "range": "6.2.0-alpha - 13.1.0",
+      "nodes": [
+        "node_modules/nyc"
       ],
       "fixAvailable": {
         "name": "nyc",
@@ -1074,6 +1092,62 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with before: opt
       ],
       "fixAvailable": true
     },
+    "os-locale": {
+      "name": "os-locale",
+      "severity": "low",
+      "via": [
+        "mem"
+      ],
+      "effects": [
+        "yargs"
+      ],
+      "range": "2.0.0 - 3.0.0",
+      "nodes": [
+        "node_modules/nyc/node_modules/os-locale"
+      ],
+      "fixAvailable": {
+        "name": "nyc",
+        "version": "15.0.0",
+        "isSemVerMajor": true
+      }
+    },
+    "set-value": {
+      "name": "set-value",
+      "severity": "high",
+      "via": [
+        {
+          "source": 1012,
+          "name": "set-value",
+          "dependency": "set-value",
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1012",
+          "severity": "high",
+          "range": "<2.0.1 || >=3.0.0 <3.0.1"
+        }
+      ],
+      "effects": [
+        "union-value"
+      ],
+      "range": "<=2.0.0 || 3.0.0",
+      "nodes": [
+        "node_modules/nyc/node_modules/set-value",
+        "node_modules/nyc/node_modules/union-value/node_modules/set-value"
+      ],
+      "fixAvailable": true
+    },
+    "union-value": {
+      "name": "union-value",
+      "severity": "high",
+      "via": [
+        "set-value"
+      ],
+      "effects": [],
+      "range": "<=1.0.0 || 2.0.0",
+      "nodes": [
+        "node_modules/nyc/node_modules/union-value"
+      ],
+      "fixAvailable": true
+    },
     "yargs": {
       "name": "yargs",
       "severity": "low",
@@ -1086,24 +1160,6 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with before: opt
       "range": "8.0.1 - 11.1.0 || 12.0.0-candidate.0 - 12.0.1",
       "nodes": [
         "node_modules/nyc/node_modules/yargs"
-      ],
-      "fixAvailable": {
-        "name": "nyc",
-        "version": "15.0.0",
-        "isSemVerMajor": true
-      }
-    },
-    "nyc": {
-      "name": "nyc",
-      "severity": "low",
-      "via": [
-        "mkdirp",
-        "yargs"
-      ],
-      "effects": [],
-      "range": "6.2.0-alpha - 13.1.0",
-      "nodes": [
-        "node_modules/nyc"
       ],
       "fixAvailable": {
         "name": "nyc",
@@ -1142,46 +1198,49 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with newer endpo
       "severity": "critical",
       "via": [
         {
-          "id": 755,
-          "url": "https://npmjs.com/advisories/755",
+          "source": 1164,
+          "name": "handlebars",
+          "dependency": "handlebars",
           "title": "Prototype Pollution",
-          "severity": "critical",
-          "vulnerable_versions": "<=4.0.13 || >=4.1.0 <4.1.2"
-        },
-        {
-          "id": 1164,
           "url": "https://npmjs.com/advisories/1164",
-          "title": "Prototype Pollution",
           "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.3.0"
+          "range": "<3.0.8 || >=4.0.0 <4.3.0"
         },
         {
-          "id": 1300,
-          "url": "https://npmjs.com/advisories/1300",
+          "source": 1300,
+          "name": "handlebars",
+          "dependency": "handlebars",
           "title": "Denial of Service",
+          "url": "https://npmjs.com/advisories/1300",
           "severity": "moderate",
-          "vulnerable_versions": ">=4.0.0 <4.4.5"
+          "range": ">=4.0.0 <4.4.5"
         },
         {
-          "id": 1316,
+          "source": 1316,
+          "name": "handlebars",
+          "dependency": "handlebars",
+          "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1316",
-          "title": "Arbitrary Code Execution",
           "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.2"
+          "range": "<3.0.8 || >=4.0.0 <4.5.2"
         },
         {
-          "id": 1324,
+          "source": 1324,
+          "name": "handlebars",
+          "dependency": "handlebars",
+          "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1324",
-          "title": "Arbitrary Code Execution",
           "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3"
+          "range": "<3.0.8 || >=4.0.0 <4.5.3"
         },
         {
-          "id": 1325,
-          "url": "https://npmjs.com/advisories/1325",
+          "source": 755,
+          "name": "handlebars",
+          "dependency": "handlebars",
           "title": "Prototype Pollution",
-          "severity": "high",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3"
+          "url": "https://npmjs.com/advisories/755",
+          "severity": "critical",
+          "range": "<=4.0.13 || >=4.1.0 <4.1.2"
         },
         "optimist"
       ],
@@ -1192,23 +1251,55 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with newer endpo
       ],
       "fixAvailable": true
     },
+    "kind-of": {
+      "name": "kind-of",
+      "severity": "low",
+      "via": [
+        {
+          "source": 1490,
+          "name": "kind-of",
+          "dependency": "kind-of",
+          "title": "Validation Bypass",
+          "url": "https://npmjs.com/advisories/1490",
+          "severity": "low",
+          "range": ">=6.0.0 <6.0.3"
+        }
+      ],
+      "effects": [],
+      "range": "6.0.0 - 6.0.2",
+      "nodes": [
+        "node_modules/nyc/node_modules/base/node_modules/kind-of",
+        "node_modules/nyc/node_modules/define-property/node_modules/kind-of",
+        "node_modules/nyc/node_modules/extglob/node_modules/kind-of",
+        "node_modules/nyc/node_modules/micromatch/node_modules/kind-of",
+        "node_modules/nyc/node_modules/nanomatch/node_modules/kind-of",
+        "node_modules/nyc/node_modules/snapdragon-node/node_modules/kind-of",
+        "node_modules/nyc/node_modules/test-exclude/node_modules/kind-of",
+        "node_modules/nyc/node_modules/use/node_modules/kind-of"
+      ],
+      "fixAvailable": true
+    },
     "lodash": {
       "name": "lodash",
       "severity": "high",
       "via": [
         {
-          "id": 782,
-          "url": "https://npmjs.com/advisories/782",
+          "source": 1065,
+          "name": "lodash",
+          "dependency": "lodash",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1065",
           "severity": "high",
-          "vulnerable_versions": "<4.17.11"
+          "range": "<4.17.12"
         },
         {
-          "id": 1065,
-          "url": "https://npmjs.com/advisories/1065",
+          "source": 782,
+          "name": "lodash",
+          "dependency": "lodash",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/782",
           "severity": "high",
-          "vulnerable_versions": "<4.17.12"
+          "range": "<4.17.11"
         }
       ],
       "effects": [],
@@ -1218,57 +1309,18 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with newer endpo
       ],
       "fixAvailable": true
     },
-    "set-value": {
-      "name": "set-value",
-      "severity": "high",
-      "via": [
-        {
-          "id": 1012,
-          "url": "https://npmjs.com/advisories/1012",
-          "title": "Prototype Pollution",
-          "severity": "high",
-          "vulnerable_versions": "<2.0.1 || >=3.0.0 <3.0.1"
-        }
-      ],
-      "effects": [
-        "union-value"
-      ],
-      "range": "<=2.0.0 || 3.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/set-value",
-        "node_modules/nyc/node_modules/union-value/node_modules/set-value"
-      ],
-      "fixAvailable": true
-    },
-    "mixin-deep": {
-      "name": "mixin-deep",
-      "severity": "high",
-      "via": [
-        {
-          "id": 1013,
-          "url": "https://npmjs.com/advisories/1013",
-          "title": "Prototype Pollution",
-          "severity": "high",
-          "vulnerable_versions": "<1.3.2 || >=2.0.0 <2.0.1"
-        }
-      ],
-      "effects": [],
-      "range": "<=1.3.1 || 2.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/mixin-deep"
-      ],
-      "fixAvailable": true
-    },
     "mem": {
       "name": "mem",
       "severity": "low",
       "via": [
         {
-          "id": 1084,
-          "url": "https://npmjs.com/advisories/1084",
+          "source": 1084,
+          "name": "mem",
+          "dependency": "mem",
           "title": "Denial of Service",
+          "url": "https://npmjs.com/advisories/1084",
           "severity": "low",
-          "vulnerable_versions": "<4.0.0"
+          "range": "<4.0.0"
         }
       ],
       "effects": [
@@ -1289,11 +1341,13 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with newer endpo
       "severity": "low",
       "via": [
         {
-          "id": 1179,
-          "url": "https://npmjs.com/advisories/1179",
+          "source": 1179,
+          "name": "minimist",
+          "dependency": "minimist",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1179",
           "severity": "low",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3"
+          "range": "<0.2.1 || >=1.0.0 <1.2.3"
         }
       ],
       "effects": [
@@ -1311,63 +1365,26 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with newer endpo
         "isSemVerMajor": true
       }
     },
-    "kind-of": {
-      "name": "kind-of",
-      "severity": "low",
+    "mixin-deep": {
+      "name": "mixin-deep",
+      "severity": "high",
       "via": [
         {
-          "id": 1490,
-          "url": "https://npmjs.com/advisories/1490",
-          "title": "Validation Bypass",
-          "severity": "low",
-          "vulnerable_versions": ">=6.0.0 <6.0.3"
+          "source": 1013,
+          "name": "mixin-deep",
+          "dependency": "mixin-deep",
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1013",
+          "severity": "high",
+          "range": "<1.3.2 || >=2.0.0 <2.0.1"
         }
       ],
       "effects": [],
-      "range": "6.0.0 - 6.0.2",
+      "range": "<=1.3.1 || 2.0.0",
       "nodes": [
-        "node_modules/nyc/node_modules/base/node_modules/kind-of",
-        "node_modules/nyc/node_modules/define-property/node_modules/kind-of",
-        "node_modules/nyc/node_modules/extglob/node_modules/kind-of",
-        "node_modules/nyc/node_modules/micromatch/node_modules/kind-of",
-        "node_modules/nyc/node_modules/nanomatch/node_modules/kind-of",
-        "node_modules/nyc/node_modules/snapdragon-node/node_modules/kind-of",
-        "node_modules/nyc/node_modules/test-exclude/node_modules/kind-of",
-        "node_modules/nyc/node_modules/use/node_modules/kind-of"
+        "node_modules/nyc/node_modules/mixin-deep"
       ],
       "fixAvailable": true
-    },
-    "union-value": {
-      "name": "union-value",
-      "severity": "high",
-      "via": [
-        "set-value"
-      ],
-      "effects": [],
-      "range": "<=1.0.0 || 2.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/union-value"
-      ],
-      "fixAvailable": true
-    },
-    "os-locale": {
-      "name": "os-locale",
-      "severity": "low",
-      "via": [
-        "mem"
-      ],
-      "effects": [
-        "yargs"
-      ],
-      "range": "2.0.0 - 3.0.0",
-      "nodes": [
-        "node_modules/nyc/node_modules/os-locale"
-      ],
-      "fixAvailable": {
-        "name": "nyc",
-        "version": "15.0.0",
-        "isSemVerMajor": true
-      }
     },
     "mkdirp": {
       "name": "mkdirp",
@@ -1382,6 +1399,24 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with newer endpo
       "nodes": [
         "node_modules/mkdirp",
         "node_modules/nyc/node_modules/mkdirp"
+      ],
+      "fixAvailable": {
+        "name": "nyc",
+        "version": "15.0.0",
+        "isSemVerMajor": true
+      }
+    },
+    "nyc": {
+      "name": "nyc",
+      "severity": "low",
+      "via": [
+        "mkdirp",
+        "yargs"
+      ],
+      "effects": [],
+      "range": "6.2.0-alpha - 13.1.0",
+      "nodes": [
+        "node_modules/nyc"
       ],
       "fixAvailable": {
         "name": "nyc",
@@ -1404,6 +1439,62 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with newer endpo
       ],
       "fixAvailable": true
     },
+    "os-locale": {
+      "name": "os-locale",
+      "severity": "low",
+      "via": [
+        "mem"
+      ],
+      "effects": [
+        "yargs"
+      ],
+      "range": "2.0.0 - 3.0.0",
+      "nodes": [
+        "node_modules/nyc/node_modules/os-locale"
+      ],
+      "fixAvailable": {
+        "name": "nyc",
+        "version": "15.0.0",
+        "isSemVerMajor": true
+      }
+    },
+    "set-value": {
+      "name": "set-value",
+      "severity": "high",
+      "via": [
+        {
+          "source": 1012,
+          "name": "set-value",
+          "dependency": "set-value",
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1012",
+          "severity": "high",
+          "range": "<2.0.1 || >=3.0.0 <3.0.1"
+        }
+      ],
+      "effects": [
+        "union-value"
+      ],
+      "range": "<=2.0.0 || 3.0.0",
+      "nodes": [
+        "node_modules/nyc/node_modules/set-value",
+        "node_modules/nyc/node_modules/union-value/node_modules/set-value"
+      ],
+      "fixAvailable": true
+    },
+    "union-value": {
+      "name": "union-value",
+      "severity": "high",
+      "via": [
+        "set-value"
+      ],
+      "effects": [],
+      "range": "<=1.0.0 || 2.0.0",
+      "nodes": [
+        "node_modules/nyc/node_modules/union-value"
+      ],
+      "fixAvailable": true
+    },
     "yargs": {
       "name": "yargs",
       "severity": "low",
@@ -1416,24 +1507,6 @@ exports[`test/audit-report.js TAP audit outdated nyc and mkdirp with newer endpo
       "range": "8.0.1 - 11.1.0 || 12.0.0-candidate.0 - 12.0.1",
       "nodes": [
         "node_modules/nyc/node_modules/yargs"
-      ],
-      "fixAvailable": {
-        "name": "nyc",
-        "version": "15.0.0",
-        "isSemVerMajor": true
-      }
-    },
-    "nyc": {
-      "name": "nyc",
-      "severity": "low",
-      "via": [
-        "mkdirp",
-        "yargs"
-      ],
-      "effects": [],
-      "range": "6.2.0-alpha - 13.1.0",
-      "nodes": [
-        "node_modules/nyc"
       ],
       "fixAvailable": {
         "name": "nyc",
@@ -1477,18 +1550,16 @@ Object {
     },
     "vulnerabilities": Object {
       "critical": 0,
-      "high": 5,
+      "high": 2,
       "info": 0,
-      "low": 3,
-      "moderate": 2,
-      "total": 10,
+      "low": 2,
+      "moderate": 1,
+      "total": 5,
     },
   },
   "vulnerabilities": Object {
     "acorn": Object {
-      "effects": Array [
-        "espree",
-      ],
+      "effects": Array [],
       "fixAvailable": true,
       "name": "acorn",
       "nodes": Array [
@@ -1498,51 +1569,17 @@ Object {
       "severity": "moderate",
       "via": Array [
         Object {
-          "id": 1488,
+          "dependency": "acorn",
+          "id": undefined,
+          "name": "acorn",
+          "range": ">=5.5.0 <5.7.4 || >=6.0.0 <6.4.1 || >=7.0.0 <7.1.1",
           "severity": "moderate",
+          "source": 1488,
           "title": "Regular Expression Denial of Service",
           "url": "https://npmjs.com/advisories/1488",
-          "vulnerable_versions": ">=5.5.0 <5.7.4 || >=6.0.0 <6.4.1 || >=7.0.0 <7.1.1",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
-      ],
-    },
-    "eslint_d": Object {
-      "effects": Array [],
-      "fixAvailable": true,
-      "name": "eslint_d",
-      "nodes": Array [
-        "node_modules/eslint_d",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "eslint",
-      ],
-    },
-    "espree": Object {
-      "effects": Array [],
-      "fixAvailable": true,
-      "name": "espree",
-      "nodes": Array [
-        "node_modules/espree",
-      ],
-      "range": "",
-      "severity": "moderate",
-      "via": Array [
-        "acorn",
-      ],
-    },
-    "inquirer": Object {
-      "effects": Array [],
-      "fixAvailable": true,
-      "name": "inquirer",
-      "nodes": Array [
-        "node_modules/inquirer",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "lodash",
       ],
     },
     "js-yaml": Object {
@@ -1556,26 +1593,33 @@ Object {
       "severity": "high",
       "via": Array [
         Object {
-          "id": 788,
+          "dependency": "js-yaml",
+          "id": undefined,
+          "name": "js-yaml",
+          "range": "<3.13.0",
           "severity": "moderate",
+          "source": 788,
           "title": "Denial of Service",
           "url": "https://npmjs.com/advisories/788",
-          "vulnerable_versions": "<3.13.0",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 813,
+          "dependency": "js-yaml",
+          "id": undefined,
+          "name": "js-yaml",
+          "range": "<3.13.1",
           "severity": "high",
+          "source": 813,
           "title": "Code Injection",
           "url": "https://npmjs.com/advisories/813",
-          "vulnerable_versions": "<3.13.1",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
     "lodash": Object {
-      "effects": Array [
-        "inquirer",
-        "table",
-      ],
+      "effects": Array [],
       "fixAvailable": true,
       "name": "lodash",
       "nodes": Array [
@@ -1585,25 +1629,40 @@ Object {
       "severity": "high",
       "via": Array [
         Object {
-          "id": 782,
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.12",
           "severity": "high",
-          "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/782",
-          "vulnerable_versions": "<4.17.11",
-        },
-        Object {
-          "id": 1065,
-          "severity": "high",
+          "source": 1065,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1065",
-          "vulnerable_versions": "<4.17.12",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1523,
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.19",
           "severity": "low",
+          "source": 1523,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1523",
-          "vulnerable_versions": "<4.17.19",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
+        },
+        Object {
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.11",
+          "severity": "high",
+          "source": 782,
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/782",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -1620,18 +1679,21 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1179,
+          "dependency": "minimist",
+          "id": undefined,
+          "name": "minimist",
+          "range": "<0.2.1 || >=1.0.0 <1.2.3",
           "severity": "low",
+          "source": 1179,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1179",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
     "mkdirp": Object {
-      "effects": Array [
-        "write",
-      ],
+      "effects": Array [],
       "fixAvailable": true,
       "name": "mkdirp",
       "nodes": Array [
@@ -1643,32 +1705,6 @@ Object {
         "minimist",
       ],
     },
-    "table": Object {
-      "effects": Array [],
-      "fixAvailable": true,
-      "name": "table",
-      "nodes": Array [
-        "node_modules/table",
-      ],
-      "range": ">=1.0.0",
-      "severity": "high",
-      "via": Array [
-        "lodash",
-      ],
-    },
-    "write": Object {
-      "effects": Array [],
-      "fixAvailable": true,
-      "name": "write",
-      "nodes": Array [
-        "node_modules/write",
-      ],
-      "range": "",
-      "severity": "low",
-      "via": Array [
-        "mkdirp",
-      ],
-    },
   },
 }
 `
@@ -1677,27 +1713,6 @@ exports[`test/audit-report.js TAP metavuln where a dep is not on the registry at
 {
   "auditReportVersion": 2,
   "vulnerabilities": {
-    "minimist": {
-      "name": "minimist",
-      "severity": "low",
-      "via": [
-        {
-          "id": 1179,
-          "url": "https://npmjs.com/advisories/1179",
-          "title": "Prototype Pollution",
-          "severity": "low",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3"
-        }
-      ],
-      "effects": [
-        "@isaacs/this-does-not-exist-at-all"
-      ],
-      "range": "<0.2.1 || >=1.0.0 <1.2.3",
-      "nodes": [
-        "node_modules/minimist"
-      ],
-      "fixAvailable": false
-    },
     "@isaacs/this-does-not-exist-at-all": {
       "name": "@isaacs/this-does-not-exist-at-all",
       "severity": "low",
@@ -1708,6 +1723,29 @@ exports[`test/audit-report.js TAP metavuln where a dep is not on the registry at
       "range": "",
       "nodes": [
         "node_modules/@isaacs/this-does-not-exist-at-all"
+      ],
+      "fixAvailable": false
+    },
+    "minimist": {
+      "name": "minimist",
+      "severity": "low",
+      "via": [
+        {
+          "source": 1179,
+          "name": "minimist",
+          "dependency": "minimist",
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1179",
+          "severity": "low",
+          "range": "<0.2.1 || >=1.0.0 <1.2.3"
+        }
+      ],
+      "effects": [
+        "@isaacs/this-does-not-exist-at-all"
+      ],
+      "range": "<0.2.1 || >=1.0.0 <1.2.3",
+      "nodes": [
+        "node_modules/minimist"
       ],
       "fixAvailable": false
     }
@@ -1737,27 +1775,6 @@ exports[`test/audit-report.js TAP metavuln where dep is not a registry dep > jso
 {
   "auditReportVersion": 2,
   "vulnerabilities": {
-    "minimist": {
-      "name": "minimist",
-      "severity": "low",
-      "via": [
-        {
-          "id": 1179,
-          "url": "https://npmjs.com/advisories/1179",
-          "title": "Prototype Pollution",
-          "severity": "low",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3"
-        }
-      ],
-      "effects": [
-        "@isaacs/minimist-git-dep"
-      ],
-      "range": "<0.2.1 || >=1.0.0 <1.2.3",
-      "nodes": [
-        "node_modules/minimist"
-      ],
-      "fixAvailable": false
-    },
     "@isaacs/minimist-git-dep": {
       "name": "@isaacs/minimist-git-dep",
       "severity": "low",
@@ -1768,6 +1785,29 @@ exports[`test/audit-report.js TAP metavuln where dep is not a registry dep > jso
       "range": "*",
       "nodes": [
         "node_modules/@isaacs/minimist-git-dep"
+      ],
+      "fixAvailable": false
+    },
+    "minimist": {
+      "name": "minimist",
+      "severity": "low",
+      "via": [
+        {
+          "source": 1179,
+          "name": "minimist",
+          "dependency": "minimist",
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1179",
+          "severity": "low",
+          "range": "<0.2.1 || >=1.0.0 <1.2.3"
+        }
+      ],
+      "effects": [
+        "@isaacs/minimist-git-dep"
+      ],
+      "range": "<0.2.1 || >=1.0.0 <1.2.3",
+      "nodes": [
+        "node_modules/minimist"
       ],
       "fixAvailable": false
     }
@@ -1782,12 +1822,12 @@ exports[`test/audit-report.js TAP metavuln where dep is not a registry dep > jso
       "total": 2
     },
     "dependencies": {
-      "prod": 0,
+      "prod": 1,
       "dev": 2,
       "optional": 0,
       "peer": 0,
       "peerOptional": 0,
-      "total": 2
+      "total": 3
     }
   }
 }
@@ -1807,191 +1847,14 @@ Object {
     },
     "vulnerabilities": Object {
       "critical": 1,
-      "high": 18,
+      "high": 4,
       "info": 0,
-      "low": 8,
+      "low": 10,
       "moderate": 0,
-      "total": 27,
+      "total": 15,
     },
   },
   "vulnerabilities": Object {
-    "babel-core": Object {
-      "effects": Array [
-        "babel-register",
-        "import-jsx",
-      ],
-      "fixAvailable": true,
-      "name": "babel-core",
-      "nodes": Array [
-        "node_modules/babel-core",
-      ],
-      "range": "<=7.0.0-beta.3",
-      "severity": "high",
-      "via": Array [
-        "babel-generator",
-        "babel-helpers",
-        "babel-register",
-        "babel-template",
-        "babel-traverse",
-        "babel-types",
-        "lodash",
-      ],
-    },
-    "babel-generator": Object {
-      "effects": Array [
-        "babel-core",
-        "istanbul-lib-instrument",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-generator",
-      "nodes": Array [
-        "node_modules/babel-generator",
-        "node_modules/nyc/node_modules/babel-generator",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-types",
-        "lodash",
-      ],
-    },
-    "babel-helper-builder-react-jsx": Object {
-      "effects": Array [
-        "babel-plugin-transform-react-jsx",
-      ],
-      "fixAvailable": true,
-      "name": "babel-helper-builder-react-jsx",
-      "nodes": Array [
-        "node_modules/babel-helper-builder-react-jsx",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-types",
-      ],
-    },
-    "babel-helpers": Object {
-      "effects": Array [
-        "babel-core",
-      ],
-      "fixAvailable": true,
-      "name": "babel-helpers",
-      "nodes": Array [
-        "node_modules/babel-helpers",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-template",
-      ],
-    },
-    "babel-plugin-transform-react-jsx": Object {
-      "effects": Array [
-        "import-jsx",
-      ],
-      "fixAvailable": true,
-      "name": "babel-plugin-transform-react-jsx",
-      "nodes": Array [
-        "node_modules/babel-plugin-transform-react-jsx",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-helper-builder-react-jsx",
-      ],
-    },
-    "babel-register": Object {
-      "effects": Array [
-        "babel-core",
-      ],
-      "fixAvailable": true,
-      "name": "babel-register",
-      "nodes": Array [
-        "node_modules/babel-register",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-core",
-        "lodash",
-      ],
-    },
-    "babel-template": Object {
-      "effects": Array [
-        "babel-core",
-        "istanbul-lib-instrument",
-        "babel-helpers",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-template",
-      "nodes": Array [
-        "node_modules/babel-template",
-        "node_modules/nyc/node_modules/babel-template",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-traverse",
-        "babel-types",
-        "lodash",
-      ],
-    },
-    "babel-traverse": Object {
-      "effects": Array [
-        "babel-core",
-        "istanbul-lib-instrument",
-        "babel-template",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-traverse",
-      "nodes": Array [
-        "node_modules/babel-traverse",
-        "node_modules/nyc/node_modules/babel-traverse",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-types",
-        "lodash",
-      ],
-    },
-    "babel-types": Object {
-      "effects": Array [
-        "babel-core",
-        "istanbul-lib-instrument",
-        "babel-template",
-        "babel-generator",
-        "babel-helper-builder-react-jsx",
-        "babel-traverse",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-types",
-      "nodes": Array [
-        "node_modules/babel-types",
-        "node_modules/nyc/node_modules/babel-types",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "lodash",
-      ],
-    },
     "handlebars": Object {
       "effects": Array [],
       "fixAvailable": Object {
@@ -2007,88 +1870,67 @@ Object {
       "range": "<=4.7.3",
       "severity": "critical",
       "via": Array [
-        "optimist",
         Object {
-          "id": 755,
-          "severity": "critical",
-          "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/755",
-          "vulnerable_versions": "<=4.0.13 || >=4.1.0 <4.1.2",
-        },
-        Object {
-          "id": 1164,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.3.0",
           "severity": "high",
+          "source": 1164,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1164",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.3.0",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1300,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": ">=4.0.0 <4.4.5",
           "severity": "moderate",
+          "source": 1300,
           "title": "Denial of Service",
           "url": "https://npmjs.com/advisories/1300",
-          "vulnerable_versions": ">=4.0.0 <4.4.5",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1316,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.5.2",
           "severity": "high",
+          "source": 1316,
           "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1316",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.2",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1324,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.5.3",
           "severity": "high",
+          "source": 1324,
           "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1324",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1325,
-          "severity": "high",
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<=4.0.13 || >=4.1.0 <4.1.2",
+          "severity": "critical",
+          "source": 755,
           "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/1325",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3",
+          "url": "https://npmjs.com/advisories/755",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
-      ],
-    },
-    "import-jsx": Object {
-      "effects": Array [
-        "tap",
-        "treport",
-      ],
-      "fixAvailable": true,
-      "name": "import-jsx",
-      "nodes": Array [
-        "node_modules/import-jsx",
-      ],
-      "range": "1.2.0 - 2.0.0",
-      "severity": "high",
-      "via": Array [
-        "babel-core",
-        "babel-plugin-transform-react-jsx",
-      ],
-    },
-    "istanbul-lib-instrument": Object {
-      "effects": Array [
-        "nyc",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "istanbul-lib-instrument",
-      "nodes": Array [
-        "node_modules/nyc/node_modules/istanbul-lib-instrument",
-      ],
-      "range": "1.1.0-alpha.0 - 1.10.2",
-      "severity": "high",
-      "via": Array [
-        "babel-generator",
-        "babel-template",
-        "babel-traverse",
-        "babel-types",
+        "optimist",
       ],
     },
     "kind-of": Object {
@@ -2109,56 +1951,64 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1490,
+          "dependency": "kind-of",
+          "id": undefined,
+          "name": "kind-of",
+          "range": ">=6.0.0 <6.0.3",
           "severity": "low",
+          "source": 1490,
           "title": "Validation Bypass",
           "url": "https://npmjs.com/advisories/1490",
-          "vulnerable_versions": ">=6.0.0 <6.0.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
     "lodash": Object {
-      "effects": Array [
-        "babel-generator",
-        "babel-template",
-        "babel-traverse",
-        "babel-types",
-        "babel-core",
-        "babel-register",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
+      "effects": Array [],
+      "fixAvailable": true,
       "name": "lodash",
       "nodes": Array [
         "node_modules/nyc/node_modules/lodash",
-        "node_modules/lodash",
       ],
       "range": "*",
       "severity": "high",
       "via": Array [
         Object {
-          "id": 782,
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.12",
           "severity": "high",
-          "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/782",
-          "vulnerable_versions": "<4.17.11",
-        },
-        Object {
-          "id": 1065,
-          "severity": "high",
+          "source": 1065,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1065",
-          "vulnerable_versions": "<4.17.12",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1523,
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.19",
           "severity": "low",
+          "source": 1523,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1523",
-          "vulnerable_versions": "<4.17.19",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
+        },
+        Object {
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.11",
+          "severity": "high",
+          "source": 782,
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/782",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -2169,7 +2019,7 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "mem",
       "nodes": Array [
@@ -2179,11 +2029,16 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1084,
+          "dependency": "mem",
+          "id": undefined,
+          "name": "mem",
+          "range": "<4.0.0",
           "severity": "low",
+          "source": 1084,
           "title": "Denial of Service",
           "url": "https://npmjs.com/advisories/1084",
-          "vulnerable_versions": "<4.0.0",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -2206,11 +2061,16 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1179,
+          "dependency": "minimist",
+          "id": undefined,
+          "name": "minimist",
+          "range": "<0.2.1 || >=1.0.0 <1.2.3",
           "severity": "low",
+          "source": 1179,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1179",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -2225,11 +2085,16 @@ Object {
       "severity": "high",
       "via": Array [
         Object {
-          "id": 1013,
+          "dependency": "mixin-deep",
+          "id": undefined,
+          "name": "mixin-deep",
+          "range": "<1.3.2 || >=2.0.0 <2.0.1",
           "severity": "high",
+          "source": 1013,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1013",
-          "vulnerable_versions": "<1.3.2 || >=2.0.0 <2.0.1",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -2259,7 +2124,7 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "nyc",
       "nodes": Array [
@@ -2267,9 +2132,8 @@ Object {
         "node_modules/tap/node_modules/nyc",
       ],
       "range": ">=6.0.0",
-      "severity": "high",
+      "severity": "low",
       "via": Array [
-        "istanbul-lib-instrument",
         "mkdirp",
         "yargs",
         "yargs-parser",
@@ -2302,7 +2166,7 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "os-locale",
       "nodes": Array [
@@ -2328,11 +2192,16 @@ Object {
       "severity": "high",
       "via": Array [
         Object {
-          "id": 1012,
+          "dependency": "set-value",
+          "id": undefined,
+          "name": "set-value",
+          "range": "<2.0.1 || >=3.0.0 <3.0.1",
           "severity": "high",
+          "source": 1012,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1012",
-          "vulnerable_versions": "<2.0.1 || >=3.0.0 <3.0.1",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -2341,33 +2210,16 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "tap",
-        "version": "5.7.1",
+        "version": "6.2.0",
       },
       "name": "tap",
       "nodes": Array [
         "node_modules/tap",
       ],
-      "range": "5.1.0 - 5.1.1 || >=5.7.2",
-      "severity": "high",
+      "range": "5.1.0 - 5.1.1 || >=6.3.0",
+      "severity": "low",
       "via": Array [
-        "import-jsx",
         "nyc",
-        "treport",
-      ],
-    },
-    "treport": Object {
-      "effects": Array [
-        "tap",
-      ],
-      "fixAvailable": true,
-      "name": "treport",
-      "nodes": Array [
-        "node_modules/treport",
-      ],
-      "range": "<=0.5.0",
-      "severity": "high",
-      "via": Array [
-        "import-jsx",
       ],
     },
     "union-value": Object {
@@ -2390,12 +2242,11 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "yargs",
       "nodes": Array [
         "node_modules/nyc/node_modules/yargs",
-        "node_modules/yargs",
       ],
       "range": ">=4.0.0-alpha1",
       "severity": "low",
@@ -2418,17 +2269,21 @@ Object {
       "nodes": Array [
         "node_modules/nyc/node_modules/yargs-parser",
         "node_modules/nyc/node_modules/yargs/node_modules/yargs-parser",
-        "node_modules/yargs-parser",
       ],
       "range": "*",
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1500,
+          "dependency": "yargs-parser",
+          "id": undefined,
+          "name": "yargs-parser",
+          "range": "<13.1.2 || >=14.0.0 <15.0.1 || >=16.0.0 <18.1.2",
           "severity": "low",
+          "source": 1500,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1500",
-          "vulnerable_versions": "<13.1.2 || >=14.0.0 <15.0.1 || >=16.0.0 <18.1.2",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -2472,49 +2327,67 @@ Object {
       "range": "<=4.7.3",
       "severity": "critical",
       "via": Array [
-        "optimist",
         Object {
-          "id": 755,
-          "severity": "critical",
-          "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/755",
-          "vulnerable_versions": "<=4.0.13 || >=4.1.0 <4.1.2",
-        },
-        Object {
-          "id": 1164,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.3.0",
           "severity": "high",
+          "source": 1164,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1164",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.3.0",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1300,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": ">=4.0.0 <4.4.5",
           "severity": "moderate",
+          "source": 1300,
           "title": "Denial of Service",
           "url": "https://npmjs.com/advisories/1300",
-          "vulnerable_versions": ">=4.0.0 <4.4.5",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1316,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.5.2",
           "severity": "high",
+          "source": 1316,
           "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1316",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.2",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1324,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.5.3",
           "severity": "high",
+          "source": 1324,
           "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1324",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1325,
-          "severity": "high",
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<=4.0.13 || >=4.1.0 <4.1.2",
+          "severity": "critical",
+          "source": 755,
           "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/1325",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3",
+          "url": "https://npmjs.com/advisories/755",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
+        "optimist",
       ],
     },
     "minimist": Object {
@@ -2534,11 +2407,16 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1179,
+          "dependency": "minimist",
+          "id": undefined,
+          "name": "minimist",
+          "range": "<0.2.1 || >=1.0.0 <1.2.3",
           "severity": "low",
+          "source": 1179,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1179",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -2579,98 +2457,14 @@ Object {
     },
     "vulnerabilities": Object {
       "critical": 1,
-      "high": 10,
+      "high": 4,
       "info": 0,
-      "low": 8,
+      "low": 9,
       "moderate": 0,
-      "total": 19,
+      "total": 14,
     },
   },
   "vulnerabilities": Object {
-    "babel-generator": Object {
-      "effects": Array [
-        "istanbul-lib-instrument",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-generator",
-      "nodes": Array [
-        "node_modules/nyc/node_modules/babel-generator",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-types",
-        "lodash",
-      ],
-    },
-    "babel-template": Object {
-      "effects": Array [
-        "istanbul-lib-instrument",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-template",
-      "nodes": Array [
-        "node_modules/nyc/node_modules/babel-template",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-traverse",
-        "babel-types",
-        "lodash",
-      ],
-    },
-    "babel-traverse": Object {
-      "effects": Array [
-        "istanbul-lib-instrument",
-        "babel-template",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-traverse",
-      "nodes": Array [
-        "node_modules/nyc/node_modules/babel-traverse",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-types",
-        "lodash",
-      ],
-    },
-    "babel-types": Object {
-      "effects": Array [
-        "istanbul-lib-instrument",
-        "babel-template",
-        "babel-generator",
-        "babel-traverse",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-types",
-      "nodes": Array [
-        "node_modules/nyc/node_modules/babel-types",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "lodash",
-      ],
-    },
     "handlebars": Object {
       "effects": Array [],
       "fixAvailable": Object {
@@ -2686,71 +2480,67 @@ Object {
       "range": "<=4.7.3",
       "severity": "critical",
       "via": Array [
-        "optimist",
         Object {
-          "id": 755,
-          "severity": "critical",
-          "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/755",
-          "vulnerable_versions": "<=4.0.13 || >=4.1.0 <4.1.2",
-        },
-        Object {
-          "id": 1164,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.3.0",
           "severity": "high",
+          "source": 1164,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1164",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.3.0",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1300,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": ">=4.0.0 <4.4.5",
           "severity": "moderate",
+          "source": 1300,
           "title": "Denial of Service",
           "url": "https://npmjs.com/advisories/1300",
-          "vulnerable_versions": ">=4.0.0 <4.4.5",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1316,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.5.2",
           "severity": "high",
+          "source": 1316,
           "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1316",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.2",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1324,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.5.3",
           "severity": "high",
+          "source": 1324,
           "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1324",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1325,
-          "severity": "high",
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<=4.0.13 || >=4.1.0 <4.1.2",
+          "severity": "critical",
+          "source": 755,
           "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/1325",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3",
+          "url": "https://npmjs.com/advisories/755",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
-      ],
-    },
-    "istanbul-lib-instrument": Object {
-      "effects": Array [
-        "nyc",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "istanbul-lib-instrument",
-      "nodes": Array [
-        "node_modules/nyc/node_modules/istanbul-lib-instrument",
-      ],
-      "range": "1.1.0-alpha.0 - 1.10.2",
-      "severity": "high",
-      "via": Array [
-        "babel-generator",
-        "babel-template",
-        "babel-traverse",
-        "babel-types",
+        "optimist",
       ],
     },
     "kind-of": Object {
@@ -2771,26 +2561,22 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1490,
+          "dependency": "kind-of",
+          "id": undefined,
+          "name": "kind-of",
+          "range": ">=6.0.0 <6.0.3",
           "severity": "low",
+          "source": 1490,
           "title": "Validation Bypass",
           "url": "https://npmjs.com/advisories/1490",
-          "vulnerable_versions": ">=6.0.0 <6.0.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
     "lodash": Object {
-      "effects": Array [
-        "babel-generator",
-        "babel-template",
-        "babel-traverse",
-        "babel-types",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
+      "effects": Array [],
+      "fixAvailable": true,
       "name": "lodash",
       "nodes": Array [
         "node_modules/nyc/node_modules/lodash",
@@ -2799,25 +2585,40 @@ Object {
       "severity": "high",
       "via": Array [
         Object {
-          "id": 782,
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.12",
           "severity": "high",
-          "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/782",
-          "vulnerable_versions": "<4.17.11",
-        },
-        Object {
-          "id": 1065,
-          "severity": "high",
+          "source": 1065,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1065",
-          "vulnerable_versions": "<4.17.12",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1523,
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.19",
           "severity": "low",
+          "source": 1523,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1523",
-          "vulnerable_versions": "<4.17.19",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
+        },
+        Object {
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.11",
+          "severity": "high",
+          "source": 782,
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/782",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -2828,7 +2629,7 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "mem",
       "nodes": Array [
@@ -2838,11 +2639,16 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1084,
+          "dependency": "mem",
+          "id": undefined,
+          "name": "mem",
+          "range": "<4.0.0",
           "severity": "low",
+          "source": 1084,
           "title": "Denial of Service",
           "url": "https://npmjs.com/advisories/1084",
-          "vulnerable_versions": "<4.0.0",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -2865,11 +2671,16 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1179,
+          "dependency": "minimist",
+          "id": undefined,
+          "name": "minimist",
+          "range": "<0.2.1 || >=1.0.0 <1.2.3",
           "severity": "low",
+          "source": 1179,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1179",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -2884,11 +2695,16 @@ Object {
       "severity": "high",
       "via": Array [
         Object {
-          "id": 1013,
+          "dependency": "mixin-deep",
+          "id": undefined,
+          "name": "mixin-deep",
+          "range": "<1.3.2 || >=2.0.0 <2.0.1",
           "severity": "high",
+          "source": 1013,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1013",
-          "vulnerable_versions": "<1.3.2 || >=2.0.0 <2.0.1",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -2916,16 +2732,15 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "nyc",
       "nodes": Array [
         "node_modules/nyc",
       ],
       "range": ">=6.0.0",
-      "severity": "high",
+      "severity": "low",
       "via": Array [
-        "istanbul-lib-instrument",
         "mkdirp",
         "yargs",
         "yargs-parser",
@@ -2958,7 +2773,7 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "os-locale",
       "nodes": Array [
@@ -2984,11 +2799,16 @@ Object {
       "severity": "high",
       "via": Array [
         Object {
-          "id": 1012,
+          "dependency": "set-value",
+          "id": undefined,
+          "name": "set-value",
+          "range": "<2.0.1 || >=3.0.0 <3.0.1",
           "severity": "high",
+          "source": 1012,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1012",
-          "vulnerable_versions": "<2.0.1 || >=3.0.0 <3.0.1",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -3012,7 +2832,7 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "yargs",
       "nodes": Array [
@@ -3044,11 +2864,16 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1500,
+          "dependency": "yargs-parser",
+          "id": undefined,
+          "name": "yargs-parser",
+          "range": "<13.1.2 || >=14.0.0 <15.0.1 || >=16.0.0 <18.1.2",
           "severity": "low",
+          "source": 1500,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1500",
-          "vulnerable_versions": "<13.1.2 || >=14.0.0 <15.0.1 || >=16.0.0 <18.1.2",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -3092,49 +2917,67 @@ Object {
       "range": "<=4.7.3",
       "severity": "critical",
       "via": Array [
-        "optimist",
         Object {
-          "id": 755,
-          "severity": "critical",
-          "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/755",
-          "vulnerable_versions": "<=4.0.13 || >=4.1.0 <4.1.2",
-        },
-        Object {
-          "id": 1164,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.3.0",
           "severity": "high",
+          "source": 1164,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1164",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.3.0",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1300,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": ">=4.0.0 <4.4.5",
           "severity": "moderate",
+          "source": 1300,
           "title": "Denial of Service",
           "url": "https://npmjs.com/advisories/1300",
-          "vulnerable_versions": ">=4.0.0 <4.4.5",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1316,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.5.2",
           "severity": "high",
+          "source": 1316,
           "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1316",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.2",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1324,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.5.3",
           "severity": "high",
+          "source": 1324,
           "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1324",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1325,
-          "severity": "high",
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<=4.0.13 || >=4.1.0 <4.1.2",
+          "severity": "critical",
+          "source": 755,
           "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/1325",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3",
+          "url": "https://npmjs.com/advisories/755",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
+        "optimist",
       ],
     },
     "minimist": Object {
@@ -3154,11 +2997,16 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1179,
+          "dependency": "minimist",
+          "id": undefined,
+          "name": "minimist",
+          "range": "<0.2.1 || >=1.0.0 <1.2.3",
           "severity": "low",
+          "source": 1179,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1179",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -3224,178 +3072,85 @@ Object {
     },
     "vulnerabilities": Object {
       "critical": 1,
-      "high": 10,
+      "high": 4,
       "info": 0,
-      "low": 8,
+      "low": 9,
       "moderate": 0,
-      "total": 19,
+      "total": 14,
     },
   },
   "vulnerabilities": Object {
-    "babel-generator": Object {
-      "effects": Array [
-        "istanbul-lib-instrument",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-generator",
-      "nodes": Array [
-        "node_modules/nyc/node_modules/babel-generator",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-types",
-        "lodash",
-      ],
-    },
-    "babel-template": Object {
-      "effects": Array [
-        "istanbul-lib-instrument",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-template",
-      "nodes": Array [
-        "node_modules/nyc/node_modules/babel-template",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-traverse",
-        "babel-types",
-        "lodash",
-      ],
-    },
-    "babel-traverse": Object {
-      "effects": Array [
-        "istanbul-lib-instrument",
-        "babel-template",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-traverse",
-      "nodes": Array [
-        "node_modules/nyc/node_modules/babel-traverse",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-types",
-        "lodash",
-      ],
-    },
-    "babel-types": Object {
-      "effects": Array [
-        "istanbul-lib-instrument",
-        "babel-template",
-        "babel-generator",
-        "babel-traverse",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-types",
-      "nodes": Array [
-        "node_modules/nyc/node_modules/babel-types",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "lodash",
-      ],
-    },
     "handlebars": Object {
       "effects": Array [],
-      "fixAvailable": Object {
-        "isSemVerMajor": false,
-        "name": "handlebars",
-        "version": "4.7.6",
-      },
+      "fixAvailable": true,
       "name": "handlebars",
       "nodes": Array [
         "node_modules/nyc/node_modules/handlebars",
-        "node_modules/handlebars",
       ],
       "range": "<=4.7.3",
       "severity": "critical",
       "via": Array [
-        "optimist",
         Object {
-          "id": 755,
-          "severity": "critical",
-          "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/755",
-          "vulnerable_versions": "<=4.0.13 || >=4.1.0 <4.1.2",
-        },
-        Object {
-          "id": 1164,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.3.0",
           "severity": "high",
+          "source": 1164,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1164",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.3.0",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1300,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": ">=4.0.0 <4.4.5",
           "severity": "moderate",
+          "source": 1300,
           "title": "Denial of Service",
           "url": "https://npmjs.com/advisories/1300",
-          "vulnerable_versions": ">=4.0.0 <4.4.5",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1316,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.5.2",
           "severity": "high",
+          "source": 1316,
           "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1316",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.2",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1324,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.5.3",
           "severity": "high",
+          "source": 1324,
           "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1324",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1325,
-          "severity": "high",
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<=4.0.13 || >=4.1.0 <4.1.2",
+          "severity": "critical",
+          "source": 755,
           "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/1325",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3",
+          "url": "https://npmjs.com/advisories/755",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
-      ],
-    },
-    "istanbul-lib-instrument": Object {
-      "effects": Array [
-        "nyc",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "istanbul-lib-instrument",
-      "nodes": Array [
-        "node_modules/nyc/node_modules/istanbul-lib-instrument",
-      ],
-      "range": "1.1.0-alpha.0 - 1.10.2",
-      "severity": "high",
-      "via": Array [
-        "babel-generator",
-        "babel-template",
-        "babel-traverse",
-        "babel-types",
+        "optimist",
       ],
     },
     "kind-of": Object {
@@ -3416,26 +3171,22 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1490,
+          "dependency": "kind-of",
+          "id": undefined,
+          "name": "kind-of",
+          "range": ">=6.0.0 <6.0.3",
           "severity": "low",
+          "source": 1490,
           "title": "Validation Bypass",
           "url": "https://npmjs.com/advisories/1490",
-          "vulnerable_versions": ">=6.0.0 <6.0.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
     "lodash": Object {
-      "effects": Array [
-        "babel-generator",
-        "babel-template",
-        "babel-traverse",
-        "babel-types",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
+      "effects": Array [],
+      "fixAvailable": true,
       "name": "lodash",
       "nodes": Array [
         "node_modules/nyc/node_modules/lodash",
@@ -3444,25 +3195,40 @@ Object {
       "severity": "high",
       "via": Array [
         Object {
-          "id": 782,
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.12",
           "severity": "high",
-          "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/782",
-          "vulnerable_versions": "<4.17.11",
-        },
-        Object {
-          "id": 1065,
-          "severity": "high",
+          "source": 1065,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1065",
-          "vulnerable_versions": "<4.17.12",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1523,
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.19",
           "severity": "low",
+          "source": 1523,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1523",
-          "vulnerable_versions": "<4.17.19",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
+        },
+        Object {
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.11",
+          "severity": "high",
+          "source": 782,
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/782",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -3473,7 +3239,7 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "mem",
       "nodes": Array [
@@ -3483,11 +3249,16 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1084,
+          "dependency": "mem",
+          "id": undefined,
+          "name": "mem",
+          "range": "<4.0.0",
           "severity": "low",
+          "source": 1084,
           "title": "Denial of Service",
           "url": "https://npmjs.com/advisories/1084",
-          "vulnerable_versions": "<4.0.0",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -3509,11 +3280,16 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1179,
+          "dependency": "minimist",
+          "id": undefined,
+          "name": "minimist",
+          "range": "<0.2.1 || >=1.0.0 <1.2.3",
           "severity": "low",
+          "source": 1179,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1179",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -3528,11 +3304,16 @@ Object {
       "severity": "high",
       "via": Array [
         Object {
-          "id": 1013,
+          "dependency": "mixin-deep",
+          "id": undefined,
+          "name": "mixin-deep",
+          "range": "<1.3.2 || >=2.0.0 <2.0.1",
           "severity": "high",
+          "source": 1013,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1013",
-          "vulnerable_versions": "<1.3.2 || >=2.0.0 <2.0.1",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -3560,16 +3341,15 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "nyc",
       "nodes": Array [
         "node_modules/nyc",
       ],
       "range": ">=6.0.0",
-      "severity": "high",
+      "severity": "low",
       "via": Array [
-        "istanbul-lib-instrument",
         "mkdirp",
         "yargs",
         "yargs-parser",
@@ -3579,11 +3359,7 @@ Object {
       "effects": Array [
         "handlebars",
       ],
-      "fixAvailable": Object {
-        "isSemVerMajor": false,
-        "name": "handlebars",
-        "version": "4.7.6",
-      },
+      "fixAvailable": true,
       "name": "optimist",
       "nodes": Array [
         "node_modules/nyc/node_modules/optimist",
@@ -3601,7 +3377,7 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "os-locale",
       "nodes": Array [
@@ -3627,11 +3403,16 @@ Object {
       "severity": "high",
       "via": Array [
         Object {
-          "id": 1012,
+          "dependency": "set-value",
+          "id": undefined,
+          "name": "set-value",
+          "range": "<2.0.1 || >=3.0.0 <3.0.1",
           "severity": "high",
+          "source": 1012,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1012",
-          "vulnerable_versions": "<2.0.1 || >=3.0.0 <3.0.1",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -3655,7 +3436,7 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "yargs",
       "nodes": Array [
@@ -3687,11 +3468,16 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1500,
+          "dependency": "yargs-parser",
+          "id": undefined,
+          "name": "yargs-parser",
+          "range": "<13.1.2 || >=14.0.0 <15.0.1 || >=16.0.0 <18.1.2",
           "severity": "low",
+          "source": 1500,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1500",
-          "vulnerable_versions": "<13.1.2 || >=14.0.0 <15.0.1 || >=16.0.0 <18.1.2",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -3713,288 +3499,85 @@ Object {
     },
     "vulnerabilities": Object {
       "critical": 1,
-      "high": 18,
+      "high": 4,
       "info": 0,
-      "low": 8,
+      "low": 10,
       "moderate": 0,
-      "total": 27,
+      "total": 15,
     },
   },
   "vulnerabilities": Object {
-    "babel-core": Object {
-      "effects": Array [
-        "babel-register",
-        "import-jsx",
-      ],
-      "fixAvailable": true,
-      "name": "babel-core",
-      "nodes": Array [
-        "node_modules/babel-core",
-      ],
-      "range": "<=7.0.0-beta.3",
-      "severity": "high",
-      "via": Array [
-        "babel-generator",
-        "babel-helpers",
-        "babel-register",
-        "babel-template",
-        "babel-traverse",
-        "babel-types",
-        "lodash",
-      ],
-    },
-    "babel-generator": Object {
-      "effects": Array [
-        "babel-core",
-        "istanbul-lib-instrument",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-generator",
-      "nodes": Array [
-        "node_modules/babel-generator",
-        "node_modules/nyc/node_modules/babel-generator",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-types",
-        "lodash",
-      ],
-    },
-    "babel-helper-builder-react-jsx": Object {
-      "effects": Array [
-        "babel-plugin-transform-react-jsx",
-      ],
-      "fixAvailable": true,
-      "name": "babel-helper-builder-react-jsx",
-      "nodes": Array [
-        "node_modules/babel-helper-builder-react-jsx",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-types",
-      ],
-    },
-    "babel-helpers": Object {
-      "effects": Array [
-        "babel-core",
-      ],
-      "fixAvailable": true,
-      "name": "babel-helpers",
-      "nodes": Array [
-        "node_modules/babel-helpers",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-template",
-      ],
-    },
-    "babel-plugin-transform-react-jsx": Object {
-      "effects": Array [
-        "import-jsx",
-      ],
-      "fixAvailable": true,
-      "name": "babel-plugin-transform-react-jsx",
-      "nodes": Array [
-        "node_modules/babel-plugin-transform-react-jsx",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-helper-builder-react-jsx",
-      ],
-    },
-    "babel-register": Object {
-      "effects": Array [
-        "babel-core",
-      ],
-      "fixAvailable": true,
-      "name": "babel-register",
-      "nodes": Array [
-        "node_modules/babel-register",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-core",
-        "lodash",
-      ],
-    },
-    "babel-template": Object {
-      "effects": Array [
-        "babel-core",
-        "istanbul-lib-instrument",
-        "babel-helpers",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-template",
-      "nodes": Array [
-        "node_modules/babel-template",
-        "node_modules/nyc/node_modules/babel-template",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-traverse",
-        "babel-types",
-        "lodash",
-      ],
-    },
-    "babel-traverse": Object {
-      "effects": Array [
-        "babel-core",
-        "istanbul-lib-instrument",
-        "babel-template",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-traverse",
-      "nodes": Array [
-        "node_modules/babel-traverse",
-        "node_modules/nyc/node_modules/babel-traverse",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "babel-types",
-        "lodash",
-      ],
-    },
-    "babel-types": Object {
-      "effects": Array [
-        "babel-core",
-        "istanbul-lib-instrument",
-        "babel-template",
-        "babel-generator",
-        "babel-helper-builder-react-jsx",
-        "babel-traverse",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "babel-types",
-      "nodes": Array [
-        "node_modules/babel-types",
-        "node_modules/nyc/node_modules/babel-types",
-      ],
-      "range": "*",
-      "severity": "high",
-      "via": Array [
-        "lodash",
-      ],
-    },
     "handlebars": Object {
       "effects": Array [],
-      "fixAvailable": Object {
-        "isSemVerMajor": false,
-        "name": "handlebars",
-        "version": "4.7.6",
-      },
+      "fixAvailable": true,
       "name": "handlebars",
       "nodes": Array [
         "node_modules/nyc/node_modules/handlebars",
-        "node_modules/handlebars",
       ],
       "range": "<=4.7.3",
       "severity": "critical",
       "via": Array [
-        "optimist",
         Object {
-          "id": 755,
-          "severity": "critical",
-          "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/755",
-          "vulnerable_versions": "<=4.0.13 || >=4.1.0 <4.1.2",
-        },
-        Object {
-          "id": 1164,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.3.0",
           "severity": "high",
+          "source": 1164,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1164",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.3.0",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1300,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": ">=4.0.0 <4.4.5",
           "severity": "moderate",
+          "source": 1300,
           "title": "Denial of Service",
           "url": "https://npmjs.com/advisories/1300",
-          "vulnerable_versions": ">=4.0.0 <4.4.5",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1316,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.5.2",
           "severity": "high",
+          "source": 1316,
           "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1316",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.2",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1324,
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<3.0.8 || >=4.0.0 <4.5.3",
           "severity": "high",
+          "source": 1324,
           "title": "Arbitrary Code Execution",
           "url": "https://npmjs.com/advisories/1324",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1325,
-          "severity": "high",
+          "dependency": "handlebars",
+          "id": undefined,
+          "name": "handlebars",
+          "range": "<=4.0.13 || >=4.1.0 <4.1.2",
+          "severity": "critical",
+          "source": 755,
           "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/1325",
-          "vulnerable_versions": "<3.0.8 || >=4.0.0 <4.5.3",
+          "url": "https://npmjs.com/advisories/755",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
-      ],
-    },
-    "import-jsx": Object {
-      "effects": Array [
-        "tap",
-        "treport",
-      ],
-      "fixAvailable": true,
-      "name": "import-jsx",
-      "nodes": Array [
-        "node_modules/import-jsx",
-      ],
-      "range": "1.2.0 - 2.0.0",
-      "severity": "high",
-      "via": Array [
-        "babel-core",
-        "babel-plugin-transform-react-jsx",
-      ],
-    },
-    "istanbul-lib-instrument": Object {
-      "effects": Array [
-        "nyc",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
-      "name": "istanbul-lib-instrument",
-      "nodes": Array [
-        "node_modules/nyc/node_modules/istanbul-lib-instrument",
-      ],
-      "range": "1.1.0-alpha.0 - 1.10.2",
-      "severity": "high",
-      "via": Array [
-        "babel-generator",
-        "babel-template",
-        "babel-traverse",
-        "babel-types",
+        "optimist",
       ],
     },
     "kind-of": Object {
@@ -4015,56 +3598,64 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1490,
+          "dependency": "kind-of",
+          "id": undefined,
+          "name": "kind-of",
+          "range": ">=6.0.0 <6.0.3",
           "severity": "low",
+          "source": 1490,
           "title": "Validation Bypass",
           "url": "https://npmjs.com/advisories/1490",
-          "vulnerable_versions": ">=6.0.0 <6.0.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
     "lodash": Object {
-      "effects": Array [
-        "babel-generator",
-        "babel-template",
-        "babel-traverse",
-        "babel-types",
-        "babel-core",
-        "babel-register",
-      ],
-      "fixAvailable": Object {
-        "isSemVerMajor": true,
-        "name": "nyc",
-        "version": "5.6.0",
-      },
+      "effects": Array [],
+      "fixAvailable": true,
       "name": "lodash",
       "nodes": Array [
         "node_modules/nyc/node_modules/lodash",
-        "node_modules/lodash",
       ],
       "range": "*",
       "severity": "high",
       "via": Array [
         Object {
-          "id": 782,
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.12",
           "severity": "high",
-          "title": "Prototype Pollution",
-          "url": "https://npmjs.com/advisories/782",
-          "vulnerable_versions": "<4.17.11",
-        },
-        Object {
-          "id": 1065,
-          "severity": "high",
+          "source": 1065,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1065",
-          "vulnerable_versions": "<4.17.12",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
         Object {
-          "id": 1523,
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.19",
           "severity": "low",
+          "source": 1523,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1523",
-          "vulnerable_versions": "<4.17.19",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
+        },
+        Object {
+          "dependency": "lodash",
+          "id": undefined,
+          "name": "lodash",
+          "range": "<4.17.11",
+          "severity": "high",
+          "source": 782,
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/782",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -4075,7 +3666,7 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "mem",
       "nodes": Array [
@@ -4085,11 +3676,16 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1084,
+          "dependency": "mem",
+          "id": undefined,
+          "name": "mem",
+          "range": "<4.0.0",
           "severity": "low",
+          "source": 1084,
           "title": "Denial of Service",
           "url": "https://npmjs.com/advisories/1084",
-          "vulnerable_versions": "<4.0.0",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -4111,11 +3707,16 @@ Object {
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1179,
+          "dependency": "minimist",
+          "id": undefined,
+          "name": "minimist",
+          "range": "<0.2.1 || >=1.0.0 <1.2.3",
           "severity": "low",
+          "source": 1179,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1179",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -4130,11 +3731,16 @@ Object {
       "severity": "high",
       "via": Array [
         Object {
-          "id": 1013,
+          "dependency": "mixin-deep",
+          "id": undefined,
+          "name": "mixin-deep",
+          "range": "<1.3.2 || >=2.0.0 <2.0.1",
           "severity": "high",
+          "source": 1013,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1013",
-          "vulnerable_versions": "<1.3.2 || >=2.0.0 <2.0.1",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -4164,7 +3770,7 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "nyc",
       "nodes": Array [
@@ -4172,9 +3778,8 @@ Object {
         "node_modules/tap/node_modules/nyc",
       ],
       "range": ">=6.0.0",
-      "severity": "high",
+      "severity": "low",
       "via": Array [
-        "istanbul-lib-instrument",
         "mkdirp",
         "yargs",
         "yargs-parser",
@@ -4184,11 +3789,7 @@ Object {
       "effects": Array [
         "handlebars",
       ],
-      "fixAvailable": Object {
-        "isSemVerMajor": false,
-        "name": "handlebars",
-        "version": "4.7.6",
-      },
+      "fixAvailable": true,
       "name": "optimist",
       "nodes": Array [
         "node_modules/nyc/node_modules/optimist",
@@ -4206,7 +3807,7 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "os-locale",
       "nodes": Array [
@@ -4232,11 +3833,16 @@ Object {
       "severity": "high",
       "via": Array [
         Object {
-          "id": 1012,
+          "dependency": "set-value",
+          "id": undefined,
+          "name": "set-value",
+          "range": "<2.0.1 || >=3.0.0 <3.0.1",
           "severity": "high",
+          "source": 1012,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1012",
-          "vulnerable_versions": "<2.0.1 || >=3.0.0 <3.0.1",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -4245,33 +3851,16 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "tap",
-        "version": "5.7.1",
+        "version": "6.2.0",
       },
       "name": "tap",
       "nodes": Array [
         "node_modules/tap",
       ],
-      "range": "5.1.0 - 5.1.1 || >=5.7.2",
-      "severity": "high",
+      "range": "5.1.0 - 5.1.1 || >=6.3.0",
+      "severity": "low",
       "via": Array [
-        "import-jsx",
         "nyc",
-        "treport",
-      ],
-    },
-    "treport": Object {
-      "effects": Array [
-        "tap",
-      ],
-      "fixAvailable": true,
-      "name": "treport",
-      "nodes": Array [
-        "node_modules/treport",
-      ],
-      "range": "<=0.5.0",
-      "severity": "high",
-      "via": Array [
-        "import-jsx",
       ],
     },
     "union-value": Object {
@@ -4294,12 +3883,11 @@ Object {
       "fixAvailable": Object {
         "isSemVerMajor": true,
         "name": "nyc",
-        "version": "5.6.0",
+        "version": "15.0.0",
       },
       "name": "yargs",
       "nodes": Array [
         "node_modules/nyc/node_modules/yargs",
-        "node_modules/yargs",
       ],
       "range": ">=4.0.0-alpha1",
       "severity": "low",
@@ -4322,17 +3910,21 @@ Object {
       "nodes": Array [
         "node_modules/nyc/node_modules/yargs-parser",
         "node_modules/nyc/node_modules/yargs/node_modules/yargs-parser",
-        "node_modules/yargs-parser",
       ],
       "range": "*",
       "severity": "low",
       "via": Array [
         Object {
-          "id": 1500,
+          "dependency": "yargs-parser",
+          "id": undefined,
+          "name": "yargs-parser",
+          "range": "<13.1.2 || >=14.0.0 <15.0.1 || >=16.0.0 <18.1.2",
           "severity": "low",
+          "source": 1500,
           "title": "Prototype Pollution",
           "url": "https://npmjs.com/advisories/1500",
-          "vulnerable_versions": "<13.1.2 || >=14.0.0 <15.0.1 || >=16.0.0 <18.1.2",
+          "versions": undefined,
+          "vulnerableVersions": undefined,
         },
       ],
     },
@@ -4349,11 +3941,13 @@ exports[`test/audit-report.js TAP one vulnerability > json version 1`] = `
       "severity": "low",
       "via": [
         {
-          "id": 1179,
-          "url": "https://npmjs.com/advisories/1179",
+          "source": 1179,
+          "name": "minimist",
+          "dependency": "minimist",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1179",
           "severity": "low",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3"
+          "range": "<0.2.1 || >=1.0.0 <1.2.3"
         }
       ],
       "effects": [],
@@ -4394,11 +3988,13 @@ exports[`test/audit-report.js TAP unfixable, but not a semver major forced fix >
       "severity": "low",
       "via": [
         {
-          "id": 1179,
-          "url": "https://npmjs.com/advisories/1179",
+          "source": 1179,
+          "name": "minimist",
+          "dependency": "minimist",
           "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1179",
           "severity": "low",
-          "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3"
+          "range": "<0.2.1 || >=1.0.0 <1.2.3"
         }
       ],
       "effects": [
@@ -4448,6 +4044,53 @@ exports[`test/audit-report.js TAP unfixable, but not a semver major forced fix >
       "peer": 0,
       "peerOptional": 0,
       "total": 2
+    }
+  }
+}
+`
+
+exports[`test/audit-report.js TAP vulnerable dep not from registry > json version 1`] = `
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {
+    "minimist": {
+      "name": "minimist",
+      "severity": "low",
+      "via": [
+        {
+          "source": 1179,
+          "name": "minimist",
+          "dependency": "minimist",
+          "title": "Prototype Pollution",
+          "url": "https://npmjs.com/advisories/1179",
+          "severity": "low",
+          "range": "<0.2.1 || >=1.0.0 <1.2.3"
+        }
+      ],
+      "effects": [],
+      "range": "<0.2.1 || >=1.0.0 <1.2.3",
+      "nodes": [
+        "node_modules/minimist"
+      ],
+      "fixAvailable": false
+    }
+  },
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 1,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0,
+      "total": 1
+    },
+    "dependencies": {
+      "prod": 0,
+      "dev": 0,
+      "optional": 0,
+      "peer": 1,
+      "peerOptional": 0,
+      "total": 1
     }
   }
 }

--- a/tap-snapshots/test-vuln.js-TAP.test.js
+++ b/tap-snapshots/test-vuln.js-TAP.test.js
@@ -5,18 +5,63 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/vuln.js TAP basic vulnerability object tests > json after adding effect 1`] = `
+{"name":"name","severity":"critical","via":[{"type":"advisory","source":420,"title":"borgsafalamash","name":"name","dependency":"name","severity":"critical","range":"1.x < 1.3"},{"type":"advisory","source":69,"title":"flerbygurrf","name":"name","dependency":"name","severity":"low","range":"2.x < 2.3.2 || 3.x <3.0.1"}],"effects":["another"],"range":"1.0.0 - 3.0.0","nodes":[],"fixAvailable":true}
+`
+
+exports[`test/vuln.js TAP basic vulnerability object tests > json formatted 1`] = `
+{
+  "name": "name",
+  "severity": "critical",
+  "via": [
+    {
+      "type": "advisory",
+      "source": 420,
+      "title": "borgsafalamash",
+      "name": "name",
+      "dependency": "name",
+      "severity": "critical",
+      "range": "1.x < 1.3"
+    },
+    {
+      "type": "advisory",
+      "source": 69,
+      "title": "flerbygurrf",
+      "name": "name",
+      "dependency": "name",
+      "severity": "low",
+      "range": "2.x < 2.3.2 || 3.x <3.0.1"
+    }
+  ],
+  "effects": [],
+  "range": "1.0.0 - 3.0.0",
+  "nodes": [],
+  "fixAvailable": true
+}
+`
+
 exports[`test/vuln.js TAP basic vulnerability object tests > json formatted after loading 1`] = `
 {
   "name": "name",
   "severity": "critical",
   "via": [
     {
-      "another": "advisory",
-      "severity": "low"
+      "type": "advisory",
+      "source": 420,
+      "title": "borgsafalamash",
+      "name": "name",
+      "dependency": "name",
+      "severity": "critical",
+      "range": "1.x < 1.3"
     },
     {
-      "some": "advisory",
-      "severity": "critical"
+      "type": "advisory",
+      "source": 69,
+      "title": "flerbygurrf",
+      "name": "name",
+      "dependency": "name",
+      "severity": "low",
+      "range": "2.x < 2.3.2 || 3.x <3.0.1"
     }
   ],
   "effects": [
@@ -26,30 +71,7 @@ exports[`test/vuln.js TAP basic vulnerability object tests > json formatted afte
   "nodes": [
     ""
   ],
-  "fixAvailable": {
-    "isSemVerMajor": true
-  }
-}
-`
-
-exports[`test/vuln.js TAP basic vulnerability object tests > json formatted before packument 1`] = `
-{
-  "name": "name",
-  "severity": "critical",
-  "via": [
-    {
-      "another": "advisory",
-      "severity": "low"
-    },
-    {
-      "some": "advisory",
-      "severity": "critical"
-    }
-  ],
-  "effects": [],
-  "range": "",
-  "nodes": [],
-  "fixAvailable": true
+  "fixAvailable": false
 }
 `
 
@@ -58,13 +80,12 @@ exports[`test/vuln.js TAP basic vulnerability object tests > json formatted meta
   "name": "another",
   "severity": "critical",
   "via": [
+    "name",
     "name"
   ],
   "effects": [],
-  "range": "",
+  "range": "1.0.0 - 2.0.1",
   "nodes": [],
-  "fixAvailable": {
-    "isSemVerMajor": true
-  }
+  "fixAvailable": false
 }
 `

--- a/test/arborist/audit.js
+++ b/test/arborist/audit.js
@@ -100,8 +100,6 @@ t.test('audit finds the bad deps', async t => {
 
   const report = await arb.audit()
   t.equal(report.topVulns.size, 0)
-  t.equal(report.dependencyVulns.size, 1)
-  t.equal(report.advisoryVulns.size, 1)
   t.equal(report.size, 2)
 })
 

--- a/test/audit-report.js
+++ b/test/audit-report.js
@@ -9,9 +9,124 @@ const {registry, auditResponse, failAudit, advisoryBulkResponse} = registryServe
 const {resolve} = require('path')
 const fixtures = resolve(__dirname, 'fixtures')
 
-const newArb = (path, opts = {}) => new Arborist({path, registry, ...opts})
+const cache = t.testdir()
+const newArb = (path, opts = {}) => new Arborist({path, registry, cache, ...opts})
+
+const sortReport = report => {
+  const entries = Object.entries(report.vulnerabilities)
+  const vulns = entries.sort(([a], [b]) => a.localeCompare(b))
+  .map(([name, vuln]) => [
+    name,
+    {
+      ...vuln,
+      via: (vuln.via || []).sort((a, b) =>
+        String(a.source || a).localeCompare(String(b.source || b))),
+      effects: (vuln.effects || []).sort((a, b) => a.localeCompare(b)),
+    }
+  ])
+  report.vulnerabilities = vulns.reduce((set, [k, v]) => {
+    set[k] = v
+    return set
+  }, {})
+}
 
 t.test('setup server', { bail: true }, registryServer)
+
+t.test('all severity levels', async t => {
+  const path = resolve(fixtures, 'audit-all-severities')
+  const auditFile = resolve(path, 'audit.json')
+  t.teardown(auditResponse(auditFile))
+  const arb = newArb(path)
+
+  const tree = await arb.loadVirtual()
+  const report = await AuditReport.load(tree, arb.options)
+  t.matchSnapshot(JSON.stringify(report, 0, 2), 'json version')
+  t.equal(report.topVulns.size, 2)
+})
+
+t.test('vulnerable dep not from registry', async t => {
+  const path = resolve(fixtures, 'minimist-git-dep')
+  const auditFile = resolve(path, 'audit.json')
+  t.teardown(auditResponse(auditFile))
+  const arb = newArb(path)
+
+  const tree = await arb.loadVirtual()
+  const report = await AuditReport.load(tree, arb.options)
+  t.matchSnapshot(JSON.stringify(report, 0, 2), 'json version')
+  t.equal(report.has('minimist'), true)
+  t.equal(report.topVulns.has('minimist'), true)
+  t.equal(report.isVulnerable(tree.children.get('minimist')), true)
+})
+
+t.test('metavuln where dep is not a registry dep', async t => {
+  const path = resolve(fixtures, 'minimist-git-metadep')
+  const auditFile = resolve(path, 'audit.json')
+  t.teardown(auditResponse(auditFile))
+  const arb = newArb(path)
+
+  const tree = await arb.loadVirtual()
+  const report = await AuditReport.load(tree, arb.options)
+  t.matchSnapshot(JSON.stringify(report, 0, 2), 'json version')
+
+  t.equal(report.has('@isaacs/minimist-git-dep'), true)
+  t.equal(report.has('minimist'), true)
+  t.equal(report.topVulns.has('@isaacs/minimist-git-dep'), true)
+})
+
+t.test('metavuln where a dep is not on the registry at all', async t => {
+  const path = resolve(fixtures, 'audit-missing-packument')
+  const auditFile = resolve(path, 'audit.json')
+  t.teardown(auditResponse(auditFile))
+  const arb = newArb(path)
+
+  const tree = await arb.loadVirtual()
+  const report = await AuditReport.load(tree, arb.options)
+  t.matchSnapshot(JSON.stringify(report, 0, 2), 'json version')
+  t.equal(report.topVulns.size, 1)
+})
+
+t.test('get advisory about node not in tree', async t => {
+  // this should never happen, but if it does, we're prepared for it
+  const path = resolve(fixtures, 'audit-nyc-mkdirp')
+  const auditFile = resolve(path, 'audit.json')
+  t.teardown(auditResponse(auditFile))
+
+  const arb = newArb(path)
+
+  const tree = await arb.loadVirtual()
+  tree.children.get('mkdirp').parent = null
+  tree.children.get('nyc').parent = null
+  tree.children.get('minimist').parent = null
+  new Node({
+    parent: tree,
+    path: resolve(path, 'node_modules/fooo'),
+    pkg: { name: 'fooo', version: '1.2.3' },
+  })
+  tree.package = { dependencies: {
+    fooo: ''
+  }}
+
+  const report = await AuditReport.load(tree, arb.options)
+  // just a gut-check that the registry server is actually doing stuff
+  t.match(report.report, auditToBulk(require(auditFile)), 'got expected response')
+  t.equal(report.topVulns.size, 0, 'one top node found vulnerable')
+  t.equal(report.size, 0, 'no vulns that were relevant')
+  t.equal(report.get('nyc'), undefined)
+  t.equal(report.get('mkdirp'), undefined)
+})
+
+t.test('unfixable, but not a semver major forced fix', async t => {
+  const path = resolve(fixtures, 'mkdirp-pinned')
+  const auditFile = resolve(fixtures, 'audit-nyc-mkdirp/audit.json')
+  t.teardown(auditResponse(auditFile))
+  const arb = newArb(path)
+
+  const tree = await arb.loadVirtual()
+  const report = await AuditReport.load(tree, arb.options)
+  t.matchSnapshot(JSON.stringify(report, 0, 2), 'json version')
+
+  t.equal(report.topVulns.size, 1)
+})
 
 t.test('audit outdated nyc and mkdirp', async t => {
   const path = resolve(fixtures, 'audit-nyc-mkdirp')
@@ -32,8 +147,6 @@ t.test('audit outdated nyc and mkdirp', async t => {
   })
 
   t.equal(report.topVulns.size, 1, 'one top node found vulnerable')
-  t.equal(report.dependencyVulns.size, 6, 'dep vulns')
-  t.equal(report.advisoryVulns.size, 7, 'advisory vulns')
   t.equal(report.get('nyc').simpleRange, '6.2.0-alpha - 13.1.0')
   t.equal(report.get('mkdirp').simpleRange, '0.4.1 - 0.5.1')
 })
@@ -57,8 +170,6 @@ t.test('audit outdated nyc and mkdirp with newer endpoint', async t => {
   })
 
   t.equal(report.topVulns.size, 1, 'one top node found vulnerable')
-  t.equal(report.dependencyVulns.size, 6, 'dep vulns')
-  t.equal(report.advisoryVulns.size, 7, 'advisory vulns')
   t.equal(report.get('nyc').simpleRange, '6.2.0-alpha - 13.1.0')
   t.equal(report.get('mkdirp').simpleRange, '0.4.1 - 0.5.1')
 })
@@ -78,8 +189,6 @@ t.test('audit outdated nyc and mkdirp with before: option', async t => {
   t.match(report.report, auditToBulk(require(auditFile)), 'got expected response')
 
   t.equal(report.topVulns.size, 1, 'one top node found vulnerable')
-  t.equal(report.dependencyVulns.size, 6, 'dep vulns')
-  t.equal(report.advisoryVulns.size, 7, 'advisory vulns')
   t.equal(report.get('nyc').simpleRange, '6.2.0-alpha - 13.1.0')
   t.equal(report.get('mkdirp').simpleRange, '0.4.1 - 0.5.1')
 })
@@ -130,83 +239,6 @@ t.test('audit disabled by config', async t => {
   t.equal(report.error, null, 'no error encountered')
 })
 
-t.test('get advisory about node not in tree', async t => {
-  // this should never happen, but if it does, we're prepared for it
-  const path = resolve(fixtures, 'audit-nyc-mkdirp')
-  const auditFile = resolve(path, 'audit.json')
-  t.teardown(auditResponse(auditFile))
-
-  const arb = newArb(path)
-
-  const tree = await arb.loadVirtual()
-  tree.children.get('mkdirp').parent = null
-  tree.children.get('nyc').parent = null
-  tree.children.get('minimist').parent = null
-  new Node({
-    parent: tree,
-    path: resolve(path, 'node_modules/fooo'),
-    pkg: { name: 'fooo', version: '1.2.3' },
-  })
-  tree.package = { dependencies: {
-    fooo: ''
-  }}
-
-  const report = await AuditReport.load(tree, arb.options)
-  // just a gut-check that the registry server is actually doing stuff
-  t.match(report.report, auditToBulk(require(auditFile)), 'got expected response')
-  t.equal(report.topVulns.size, 0, 'one top node found vulnerable')
-  t.equal(report.dependencyVulns.size, 0, 'dep vulns')
-  t.equal(report.advisoryVulns.size, 0, 'advisory vulns')
-  t.equal(report.size, 0, 'no vulns that were relevant')
-  t.equal(report.get('nyc'), undefined)
-  t.equal(report.get('mkdirp'), undefined)
-})
-
-t.test('metavuln where dep is not a registry dep', async t => {
-  const path = resolve(fixtures, 'minimist-git-metadep')
-  const auditFile = resolve(path, 'audit.json')
-  t.teardown(auditResponse(auditFile))
-  const arb = newArb(path)
-
-  const tree = await arb.loadVirtual()
-  const report = await AuditReport.load(tree, arb.options)
-  t.matchSnapshot(JSON.stringify(report, 0, 2), 'json version')
-
-  t.equal(report.has('@isaacs/minimist-git-dep'), true)
-  t.equal(report.has('minimist'), true)
-  t.equal(report.topVulns.has('@isaacs/minimist-git-dep'), true)
-})
-
-t.test('metavuln where a dep is not on the registry at all', async t => {
-  const path = resolve(fixtures, 'audit-missing-packument')
-  const auditFile = resolve(path, 'audit.json')
-  t.teardown(auditResponse(auditFile))
-  const arb = newArb(path)
-
-  const tree = await arb.loadVirtual()
-  const report = await AuditReport.load(tree, arb.options)
-  t.matchSnapshot(JSON.stringify(report, 0, 2), 'json version')
-
-  t.equal(report.topVulns.size, 1)
-  t.equal(report.advisoryVulns.size, 1)
-  t.equal(report.dependencyVulns.size, 1)
-})
-
-t.test('all severity levels', async t => {
-  const path = resolve(fixtures, 'audit-all-severities')
-  const auditFile = resolve(path, 'audit.json')
-  t.teardown(auditResponse(auditFile))
-  const arb = newArb(path)
-
-  const tree = await arb.loadVirtual()
-  const report = await AuditReport.load(tree, arb.options)
-  t.matchSnapshot(JSON.stringify(report, 0, 2), 'json version')
-
-  t.equal(report.topVulns.size, 2)
-  t.equal(report.advisoryVulns.size, 10)
-  t.equal(report.dependencyVulns.size, 6)
-})
-
 t.test('one vulnerability', async t => {
   const path = resolve(fixtures, 'audit-one-vuln')
   const auditFile = resolve(path, 'audit.json')
@@ -218,23 +250,6 @@ t.test('one vulnerability', async t => {
   t.matchSnapshot(JSON.stringify(report, 0, 2), 'json version')
 
   t.equal(report.topVulns.size, 0)
-  t.equal(report.advisoryVulns.size, 1)
-  t.equal(report.dependencyVulns.size, 0)
-})
-
-t.test('unfixable, but not a semver major forced fix', async t => {
-  const path = resolve(fixtures, 'mkdirp-pinned')
-  const auditFile = resolve(fixtures, 'audit-nyc-mkdirp/audit.json')
-  t.teardown(auditResponse(auditFile))
-  const arb = newArb(path)
-
-  const tree = await arb.loadVirtual()
-  const report = await AuditReport.load(tree, arb.options)
-  t.matchSnapshot(JSON.stringify(report, 0, 2), 'json version')
-
-  t.equal(report.topVulns.size, 1)
-  t.equal(report.advisoryVulns.size, 1)
-  t.equal(report.dependencyVulns.size, 1)
 })
 
 t.test('a dep vuln that also has its own advisory against it', async t => {
@@ -248,8 +263,6 @@ t.test('a dep vuln that also has its own advisory against it', async t => {
   t.matchSnapshot(JSON.stringify(report, 0, 2), 'json version')
 
   t.equal(report.topVulns.size, 0)
-  t.equal(report.advisoryVulns.size, 2)
-  t.equal(report.dependencyVulns.size, 0)
 })
 
 t.test('get default opts when loaded without opts', async t => {
@@ -309,24 +322,6 @@ t.test('omit options', async t => {
   ]
   const arb = newArb(path)
   const tree = await arb.loadVirtual()
-
-  const sortReport = report => {
-    const entries = Object.entries(report.vulnerabilities)
-    const vulns = entries.sort(([a, _], [b, $]) =>
-      a.localeCompare(b)
-    ).map(([name, vuln]) =>
-      [name, { ...vuln, via: (vuln.via || []).sort((a, b) =>
-        typeof a === 'string' && typeof b === 'string' ? a.localeCompare(b)
-        : typeof a === 'string' ? -1
-        : typeof b === 'string' ? 1
-        : a.id - b.id
-      )}]
-    )
-    report.vulnerabilities = vulns.reduce((set, [k, v]) => {
-      set[k] = v
-      return set
-    }, {})
-  }
 
   for (const omit of omits) {
     t.test(`omit=[${omit.join(',')}]`, async t => {

--- a/test/fixtures/minimist-git-dep/audit.json
+++ b/test/fixtures/minimist-git-dep/audit.json
@@ -1,48 +1,6 @@
 {
   "actions": [],
   "advisories": {
-    "42060":{
-      "findings": [
-        {
-          "version": "0.0.8",
-          "paths": [
-            "@isaacs/no-thing-here"
-          ]
-        }
-      ],
-      "id": 42069,
-      "created": "2019-09-23T15:01:43.049Z",
-      "updated": "2020-03-18T19:41:45.921Z",
-      "deleted": null,
-      "title": "Prototype Pollution",
-      "found_by": {
-        "link": "https://www.checkmarx.com/resources/blog/",
-        "name": "Checkmarx Research Team",
-        "email": ""
-      },
-      "reported_by": {
-        "link": "https://www.checkmarx.com/resources/blog/",
-        "name": "Checkmarx Research Team",
-        "email": ""
-      },
-      "module_name": "@isaacs/no-thing-here",
-      "cves": [],
-      "vulnerable_versions": "<0.2.1 || >=1.0.0 <1.2.3",
-      "patched_versions": ">=0.2.1 <1.0.0 || >=1.2.3",
-      "overview": "Affected versions of `minimist` are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of `Object`, causing the addition or modification of an existing property that will exist on all objects.  \nParsing the argument `--__proto__.y=Polluted` adds a `y` property with value `Polluted` to all objects. The argument `--__proto__=Polluted` raises and uncaught error and crashes the application.  \nThis is exploitable if attackers have control over the arguments being passed to `minimist`.\n",
-      "recommendation": "Upgrade to versions 0.2.1, 1.2.3 or later.",
-      "references": "- [GitHub commit 1](https://github.com/substack/minimist/commit/4cf1354839cb972e38496d35e12f806eea92c11f#diff-a1e0ee62c91705696ddb71aa30ad4f95)\n- [GitHub commit 2](https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94)",
-      "access": "public",
-      "severity": "low",
-      "cwe": "CWE-471",
-      "metadata": {
-        "module_type": "",
-        "exploitability": 1,
-        "affected_components": ""
-      },
-      "url": "https://npmjs.com/advisories/42069"
-
-    },
     "1179": {
       "findings": [
         {

--- a/test/fixtures/minimist-git-dep/package-lock.json
+++ b/test/fixtures/minimist-git-dep/package-lock.json
@@ -1,12 +1,30 @@
 {
   "name": "@isaacs/minimist-git-dep",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
+  "version": "1.0.2",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@isaacs/minimist-git-dep",
+      "version": "1.0.2",
+      "peerDependencies": {
+        "minimist": "github:substack/minimist#3754568bfd43a841d2d72d7fb54598635aea8fa4"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "git+ssh://git@github.com/substack/minimist.git#3754568bfd43a841d2d72d7fb54598635aea8fa4",
+      "integrity": "sha512-dYEyruIho8J+fbL60i3+R+9WbvX0YIN2uomWgCr06hT0AHu9O6BhIl5z5FRiJUgykJ1dzb092eR/FjBtnKEb8w==",
+      "license": "MIT",
+      "peer": true
+    }
+  },
   "dependencies": {
     "minimist": {
-      "version": "github:substack/minimist#3754568bfd43a841d2d72d7fb54598635aea8fa4",
-      "from": "github:substack/minimist#3754568bfd43a841d2d72d7fb54598635aea8fa4"
+      "version": "git+ssh://git@github.com/substack/minimist.git#3754568bfd43a841d2d72d7fb54598635aea8fa4",
+      "integrity": "sha512-dYEyruIho8J+fbL60i3+R+9WbvX0YIN2uomWgCr06hT0AHu9O6BhIl5z5FRiJUgykJ1dzb092eR/FjBtnKEb8w==",
+      "from": "minimist@github:substack/minimist#3754568bfd43a841d2d72d7fb54598635aea8fa4",
+      "peer": true
     }
   }
 }

--- a/test/fixtures/minimist-git-metadep/package-lock.json
+++ b/test/fixtures/minimist-git-metadep/package-lock.json
@@ -11,6 +11,7 @@
         "@isaacs/minimist-git-dep": "^1.0.0"
       }
     },
+    "node_modules/@isaacs/no-thing-here": {},
     "node_modules/@isaacs/minimist-git-dep": {
       "dev": true,
       "name": "@isaacs/minimist-git-dep",

--- a/test/vuln.js
+++ b/test/vuln.js
@@ -2,80 +2,179 @@ const t = require('tap')
 const Vuln = require('../lib/vuln.js')
 const Node = require('../lib/node.js')
 
-t.test('basic vulnerability object tests', async t => {
-  const crit = { some: 'advisory', severity: 'critical' }
-  const v = new Vuln({ name: 'name', via: crit })
-  t.isa(v, Vuln)
-  t.match(v.via, new Set([{some: 'advisory', severity: 'critical'}]))
-  t.equal(v.severity, 'critical')
-  v.addVia({ another: 'advisory', severity: 'low' })
-  t.equal(v.severity, 'critical')
-  t.match(v.via, new Set([{some: 'advisory', severity: 'critical'}, {another: 'advisory', severity: 'low'}]))
-  v.deleteVia(crit)
-  t.equal(v.severity, 'low')
-  t.match(v.via, new Set([{another: 'advisory', severity: 'low'}]))
-  v.addVia(crit)
-  t.equal(v.severity, 'critical')
-  t.match(v.via, new Set([{some: 'advisory', severity: 'critical'}, {another: 'advisory', severity: 'low'}]))
+const Calculator = require('@npmcli/metavuln-calculator')
 
-  t.matchSnapshot(JSON.stringify(v, 0, 2), 'json formatted before packument')
-  const v2 = new Vuln({ name: 'another', via: v })
-  t.match(v.effects, new Set([v2]))
-  t.match(v2.via, new Set([v]))
-  t.equal(v.range, '')
+const cache = t.testdir()
 
-  v.addRange('1.x < 1.3')
-  v.addRange('2.x < 2.3.2 || 3.x <3.0.1')
-  t.equal(v.range, '1.x < 1.3 || 2.x < 2.3.2 || 3.x <3.0.1')
-  v.packument = {
-    versions: {
-      '0.0.1': {},
-      '0.0.2': {},
-      '0.0.3': {},
-      '0.1.0': {},
-      '1.0.0': {},
-      '1.0.1': {},
-      '1.1.0': {},
-      '1.2.0': {},
-      '1.2.1': {},
-      '2.0.0': {},
-      '2.0.1': {},
-      '2.1.0': {},
-      '2.2.0': {},
-      '2.2.0-pre.0': {},
-      '3.0.0-pre.0': {},
-      '3.0.0-pre.1': {},
-      '3.0.0': {},
-      '3.0.1': {},
-      '3.1.0': {},
-      '3.2.0': {},
-    }
+const semver = require('semver')
+const semverOpt = { includePrerelease: true, loose: true }
+class MockAdvisory {
+  constructor (obj) {
+    Object.assign(this, obj)
+    this.vulnerableVersions = this.versions.filter(v =>
+      semver.satisfies(v, this.range, semverOpt))
   }
-  // when the simple range is loaded, it memoizes and sets range as well
-  t.equal(v.simpleRange, '1.0.0 - 3.0.0')
-  t.equal(v.simpleRange, '1.0.0 - 3.0.0')
-  t.equal(v.range, v.simpleRange)
+  testVersion (v) {
+    return this.vulnerableVersions.includes(v)
+  }
+}
 
-  // when we add a range, it throws away any memoized calculations
-  v.addRange('1.2.1')
-  t.equal(v.hasRange('1.2.1'), true)
-  t.equal(v.hasRange('1.2.3'), false)
-  t.equal(v.range, '1.x < 1.3 || 2.x < 2.3.2 || 3.x <3.0.1 || 1.2.1')
-  t.equal(v.simpleRange, '1.0.0 - 3.0.0')
-  t.equal(v.range, v.simpleRange)
+t.test('basic vulnerability object tests', async t => {
+  const crit = new MockAdvisory({
+    type: 'advisory',
+    source: 420,
+    id: 'cafebad',
+    title: 'borgsafalamash',
+    name: 'name',
+    dependency: 'name',
+    severity: 'critical',
+    range: '1.x < 1.3',
+    versions: [
+      '0.0.1',
+      '0.0.2',
+      '0.0.3',
+      '0.1.0',
+      '1.0.0',
+      '1.0.1',
+      '1.1.0',
+      '1.2.0',
+      '1.2.1',
+      '2.0.0',
+      '2.0.1',
+      '2.1.0',
+      '2.2.0',
+      '2.2.0-pre.0',
+      '3.0.0-pre.0',
+      '3.0.0-pre.1',
+      '3.0.0',
+      '3.0.1',
+      '3.1.0',
+      '3.2.0',
+    ],
+  })
+
+  const low = new MockAdvisory({
+    type: 'advisory',
+    source: 69,
+    id: 'deadbeef',
+    title: 'flerbygurrf',
+    name: 'name',
+    dependency: 'name',
+    severity: 'low',
+    range: '2.x < 2.3.2 || 3.x <3.0.1',
+    versions: [
+      '0.0.1',
+      '0.0.2',
+      '0.0.3',
+      '0.1.0',
+      '1.0.0',
+      '1.0.1',
+      '1.1.0',
+      '1.2.0',
+      '1.2.1',
+      '2.0.0',
+      '2.0.1',
+      '2.1.0',
+      '2.2.0',
+      '2.2.0-pre.0',
+      '3.0.0-pre.0',
+      '3.0.0-pre.1',
+      '3.0.0',
+      '3.0.1',
+      '3.1.0',
+      '3.2.0',
+    ],
+  })
+
+  const v = new Vuln({ name: 'name', advisory: crit })
+  t.isa(v, Vuln)
+  t.equal(v.testSpec('github:foo/bar'), true)
+  t.equal(v.testSpec('0.x'), false)
+  t.equal(v.testSpec('>4.x'), true)
+  t.strictSame([...v.advisories], [crit])
+  t.equal(v.severity, 'critical')
+  v.addAdvisory(low)
+  t.equal(v.testSpec('2.x'), true)
+  t.equal(v.severity, 'critical')
+  t.match(v.advisories, new Set([crit, low]))
+  v.deleteAdvisory(crit)
+  t.equal(v.severity, 'low')
+  t.match(v.advisories, new Set([low]))
+  v.addAdvisory(crit)
+  t.equal(v.severity, 'critical')
+  t.match(v.advisories, new Set([crit, low]))
+  t.matchSnapshot(JSON.stringify(v, 0, 2), 'json formatted')
+
+  const meta = new MockAdvisory({
+    type: 'metavuln',
+    source: 'deadbeef',
+    severity: 'low',
+    name: 'another',
+    dependency: 'name',
+    range: '1.x',
+    versions: [
+      '0.0.0',
+      '1.0.0',
+      '1.0.1',
+      '1.0.2',
+      '2.0.0',
+      '2.0.1',
+      '3.0.0',
+    ],
+  })
+
+  const meta2 = new MockAdvisory({
+    type: 'metavuln',
+    source: 'cafebad',
+    severity: 'critical',
+    name: 'another',
+    dependency: 'name',
+    range: '>1.0.0 <=2.0.1',
+    versions: [
+      '0.0.0',
+      '1.0.0',
+      '1.0.1',
+      '2.0.0',
+      '2.0.1',
+      '3.0.0',
+    ],
+  })
+
+  const v2 = new Vuln({ name: 'another', advisory: meta })
+  v2.addVia(v)
+  t.matchSnapshot(JSON.stringify(v), 'json after adding effect')
+  t.match(v2.advisories, new Set([meta]))
+  t.equal(v2.range, meta.range)
+
+  v2.addAdvisory(meta2)
+  t.equal(v2.range, [meta.range, meta2.range].join(' || '))
+
+  // when the simple range is loaded, it memoizes and sets range as well
+  t.equal(v2.simpleRange, '1.0.0 - 2.0.1')
+  t.equal(v2.range, v2.simpleRange)
 
   const node = new Node({
     path: '/path/to/node_modules/thing',
+    name: 'thing',
     pkg: {
       name: 'name',
       version: '1.2.1',
     },
   })
+
   // check twice to hit memoizing code path
   t.equal(v.isVulnerable(node), true)
   t.equal(v.isVulnerable(node), true)
   t.match(v.nodes, new Set([node]))
+  v2.fixAvailable = { isSemVerMajor: false }
+  t.strictSame(v.fixAvailable, { isSemVerMajor: false })
+  v2.fixAvailable = true
+  t.strictSame(v.fixAvailable, { isSemVerMajor: false })
   v2.fixAvailable = { isSemVerMajor: true }
+  t.strictSame(v.fixAvailable, { isSemVerMajor: true })
+  v2.fixAvailable = false
+  t.strictSame(v.fixAvailable, false)
+
   t.matchSnapshot(JSON.stringify(v, 0, 2), 'json formatted after loading')
   t.matchSnapshot(JSON.stringify(v2, 0, 2), 'json formatted metavuln')
 
@@ -87,4 +186,16 @@ t.test('basic vulnerability object tests', async t => {
     },
   })
   t.match(v.isVulnerable(ok), false)
+
+  const noVersion = new Node({
+    path: '/path/to/node_modules/thing',
+    pkg: {},
+  })
+  t.match(v.isVulnerable(noVersion), false, 'node without version, no opinion')
+
+
+  v2.deleteAdvisory(meta2)
+  v2.deleteAdvisory(meta)
+  t.strictSame([...v2.via], [], 'removing advisories removes via')
+  t.strictSame([...v.effects], [], 'removing via removes effect')
 })


### PR DESCRIPTION
This makes the AuditReport calculation around 40% faster in the cold
cache state, and anywhere from 90% to 99% faster with a warm cache.

It also sets the stage for the capability of doing audits without
hitting the registry, and potentially avoiding known-vulnerable package
versions if they've been previously marked and cached as vulnerable.
(This additional functionality is not implemented in this change, but
it's something we can do in the future.)

One impact is that the `Vuln` class now has an `advisories` set, as well
as a `via` set.  `vuln.advisories` is a set of advisories created by the
metavuln-calculator, which can represent either actual advisories or
metavulns.  The `via` set is a list of Vuln objects _only_, so that we
can track fixes and report on them comprehensively.

Fix: https://github.com/npm/arborist/issues/109