### PR TITLE
Add strictPeerDeps, override ERESOLVE if not true

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -86,6 +86,7 @@ const _updateFilePath = Symbol('updateFilePath')
 const _followSymlinkPath = Symbol('followSymlinkPath')
 const _getRelpathSpec = Symbol('getRelpathSpec')
 const _retrieveSpecName = Symbol('retrieveSpecName')
+const _strictPeerDeps = Symbol('strictPeerDeps')
 
 // used for the ERESOLVE error to show the last peer conflict encountered
 const _peerConflict = Symbol('peerConflict')
@@ -112,9 +113,11 @@ module.exports = cls => class IdealTreeBuilder extends cls {
       legacyPeerDeps = false,
       force = false,
       packageLock = true,
+      strictPeerDeps = false,
     } = options
 
     this[_force] = !!force
+    this[_strictPeerDeps] = !!strictPeerDeps
 
     this.idealTree = options.idealTree
     this.legacyPeerDeps = legacyPeerDeps
@@ -913,8 +916,9 @@ This is a one-time fix-up, please be patient...
         type: edge.type,
         isPeer: edge.peer,
       }
+      const override = this[_force] || !this[_strictPeerDeps]
 
-      if (this[_force] && expl.fixWithForce) {
+      if (override && expl.fixWithForce) {
         this.log.warn('ERESOLVE', 'overriding peer dependency', expl)
         return []
       } else {

--- a/lib/vuln.js
+++ b/lib/vuln.js
@@ -64,6 +64,10 @@ class Vuln {
     // - {name, version} fix requires -f, not semver major
     // - true: fix does not require -f
     for (const v of this.via) {
+      // don't blow up on loops
+      if (v.fixAvailable === f)
+        continue
+
       if (f === false)
         v.fixAvailable = f
       else if (v.fixAvailable === true)

--- a/tap-snapshots/test-arborist-build-ideal-tree.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-build-ideal-tree.js-TAP.test.js
@@ -26426,7 +26426,344 @@ Node {
 }
 `
 
+exports[`test/arborist/build-ideal-tree.js TAP override a conflict with the root dep (with force) > non-strict (default) override 1`] = `
+Node {
+  "children": Map {
+    "@isaacs/testing-peer-dep-conflict-chain-a" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+          "spec": "2",
+          "type": "prod",
+        },
+        Edge {
+          "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-e",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+          "spec": "2",
+          "type": "peer",
+        },
+        Edge {
+          "error": "INVALID",
+          "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-v",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+          "spec": "1",
+          "type": "peer",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-conflict-chain-b" => Edge {
+          "name": "@isaacs/testing-peer-dep-conflict-chain-b",
+          "spec": "2",
+          "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-b",
+          "type": "peer",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
+      "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-a/-/testing-peer-dep-conflict-chain-a-2.0.0.tgz",
+    },
+    "@isaacs/testing-peer-dep-conflict-chain-b" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-b",
+          "spec": "2",
+          "type": "peer",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-conflict-chain-c" => Edge {
+          "name": "@isaacs/testing-peer-dep-conflict-chain-c",
+          "spec": "2",
+          "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-c",
+          "type": "peer",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-b",
+      "name": "@isaacs/testing-peer-dep-conflict-chain-b",
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-b/-/testing-peer-dep-conflict-chain-b-2.0.0.tgz",
+    },
+    "@isaacs/testing-peer-dep-conflict-chain-c" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-b",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-c",
+          "spec": "2",
+          "type": "peer",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-conflict-chain-d" => Edge {
+          "name": "@isaacs/testing-peer-dep-conflict-chain-d",
+          "spec": "2",
+          "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-d",
+          "type": "peer",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-c",
+      "name": "@isaacs/testing-peer-dep-conflict-chain-c",
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-c/-/testing-peer-dep-conflict-chain-c-2.0.0.tgz",
+    },
+    "@isaacs/testing-peer-dep-conflict-chain-d" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-c",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-d",
+          "spec": "2",
+          "type": "peer",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-conflict-chain-e" => Edge {
+          "name": "@isaacs/testing-peer-dep-conflict-chain-e",
+          "spec": "2",
+          "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-e",
+          "type": "peer",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-d",
+      "name": "@isaacs/testing-peer-dep-conflict-chain-d",
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-d/-/testing-peer-dep-conflict-chain-d-2.0.0.tgz",
+    },
+    "@isaacs/testing-peer-dep-conflict-chain-e" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-d",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-e",
+          "spec": "2",
+          "type": "peer",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-conflict-chain-a" => Edge {
+          "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+          "spec": "2",
+          "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
+          "type": "peer",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-e",
+      "name": "@isaacs/testing-peer-dep-conflict-chain-e",
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-e/-/testing-peer-dep-conflict-chain-e-2.0.0.tgz",
+    },
+    "@isaacs/testing-peer-dep-conflict-chain-v" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-v",
+          "spec": "1",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-conflict-chain-a" => Edge {
+          "error": "INVALID",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+          "spec": "1",
+          "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
+          "type": "peer",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-v",
+      "name": "@isaacs/testing-peer-dep-conflict-chain-v",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-v/-/testing-peer-dep-conflict-chain-v-1.0.0.tgz",
+    },
+  },
+  "edgesOut": Map {
+    "@isaacs/testing-peer-dep-conflict-chain-a" => Edge {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+      "spec": "2",
+      "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
+      "type": "prod",
+    },
+    "@isaacs/testing-peer-dep-conflict-chain-v" => Edge {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-v",
+      "spec": "1",
+      "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-v",
+      "type": "prod",
+    },
+  },
+  "location": "",
+  "name": "override",
+  "resolved": null,
+}
+`
+
 exports[`test/arborist/build-ideal-tree.js TAP override a conflict with the root peer dep (with force) > force override 1`] = `
