### PR TITLE
fix: should not count omitted optional deps in diff

### DIFF
--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -204,6 +204,7 @@ module.exports = cls => class Reifier extends cls {
     this.diff = Diff.calculate({
       actual: this.actualTree,
       ideal: this.idealTree,
+      omitOptional: this[_omitOptional],
     })
 
     for (const node of this.diff.removed) {

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -10,7 +10,7 @@ const {depth} = require('treeverse')
 const ssri = require('ssri')
 
 class Diff {
-  constructor ({actual, ideal}) {
+  constructor ({actual, ideal, omitOptional}) {
     this.children = []
     this.actual = actual
     this.ideal = ideal
@@ -18,7 +18,7 @@ class Diff {
       this.resolved = this.ideal.resolved
       this.integrity = this.ideal.integrity
     }
-    this.action = getAction(this)
+    this.action = getAction({omitOptional})(this)
     this.parent = null
     // the set of leaf nodes that we rake up to the top level
     this.leaves = []
@@ -28,22 +28,22 @@ class Diff {
     this.removed = []
   }
 
-  static calculate ({actual, ideal}) {
+  static calculate ({actual, ideal, omitOptional}) {
     return depth({
-      tree: new Diff({actual, ideal}),
-      getChildren,
+      tree: new Diff({actual, ideal, omitOptional}),
+      getChildren: getChildren({ omitOptional }),
       leave,
     })
   }
 }
 
-const getAction = ({actual, ideal}) =>
+const getAction = ({omitOptional}) => ({actual, ideal}) =>
   !ideal ? 'REMOVE'
   // bundled meta-deps are copied over to the ideal tree when we visit it,
   // so they'll appear to be missing here.  There's no need to handle them
   // in the diff, though, because they'll be replaced at reify time anyway
   // Otherwise, add the missing node.
-  : !actual ? (ideal.inDepBundle ? null : 'ADD')
+  : !actual ? ((omitOptional && ideal.optional) || ideal.inDepBundle ? null : 'ADD')
   // always ignore the root node
   : ideal.isRoot && actual.isRoot ||
   // top nodes, links, and git deps won't have integrity, but do have resolved
@@ -72,7 +72,7 @@ const allChildren = node => {
 
 // functions for the walk options when we traverse the trees
 // to create the diff tree
-const getChildren = diff => {
+const getChildren = ({ omitOptional }) => diff => {
   const children = []
   const {unchanged, removed} = diff
 
@@ -87,7 +87,14 @@ const getChildren = diff => {
   for (const path of paths) {
     const actual = actualKids.get(path)
     const ideal = idealKids.get(path)
-    diffNode(actual, ideal, children, unchanged, removed)
+    diffNode({
+      actual,
+      ideal,
+      children,
+      unchanged,
+      removed,
+      omitOptional
+    })
   }
 
 
@@ -97,8 +104,15 @@ const getChildren = diff => {
   return children
 }
 
-const diffNode = (actual, ideal, children, unchanged, removed) => {
-  const action = getAction({actual, ideal})
+const diffNode = ({
+  actual,
+  ideal,
+  children,
+  unchanged,
+  removed,
+  omitOptional
+}) => {
+  const action = getAction({omitOptional})({actual, ideal})
 
   // if it's a match, then get its children
   // otherwise, this is the child diff node
@@ -137,7 +151,7 @@ const diffNode = (actual, ideal, children, unchanged, removed) => {
         node.parent = ideal
       }
     }
-    children.push(...getChildren({actual, ideal, unchanged, removed}))
+    children.push(...getChildren({omitOptional})({actual, ideal, unchanged, removed}))
   }
 }
 

--- a/tap-snapshots/test-diff.js-TAP.test.js
+++ b/tap-snapshots/test-diff.js-TAP.test.js
@@ -246,3 +246,44 @@ Diff {
   ],
 }
 `
+
+exports[`test/diff.js TAP omitOptional > diff two trees 1`] = `
+Diff {
+  "action": null,
+  "actual": Node {
+    "name": "a",
+    "path": "/path/to/root",
+    "integrity": "sha512-aaa",
+  },
+  "ideal": Node {
+    "name": "a",
+    "path": "/path/to/root",
+    "integrity": "sha512-aaa",
+  },
+  "leaves": Array [
+    "/path/to/root/node_modules/p",
+  ],
+  "unchanged": Array [
+    "/path/to/root/node_modules/b",
+    "/path/to/root/node_modules/x",
+  ],
+  "removed": Array [],
+  "children": Array [
+    Diff {
+      "action": "ADD",
+      "actual": undefined,
+      "ideal": Node {
+        "name": "p",
+        "path": "/path/to/root/node_modules/p",
+        "integrity": "sha512-ppp",
+      },
+      "leaves": Array [
+        "/path/to/root/node_modules/p",
+      ],
+      "unchanged": Array [],
+      "removed": Array [],
+      "children": Array [],
+    },
+  ],
+}
+`

--- a/test/diff.js
+++ b/test/diff.js
@@ -165,3 +165,49 @@ t.matchSnapshot(d, 'diff two trees')
 t.equal(d.parent, null, 'root has no parent')
 t.equal([...d.children][0].parent, d, 'parent of root child is root')
 t.equal(d.action, null, 'root has no action')
+
+t.test('omitOptional', t => {
+  const actual = new Node({
+    name: 'a',
+    path: '/path/to/root',
+    realpath: '/path/to/root',
+    integrity: 'sha512-aaa',
+    fsChildren: [],
+    children: [
+      {
+        name: 'b',
+        integrity: 'sha512-bbb',
+        children: [],
+      }
+    ]
+  })
+  const ideal = new Node({
+    name: 'a',
+    path: '/path/to/root',
+    realpath: '/path/to/root',
+    integrity: 'sha512-aaa',
+    fsChildren: [],
+    children: [
+      {
+        name: 'b',
+        integrity: 'sha512-bbb',
+        children: [],
+      },
+      {
+        name: 'x',
+        integrity: 'sha512-xxx',
+        optional: true,
+        children: [],
+      },
+      {
+        name: 'p',
+        integrity: 'sha512-ppp',
+        optional: false,
+        children: [],
+      }
+    ]
+  })
+  const d = Diff.calculate({actual, ideal, omitOptional: true})
+  t.matchSnapshot(d, 'diff two trees')
+  t.end()
+})


### PR DESCRIPTION
When using `omit: 'optional'` option the reify diff should not count
optional deps into its diff tree.

Fix: https://github.com/npm/cli/issues/1813
