### PR TITLE
Respect gypfile:false flag in package.json

### DIFF
--- a/test/arborist/rebuild.js
+++ b/test/arborist/rebuild.js
@@ -350,10 +350,10 @@ t.test('rebuild node-gyp dependencies lacking both preinstall and install script
   const path = t.testdir({
     node_modules: {
       dep: {
-        'package.json': {
+        'package.json': JSON.stringify({
           name: 'dep',
           version: '1.0.0',
-        },
+        }),
         'binding.gyp': '',
       },
     },
@@ -384,4 +384,34 @@ t.test('rebuild node-gyp dependencies lacking both preinstall and install script
       scriptShell: undefined
     }
   ])
+})
+
+t.test('do not rebuild node-gyp dependencies with gypfile:false', async t => {
+  // use require-inject so we don't need an actual massive binary dep fixture
+  const RUNS = []
+  const Arborist = requireInject('../../lib/arborist/index.js', {
+    '@npmcli/run-script': async opts => {
+      throw new Error('should not run any scripts')
+    }
+  })
+  const path = t.testdir({
+    node_modules: {
+      dep: {
+        'package.json': JSON.stringify({
+          name: 'dep',
+          version: '1.0.0',
+          gypfile: false,
+        }),
+        'binding.gyp': '',
+      },
+    },
+    'package.json': JSON.stringify({
+      name: 'project',
+      dependencies: {
+        dep: '1',
+      },
+    })
+  })
+  const arb = new Arborist({ path, registry })
+  await arb.rebuild()
 })


### PR DESCRIPTION
This does a couple of things:

1. Explicitly add a flag in _addToBuildSet to indicate that we've
   already checked this node.  This _should_ be unnecessary, but it's
   possible that we have no script and still need to check for a gypfile
   when we have old metadata, so this addresses the edge case there, and
   makes the logic a little clearer.
2. Use the defaultGypInstallScript from the @npmcli/node-gyp package,
   rather than a hard-coded string.
3. Handle cases where there are bins and also a default node-gyp script.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
