### PR TITLE
chore: pruner should use _idealTreePrune

### DIFF
--- a/lib/arborist/pruner.js
+++ b/lib/arborist/pruner.js
@@ -1,14 +1,14 @@
+const _idealTreePrune = Symbol.for('idealTreePrune')
+
 module.exports = cls => class Pruner extends cls {
   async prune (options = {}) {
     // allow the user to set options on the ctor as well.
     // XXX: deprecate separate method options objects.
     options = { ...this.options, ...options }
 
-    const tree = await this.buildIdealTree(options)
-    const extraneousNodes = tree.inventory.filter(n => n.extraneous)
+    await this.buildIdealTree(options)
 
-    for (const node of extraneousNodes)
-      node.parent = null
+    this[_idealTreePrune]()
 
     return this.reify(options)
   }


### PR DESCRIPTION
Caught this small TODO refactor while I was debugging stuff and thought I might as well just send a PR right away 😊 

`_idealTreePrune` symbol was already shared but not used anywhere else, while `lib/arborist/pruner.js` had the duplicated code just there...
