### PR TITLE
fix: package-lock.json custom indentation

### DIFF
--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -865,7 +865,11 @@ module.exports = cls => class Reifier extends cls {
     const json = (JSON.stringify(pjData, null, format) + '\n')
       .replace(/\n/g, eol)
 
-    const saveOpt = { format: this[_formatPackageLock] }
+    const saveOpt = {
+      format: (this[_formatPackageLock] && format)
+        ? format
+        : this[_formatPackageLock]
+    }
     return Promise.all([
       this[_usePackageLock] && this.idealTree.meta.save(saveOpt),
       writeFile(pj, json),

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -914,7 +914,12 @@ class Shrinkwrap {
       throw new Error('run load() before saving data')
 
     const { format = true } = options
-    const indent = format ? this.indent || 2 : 0
+    const defaultIndent = this.indent || 2
+    const indent = format === true
+      ? defaultIndent
+      : format
+        ? format
+        : 0
     const eol = format ? this.newline || '\n' : ''
     const data = this.commit()
     const json = stringify(data, swKeyOrder, indent).replace(/\n/g, eol)

--- a/tap-snapshots/test-arborist-reify.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-reify.js-TAP.test.js
@@ -27084,6 +27084,48 @@ Object {
 }
 `
 
+exports[`test/arborist/reify.js TAP store files with a custom indenting > must match snapshot 1`] = `
+{
+	"name": "tab-indented-package-json",
+	"version": "1.0.0",
+	"dependencies": {
+		"abbrev": "^1.0.0"
+	}
+}
+
+`
+
+exports[`test/arborist/reify.js TAP store files with a custom indenting > must match snapshot 2`] = `
+{
+	"name": "tab-indented-package-json",
+	"version": "1.0.0",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "tab-indented-package-json",
+			"version": "1.0.0",
+			"dependencies": {
+				"abbrev": "^1.0.0"
+			}
+		},
+		"node_modules/abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+		}
+	},
+	"dependencies": {
+		"abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+		}
+	}
+}
+
+`
+
 exports[`test/arborist/reify.js TAP tarball deps with transitive tarball deps > expect resolving Promise 1`] = `
 Node {
   "children": Map {

--- a/tap-snapshots/test-shrinkwrap.js-TAP.test.js
+++ b/tap-snapshots/test-shrinkwrap.js-TAP.test.js
@@ -14276,6 +14276,16 @@ Object {
 }
 `
 
+exports[`test/shrinkwrap.js TAP saving dependency-free shrinkwrap object load file, and save it with a custom format > custom indented json output 1`] = `
+{
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {},
+	"dependencies": {}
+}
+
+`
+
 exports[`test/shrinkwrap.js TAP saving dependency-free shrinkwrap object load the unindented file, and save it back default > indented json output 1`] = `
 {
   "lockfileVersion": 2,

--- a/test/arborist/reify.js
+++ b/test/arborist/reify.js
@@ -1025,6 +1025,20 @@ t.test('add a dep present in the tree, with v1 shrinkwrap', async t => {
   t.matchSnapshot(fs.readFileSync(path + '/package.json', 'utf8'))
 })
 
+t.test('store files with a custom indenting', async t => {
+  const tabIndentedPackageJson =
+    fs.readFileSync(
+      resolve(__dirname, '../fixtures/tab-indented-package-json/package.json'),
+      'utf8'
+    )
+  const path = t.testdir({
+    'package.json': tabIndentedPackageJson
+  })
+  const tree = await reify(path)
+  t.matchSnapshot(fs.readFileSync(path + '/package.json', 'utf8'))
+  t.matchSnapshot(fs.readFileSync(path + '/package-lock.json', 'utf8'))
+})
+
 t.test('modules bundled by the root should be installed', async t => {
   const path = fixture(t, 'root-bundler')
   const tree = await reify(path)

--- a/test/fixtures/tab-indented-package-json/package.json
+++ b/test/fixtures/tab-indented-package-json/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "tab-indented-package-json",
+	"version": "1.0.0",
+	"dependencies": {
+		"abbrev": "^1.0.0"
+	}
+}

--- a/test/shrinkwrap.js
+++ b/test/shrinkwrap.js
@@ -438,6 +438,17 @@ t.test('saving dependency-free shrinkwrap object', t => {
     t.matchSnapshot(fs.readFileSync(sw.filename, 'utf8'), 'indented json output')
   })
 
+  t.test('load file, and save it with a custom format', async t => {
+    const sw = await Shrinkwrap.load({ path: dir })
+    t.equal(
+      sw.filename,
+      resolve(`${dir}/package-lock.json`),
+      'correct filepath on shrinkwrap instance'
+    )
+    await sw.save({ format: '\t' })
+    t.matchSnapshot(fs.readFileSync(sw.filename, 'utf8'), 'custom indented json output')
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
`package-lock.json` files should follow the same indentation used on `package.json` files.

This commit fixes the issue by forwarding the proper indent selected for `package.json` to `Shrinkwarp.save` method. Also, added tests asserting appropriate tab-indentation for both files.

Fixes: https://github.com/npm/cli/issues/1662