### PR TITLE
Don't automatically install optional peer dependencies

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -768,12 +768,43 @@ This is a one-time fix-up, please be patient...
     const bundled = new Set(bd || [])
 
     return [...node.edgesOut.values()]
-      .filter(edge => !bundled.has(edge.name) &&
-        !(edge.to && this[_loadFailures].has(edge.to)) &&
-        !(edge.to && edge.to.inShrinkwrap) &&
-        (!edge.valid || !edge.to || this[_updateNames].includes(edge.name) ||
-          this[_isVulnerable](edge.to) ||
-          node.isRoot && this[_explicitRequests].has(edge.name)))
+      .filter(edge => {
+
+        // If it's included in a bundle, we take whatever is specified.
+        if (bundled.has(edge.name))
+          return false
+
+        // If it's already been logged as a load failure, skip it.
+        if (edge.to && this[_loadFailures].has(edge.to))
+          return false
+
+        // If it's shrinkwrapped, we use what the shrinkwap wants.
+        if (edge.to && edge.to.inShrinkwrap)
+          return false
+
+        // If the edge has an error, there's a problem.
+        if (!edge.valid)
+          return true
+
+        // If the edge has no destination, that's a problem.
+        if (!edge.to)
+          return true
+
+        // If user has explicitly asked to update this package by name, it's a problem.
+        if (this[_updateNames].includes(edge.name))
+          return true
+
+        // If we're fixing a security vulnerability with this package, it's a problem.
+        if (this[_isVulnerable](edge.to))
+          return true
+
+        // If the user has explicitly asked to install this package, it's a problem.
+        if (node.isRoot && this[_explicitRequests].has(edge.name))
+          return true
+
+        // No problems!
+        return false
+      })
   }
 
   async [_fetchManifest] (spec) {

--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -787,8 +787,9 @@ This is a one-time fix-up, please be patient...
           return true
 
         // If the edge has no destination, that's a problem.
-        if (!edge.to)
-          return true
+        if (!edge.to) {
+          return edge.type !== 'peerOptional'
+        }
 
         // If user has explicitly asked to update this package by name, it's a problem.
         if (this[_updateNames].includes(edge.name))

--- a/tap-snapshots/test-arborist-build-ideal-tree.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-build-ideal-tree.js-TAP.test.js
@@ -28328,52 +28328,6 @@ Node {
       "name": "@types/color-name",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
     },
-    "@types/prop-types" => Node {
-      "dev": true,
-      "edgesIn": Set {
-        Edge {
-          "from": "node_modules/@types/react",
-          "name": "@types/prop-types",
-          "spec": "*",
-          "type": "prod",
-        },
-      },
-      "location": "node_modules/@types/prop-types",
-      "name": "@types/prop-types",
-      "optional": true,
-      "peer": true,
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-    },
-    "@types/react" => Node {
-      "dev": true,
-      "edgesIn": Set {
-        Edge {
-          "from": "node_modules/tap/node_modules/ink",
-          "name": "@types/react",
-          "spec": ">=16.8.0",
-          "type": "peerOptional",
-        },
-      },
-      "edgesOut": Map {
-        "@types/prop-types" => Edge {
-          "name": "@types/prop-types",
-          "spec": "*",
-          "to": "node_modules/@types/prop-types",
-          "type": "prod",
-        },
-        "csstype" => Edge {
-          "name": "csstype",
-          "spec": "^2.2.0",
-          "to": "node_modules/csstype",
-          "type": "prod",
-        },
-      },
-      "location": "node_modules/@types/react",
-      "name": "@types/react",
-      "optional": true,
-      "peer": true,
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.19.tgz",
-    },
     "ajv" => Node {
       "dev": true,
       "edgesIn": Set {
@@ -29760,22 +29714,6 @@ Node {
       "location": "node_modules/cross-spawn",
       "name": "cross-spawn",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-    },
-    "csstype" => Node {
-      "dev": true,
-      "edgesIn": Set {
-        Edge {
-          "from": "node_modules/@types/react",
-          "name": "csstype",
-          "spec": "^2.2.0",
-          "type": "prod",
-        },
-      },
-      "location": "node_modules/csstype",
-      "name": "csstype",
-      "optional": true,
-      "peer": true,
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
     },
     "dashdash" => Node {
       "dev": true,
@@ -35253,7 +35191,7 @@ Node {
             "@types/react" => Edge {
               "name": "@types/react",
               "spec": ">=16.8.0",
-              "to": "node_modules/@types/react",
+              "to": null,
               "type": "peerOptional",
             },
             "ansi-escapes" => Edge {
@@ -49434,52 +49372,6 @@ Node {
       "name": "@types/color-name",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
     },
-    "@types/prop-types" => Node {
-      "edgesIn": Set {
-        Edge {
-          "from": "node_modules/@types/react",
-          "name": "@types/prop-types",
-          "spec": "*",
-          "type": "prod",
-        },
-      },
-      "location": "node_modules/@types/prop-types",
-      "name": "@types/prop-types",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-    },
-    "@types/react" => Node {
-      "edgesIn": Set {
-        Edge {
-          "from": "node_modules/ink",
-          "name": "@types/react",
-          "spec": ">=16.8.0",
-          "type": "peerOptional",
-        },
-        Edge {
-          "from": "node_modules/tap",
-          "name": "@types/react",
-          "spec": "^16.9.16",
-          "type": "prod",
-        },
-      },
-      "edgesOut": Map {
-        "@types/prop-types" => Edge {
-          "name": "@types/prop-types",
-          "spec": "*",
-          "to": "node_modules/@types/prop-types",
-          "type": "prod",
-        },
-        "csstype" => Edge {
-          "name": "csstype",
-          "spec": "^2.2.0",
-          "to": "node_modules/csstype",
-          "type": "prod",
-        },
-      },
-      "location": "node_modules/@types/react",
-      "name": "@types/react",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.19.tgz",
-    },
     "ajv" => Node {
       "edgesIn": Set {
         Edge {
@@ -50833,19 +50725,6 @@ Node {
       "name": "cross-spawn",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
     },
-    "csstype" => Node {
-      "edgesIn": Set {
-        Edge {
-          "from": "node_modules/@types/react",
-          "name": "csstype",
-          "spec": "^2.2.0",
-          "type": "prod",
-        },
-      },
-      "location": "node_modules/csstype",
-      "name": "csstype",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
-    },
     "dashdash" => Node {
       "edgesIn": Set {
         Edge {
@@ -51957,7 +51836,7 @@ Node {
         "@types/react" => Edge {
           "name": "@types/react",
           "spec": ">=16.8.0",
-          "to": "node_modules/@types/react",
+          "to": null,
           "type": "peerOptional",
         },
         "ansi-escapes" => Edge {
@@ -55874,9 +55753,10 @@ Node {
       },
       "edgesOut": Map {
         "@types/react" => Edge {
+          "error": "MISSING",
           "name": "@types/react",
           "spec": "^16.9.16",
-          "to": "node_modules/@types/react",
+          "to": null,
           "type": "prod",
         },
         "async-hook-domain" => Edge {
@@ -57927,50 +57807,6 @@ Node {
       "name": "@types/color-name",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
     },
-    "@types/prop-types" => Node {
-      "edgesIn": Set {
-        Edge {
-          "from": "node_modules/@types/react",
-          "name": "@types/prop-types",
-          "spec": "*",
-          "type": "prod",
-        },
-      },
-      "location": "node_modules/@types/prop-types",
-      "name": "@types/prop-types",
-      "optional": true,
-      "peer": true,
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-    },
-    "@types/react" => Node {
-      "edgesIn": Set {
-        Edge {
-          "from": "node_modules/ink",
-          "name": "@types/react",
-          "spec": ">=16.8.0",
-          "type": "peerOptional",
-        },
-      },
-      "edgesOut": Map {
-        "@types/prop-types" => Edge {
-          "name": "@types/prop-types",
-          "spec": "*",
-          "to": "node_modules/@types/prop-types",
-          "type": "prod",
-        },
-        "csstype" => Edge {
-          "name": "csstype",
-          "spec": "^2.2.0",
-          "to": "node_modules/csstype",
-          "type": "prod",
-        },
-      },
-      "location": "node_modules/@types/react",
-      "name": "@types/react",
-      "optional": true,
-      "peer": true,
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.19.tgz",
-    },
     "ajv" => Node {
       "edgesIn": Set {
         Edge {
@@ -59298,21 +59134,6 @@ Node {
       "name": "cross-spawn",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
     },
-    "csstype" => Node {
-      "edgesIn": Set {
-        Edge {
-          "from": "node_modules/@types/react",
-          "name": "csstype",
-          "spec": "^2.2.0",
-          "type": "prod",
-        },
-      },
-      "location": "node_modules/csstype",
-      "name": "csstype",
-      "optional": true,
-      "peer": true,
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
-    },
     "dashdash" => Node {
       "edgesIn": Set {
         Edge {
@@ -60368,7 +60189,7 @@ Node {
         "@types/react" => Edge {
           "name": "@types/react",
           "spec": ">=16.8.0",
-          "to": "node_modules/@types/react",
+          "to": null,
           "type": "peerOptional",
         },
         "ansi-escapes" => Edge {


### PR DESCRIPTION
So installing ORMs doesn't install every database driver ever.

## References
https://github.com/npm/rfcs/pull/224