### PR TITLE
Save provided range if not a subset of savePrefix

### DIFF
--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -4,6 +4,7 @@ const pacote = require('pacote')
 const rpj = require('read-package-json-fast')
 const { orderDeps, updateDepSpec } = require('../dep-spec.js')
 const AuditReport = require('../audit-report.js')
+const {subset} = require('semver')
 
 const {dirname, resolve, relative} = require('path')
 const {depth: dfwalk} = require('treeverse')
@@ -788,12 +789,21 @@ module.exports = cls => class Reifier extends cls {
       const root = this.idealTree
       const pkg = root.package
       for (const req of this[_resolvedAdd]) {
-        const {name} = req
+        const {name, rawSpec, subSpec} = req
+        const spec = subSpec ? subSpec.rawSpec : rawSpec
         const child = root.children.get(name)
 
         if (req.registry) {
           const version = child.version
-          const range = this[_savePrefix] + version
+          const prefixRange = this[_savePrefix] + version
+          // if we installed a range, then we save the range specified
+          // if it is not a subset of the ^x.y.z.  eg, installing a range
+          // of `1.x <1.2.3` will not be saved as `^1.2.0`, because that
+          // would allow versions outside the requested range.  Tags and
+          // specific versions save with the save-prefix.
+          const isRange = (subSpec || req).type === 'range'
+          const range = !isRange || subset(prefixRange, spec, { loose: true })
+            ? prefixRange : spec
           const pname = child.package.name
           const alias = name !== pname
           updateDepSpec(pkg, name, (alias ? `npm:${pname}@` : '') + range)

--- a/tap-snapshots/test-arborist-reify.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-reify.js-TAP.test.js
@@ -27051,7 +27051,7 @@ Object {
       "dependencies": Object {
         "a": "github:foo/bar#baz",
         "b": "^1.2.3",
-        "d": "npm:c@^1.2.3",
+        "d": "npm:c@1.x <1.9.9",
       },
       "devDependencies": Object {
         "c": "git+ssh://git@githost.com:a/b/c.git#master",

--- a/test/arborist/reify.js
+++ b/test/arborist/reify.js
@@ -816,7 +816,7 @@ t.test('saving the ideal tree', t => {
       dependencies: {
         a: 'git+ssh://git@github.com:foo/bar#baz',
         b: '',
-        d: 'd@npm:c@1.x',
+        d: 'd@npm:c@1.x <1.9.9',
       },
       devDependencies: {
         c: `git+ssh://git@githost.com:a/b/c.git#master`,
@@ -870,7 +870,7 @@ t.test('saving the ideal tree', t => {
       a[kResolvedAdd] = [
         npa('a@git+ssh://git@github.com:foo/bar#baz'),
         npa('b'),
-        npa('d@npm:c@1.x'),
+        npa('d@npm:c@1.x <1.9.9'),
         npa(`c@git+ssh://git@githost.com:a/b/c.git#master`),
       ]
       return a[kSaveIdealTree]({
@@ -883,7 +883,7 @@ t.test('saving the ideal tree', t => {
         dependencies: {
           a: 'github:foo/bar#baz',
           b: '^1.2.3',
-          d: 'npm:c@^1.2.3',
+          d: 'npm:c@1.x <1.9.9',
         },
         devDependencies: {
           c: 'git+ssh://git@githost.com:a/b/c.git#master',


### PR DESCRIPTION
based on #144, land that first.

Save provided range if not a subset of savePrefix

If a user installs `foo@1.x <1.2.3`, and we resolve to `1.2.2`, then we
should not save it as `^1.2.2`, since that would allow versions outside
of the requested range.

Explicit versions and tags are still saved using the savePrefix, since
those are not ranges, and users can set `--save-exact` if they wish it
to be saved exactly.

Fix: https://github.com/npm/arborist/issues/127
Fix: https://github.com/npm/cli/pull/193
Fix: https://npm.community/t/7005