+Node {
+  "children": Map {
+    "@isaacs/testing-peer-dep-conflict-chain-a" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+          "spec": "2",
+          "type": "peer",
+        },
+        Edge {
+          "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-e",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+          "spec": "2",
+          "type": "peer",
+        },
+        Edge {
+          "error": "INVALID",
+          "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-v",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+          "spec": "1",
+          "type": "peer",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-conflict-chain-b" => Edge {
+          "name": "@isaacs/testing-peer-dep-conflict-chain-b",
+          "spec": "2",
+          "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-b",
+          "type": "peer",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
+      "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-a/-/testing-peer-dep-conflict-chain-a-2.0.0.tgz",
+    },
+    "@isaacs/testing-peer-dep-conflict-chain-b" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-b",
+          "spec": "2",
+          "type": "peer",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-conflict-chain-c" => Edge {
+          "name": "@isaacs/testing-peer-dep-conflict-chain-c",
+          "spec": "2",
+          "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-c",
+          "type": "peer",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-b",
+      "name": "@isaacs/testing-peer-dep-conflict-chain-b",
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-b/-/testing-peer-dep-conflict-chain-b-2.0.0.tgz",
+    },
+    "@isaacs/testing-peer-dep-conflict-chain-c" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-b",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-c",
+          "spec": "2",
+          "type": "peer",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-conflict-chain-d" => Edge {
+          "name": "@isaacs/testing-peer-dep-conflict-chain-d",
+          "spec": "2",
+          "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-d",
+          "type": "peer",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-c",
+      "name": "@isaacs/testing-peer-dep-conflict-chain-c",
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-c/-/testing-peer-dep-conflict-chain-c-2.0.0.tgz",
+    },
+    "@isaacs/testing-peer-dep-conflict-chain-d" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-c",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-d",
+          "spec": "2",
+          "type": "peer",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-conflict-chain-e" => Edge {
+          "name": "@isaacs/testing-peer-dep-conflict-chain-e",
+          "spec": "2",
+          "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-e",
+          "type": "peer",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-d",
+      "name": "@isaacs/testing-peer-dep-conflict-chain-d",
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-d/-/testing-peer-dep-conflict-chain-d-2.0.0.tgz",
+    },
+    "@isaacs/testing-peer-dep-conflict-chain-e" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-d",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-e",
+          "spec": "2",
+          "type": "peer",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-conflict-chain-a" => Edge {
+          "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+          "spec": "2",
+          "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
+          "type": "peer",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-e",
+      "name": "@isaacs/testing-peer-dep-conflict-chain-e",
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-e/-/testing-peer-dep-conflict-chain-e-2.0.0.tgz",
+    },
+    "@isaacs/testing-peer-dep-conflict-chain-v" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-v",
+          "spec": "1",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-conflict-chain-a" => Edge {
+          "error": "INVALID",
+          "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+          "spec": "1",
+          "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
+          "type": "peer",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-v",
+      "name": "@isaacs/testing-peer-dep-conflict-chain-v",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-v/-/testing-peer-dep-conflict-chain-v-1.0.0.tgz",
+    },
+  },
+  "edgesOut": Map {
+    "@isaacs/testing-peer-dep-conflict-chain-a" => Edge {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+      "spec": "2",
+      "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
+      "type": "peer",
+    },
+    "@isaacs/testing-peer-dep-conflict-chain-v" => Edge {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-v",
+      "spec": "1",
+      "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-v",
+      "type": "prod",
+    },
+  },
+  "location": "",
+  "name": "override-peer",
+  "resolved": null,
+}
+`
+
+exports[`test/arborist/build-ideal-tree.js TAP override a conflict with the root peer dep (with force) > non-strict (default) override 1`] = `
 Node {
   "children": Map {
     "@isaacs/testing-peer-dep-conflict-chain-a" => Node {

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -361,6 +361,7 @@ t.test('nested cyclical peer deps', t => {
         add: [ '@isaacs/peer-dep-cycle-c@2.x' ],
       }), 'upgrade c'))
       .then(() => t.rejects(printIdeal(path, {
+        strictPeerDeps: true,
         add: [
           '@isaacs/peer-dep-cycle-a@1.x',
           '@isaacs/peer-dep-cycle-c@2.x',
@@ -455,7 +456,7 @@ t.test('bundle deps example 2', t => {
 t.test('unresolveable peer deps', t => {
   const path = resolve(fixtures, 'testing-peer-deps-unresolvable')
 
-  return t.rejects(printIdeal(path), {
+  return t.rejects(printIdeal(path, { strictPeerDeps: true }), {
     message: 'unable to resolve dependency tree',
     code: 'ERESOLVE',
     dep: {
@@ -1496,7 +1497,7 @@ This is a one-time fix-up, please be patient...
 
 t.test('override a conflict with the root dep (with force)', async t => {
   const path = resolve(fixtures, 'testing-peer-dep-conflict-chain/override')
-  await t.rejects(() => buildIdeal(path), {
+  await t.rejects(() => buildIdeal(path, { strictPeerDeps: true }), {
     code: 'ERESOLVE',
     dep: {
       name: '@isaacs/testing-peer-dep-conflict-chain-a',
@@ -1542,12 +1543,13 @@ t.test('override a conflict with the root dep (with force)', async t => {
     type: 'peer',
     isPeer: true
   })
-  t.matchSnapshot(await printIdeal(path, { force: true }), 'force override')
+  t.matchSnapshot(await printIdeal(path, { strictPeerDeps: true, force: true }), 'force override')
+  t.matchSnapshot(await printIdeal(path, { strictPeerDeps: false }), 'non-strict (default) override')
 })
 
 t.test('override a conflict with the root peer dep (with force)', async t => {
   const path = resolve(fixtures, 'testing-peer-dep-conflict-chain/override-peer')
-  await t.rejects(() => buildIdeal(path), {
+  await t.rejects(() => buildIdeal(path, { strictPeerDeps: true }), {
     code: 'ERESOLVE',
     dep: {
       name: '@isaacs/testing-peer-dep-conflict-chain-a',
@@ -1593,7 +1595,8 @@ t.test('override a conflict with the root peer dep (with force)', async t => {
     type: 'peer',
     isPeer: true
   })
-  t.matchSnapshot(await printIdeal(path, { force: true }), 'force override')
+  t.matchSnapshot(await printIdeal(path, { strictPeerDeps: true, force: true }), 'force override')
+  t.matchSnapshot(await printIdeal(path, { strictPeerDeps: false }), 'non-strict (default) override')
 })
 
 t.test('push conflicted peer deps deeper in to the tree to solve', async t => {

--- a/test/vuln.js
+++ b/test/vuln.js
@@ -166,6 +166,14 @@ t.test('basic vulnerability object tests', async t => {
   t.equal(v.isVulnerable(node), true)
   t.equal(v.isVulnerable(node), true)
   t.match(v.nodes, new Set([node]))
+
+  // make sure we don't infinitely loop when setting it to true
+  v.addVia(v2)
+  v2.fixAvailable = true
+  v.fixAvailable = true
+  v2.fixAvailable = true
+  v.deleteVia(v2)
+
   v2.fixAvailable = { isSemVerMajor: false }
   t.strictSame(v.fixAvailable, { isSemVerMajor: false })
   v2.fixAvailable = true
@@ -192,7 +200,6 @@ t.test('basic vulnerability object tests', async t => {
     pkg: {},
   })
   t.match(v.isVulnerable(noVersion), false, 'node without version, no opinion')
-
 
   v2.deleteAdvisory(meta2)
   v2.deleteAdvisory(meta)


### PR DESCRIPTION
In the overwhelming majority of cases in the wild, a peer dependency
conflict that results in an ERESOLVE can be fixed by using the
`--force` flag.

However, this has other side effects (causing `npm audit fix` to install
semver-major fixes, blowing away file collisions, etc.) which might not
be desirable.  Also, since it's opt-in, it means that users have to run
the install twice for something where we're _pretty_ sure what the right
course of action is.

Let's just make that particular override the default, and reduce most
ERESOLVE errors from a crash to a warning.

(Also, a dumb fix for vuln, should probably pull that in regardless of where we land on this.)

cc: @MylesBorins 