### PR TITLE
fix: workspaces cleaning up nm folders

### DIFF
--- a/lib/arborist/index.js
+++ b/lib/arborist/index.js
@@ -35,6 +35,7 @@ const mixins = [
   require('./deduper.js'),
   require('./audit.js'),
   require('./build-ideal-tree.js'),
+  require('./load-workspaces.js'),
   require('./load-actual.js'),
   require('./load-virtual.js'),
   require('./rebuild.js'),

--- a/lib/arborist/load-virtual.js
+++ b/lib/arborist/load-virtual.js
@@ -1,7 +1,6 @@
 // mixin providing the loadVirtual method
 
 const {dirname, resolve} = require('path')
-const mapWorkspaces = require('@npmcli/map-workspaces')
 const walkUp = require('walk-up-path')
 
 const nameFromFolder = require('@npmcli/name-from-folder')
@@ -20,7 +19,8 @@ const assignParentage = Symbol('assignParentage')
 const loadRoot = Symbol('loadRoot')
 const loadNode = Symbol('loadVirtualNode')
 const loadLink = Symbol('loadVirtualLink')
-const loadWorkspaces = Symbol('loadWorkspaces')
+const loadWorkspaces = Symbol.for('loadWorkspaces')
+const loadWorkspacesVirtual = Symbol.for('loadWorkspacesVirtual')
 const flagsSuspect = Symbol.for('flagsSuspect')
 const reCalcDepFlags = Symbol('reCalcDepFlags')
 const checkRootEdges = Symbol('checkRootEdges')
@@ -131,7 +131,7 @@ module.exports = cls => class VirtualLoader extends cls {
       delete prod[name]
 
     const lockWS = []
-    const workspaces = mapWorkspaces.virtual({
+    const workspaces = this[loadWorkspacesVirtual]({
       cwd: this.path,
       lockfile: s.data,
     })
@@ -267,16 +267,6 @@ module.exports = cls => class VirtualLoader extends cls {
     node.peer = !!sw.peer
     node.optional = !!sw.optional
     node.dev = !!sw.dev
-    return node
-  }
-
-  async [loadWorkspaces] (node) {
-    const workspaces = await mapWorkspaces({
-      cwd: node.path,
-      pkg: node.package,
-    })
-    if (workspaces.size)
-      node.workspaces = workspaces
     return node
   }
 

--- a/lib/arborist/load-workspaces.js
+++ b/lib/arborist/load-workspaces.js
@@ -1,0 +1,31 @@
+const mapWorkspaces = require('@npmcli/map-workspaces')
+
+const _appendWorkspaces = Symbol('appendWorkspaces')
+// shared ref used by other mixins/Arborist
+const _loadWorkspaces = Symbol.for('loadWorkspaces')
+const _loadWorkspacesVirtual = Symbol.for('loadWorkspacesVirtual')
+
+module.exports = cls => class MapWorkspaces extends cls {
+  [_appendWorkspaces] (node, workspaces) {
+    if (node && workspaces.size)
+      node.workspaces = workspaces
+
+    return node
+  }
+
+  async [_loadWorkspaces] (node) {
+    if (node.workspaces)
+      return node
+
+    const workspaces = await mapWorkspaces({
+      cwd: node.path,
+      pkg: node.package,
+    })
+
+    return this[_appendWorkspaces](node, workspaces)
+  }
+
+  [_loadWorkspacesVirtual] (opts) {
+    return mapWorkspaces.virtual(opts)
+  }
+}

--- a/tap-snapshots/test-arborist-reify.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-reify.js-TAP.test.js
@@ -45648,6 +45648,110 @@ Node {
 }
 `
 
+exports[`test/arborist/reify.js TAP workspaces reify from an actual loaded workspace env > should not clean up entire nm folder for no reason 1`] = `
+Node {
+  "children": Map {
+    "@ruyadorno/dep-bar" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "a",
+          "name": "@ruyadorno/dep-bar",
+          "spec": "^1.0.0",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "@ruyadorno/dep-foo" => Edge {
+          "name": "@ruyadorno/dep-foo",
+          "spec": "^1.0.0",
+          "to": "node_modules/@ruyadorno/dep-foo",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@ruyadorno/dep-bar",
+      "name": "@ruyadorno/dep-bar",
+      "resolved": "https://registry.npmjs.org/@ruyadorno/dep-bar/-/dep-bar-1.0.0.tgz",
+    },
+    "@ruyadorno/dep-foo" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@ruyadorno/dep-bar",
+          "name": "@ruyadorno/dep-foo",
+          "spec": "^1.0.0",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@ruyadorno/dep-foo",
+      "name": "@ruyadorno/dep-foo",
+      "resolved": "https://registry.npmjs.org/@ruyadorno/dep-foo/-/dep-foo-1.0.0.tgz",
+    },
+    "abbrev" => Node {
+      "dev": true,
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "abbrev",
+          "spec": "^1.0.0",
+          "type": "dev",
+        },
+      },
+      "location": "node_modules/abbrev",
+      "name": "abbrev",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+    },
+    "pkg-a" => Link {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "pkg-a",
+          "spec": "file:{CWD}/test/arborist/reify-workspaces-reify-from-an-actual-loaded-workspace-env/a",
+          "type": "workspace",
+        },
+      },
+      "location": "node_modules/pkg-a",
+      "name": "pkg-a",
+      "resolved": "file:../a",
+      "target": Object {
+        "name": "a",
+        "parent": undefined,
+      },
+    },
+  },
+  "edgesOut": Map {
+    "abbrev" => Edge {
+      "name": "abbrev",
+      "spec": "^1.0.0",
+      "to": "node_modules/abbrev",
+      "type": "dev",
+    },
+    "pkg-a" => Edge {
+      "name": "pkg-a",
+      "spec": "file:{CWD}/test/arborist/reify-workspaces-reify-from-an-actual-loaded-workspace-env/a",
+      "to": "node_modules/pkg-a",
+      "type": "workspace",
+    },
+  },
+  "fsChildren": Set {
+    Node {
+      "edgesOut": Map {
+        "@ruyadorno/dep-bar" => Edge {
+          "name": "@ruyadorno/dep-bar",
+          "spec": "^1.0.0",
+          "to": "node_modules/@ruyadorno/dep-bar",
+          "type": "prod",
+        },
+      },
+      "location": "a",
+      "name": "a",
+      "resolved": null,
+    },
+  },
+  "location": "",
+  "name": "reify-workspaces-reify-from-an-actual-loaded-workspace-env",
+  "resolved": null,
+}
+`
+
 exports[`test/arborist/reify.js TAP workspaces reify simple-workspaces > should reify simple workspaces 1`] = `
 Node {
   "children": Map {

--- a/test/arborist/reify.js
+++ b/test/arborist/reify.js
@@ -990,6 +990,12 @@ t.test('workspaces', t => {
       .then(checkBin)
   })
 
+  t.test('reify from an actual loaded workspace env', t =>
+    t.resolveMatchSnapshot(
+      printReified(fixture(t, 'workspaces-non-simplistic')),
+      'should not clean up entire nm folder for no reason'
+    ))
+
   t.end()
 })
 

--- a/test/fixtures/reify-cases/workspaces-non-simplistic.js
+++ b/test/fixtures/reify-cases/workspaces-non-simplistic.js
@@ -1,0 +1,328 @@
+// generated from test/fixtures/workspaces-non-simplistic
+module.exports = t => {
+  const path = t.testdir({
+  "a": {
+    "package.json": JSON.stringify({
+      "name": "pkg-a",
+      "dependencies": {
+        "@ruyadorno/dep-bar": "^1.0.0"
+      }
+    })
+  },
+  "node_modules": {
+    ".package-lock.json": JSON.stringify({
+      "name": "workspaces-non-simplistic",
+      "lockfileVersion": 2,
+      "requires": true,
+      "packages": {
+        "a": {
+          "dependencies": {
+            "@ruyadorno/dep-bar": "^1.0.0"
+          }
+        },
+        "node_modules/@ruyadorno/dep-bar": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@ruyadorno/dep-bar/-/dep-bar-1.0.0.tgz",
+          "integrity": "sha512-odCQAbeN4ZPv0AAVIyVMZuX4sMYEsUgVAbAtRa+oDsLAoyz+weSQCDcefkk23sfqsJuOXTiohHJ3rcr0lN0rGA==",
+          "dependencies": {
+            "@ruyadorno/dep-foo": "^1.0.0"
+          }
+        },
+        "node_modules/@ruyadorno/dep-foo": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@ruyadorno/dep-foo/-/dep-foo-1.0.0.tgz",
+          "integrity": "sha512-ffU1K0OPjx+75PIZRjDQy/Iwj/tAFYczGiqYx5ak9JWDRDubLwN2VLarPq4w0QqPdZtJ7Z9AMGDLKPmLnu6iZw==",
+          "funding": {
+            "type": "Patreon",
+            "url": "https://patreon.com/ruyadorno"
+          }
+        },
+        "node_modules/abbrev": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+          "dev": true
+        },
+        "node_modules/pkg-a": {
+          "resolved": "a",
+          "link": true
+        }
+      }
+    }),
+    "@ruyadorno": {
+      "dep-bar": {
+        "package.json": JSON.stringify({
+          "name": "@ruyadorno/dep-bar",
+          "version": "1.0.0",
+          "dependencies": {
+            "@ruyadorno/dep-foo": "^1.0.0"
+          }
+        })
+      },
+      "dep-foo": {
+        "package.json": JSON.stringify({
+          "name": "@ruyadorno/dep-foo",
+          "version": "1.0.0",
+          "description": "",
+          "main": "index.js",
+          "scripts": {
+            "test": "echo \"Error: no test specified\" && exit 1"
+          },
+          "funding": {
+            "type": "Patreon",
+            "url": "https://patreon.com/ruyadorno"
+          },
+          "author": "Ruy Adorno",
+          "license": "ISC"
+        })
+      }
+    },
+    "abbrev": {
+      "LICENSE": `This software is dual-licensed under the ISC and MIT licenses.
+You may use this software under EITHER of the following licenses.
+
+----------
+
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+----------
+
+Copyright Isaac Z. Schlueter and Contributors
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+`,
+      "README.md": `# abbrev-js
+
+Just like [ruby's Abbrev](http://apidock.com/ruby/Abbrev).
+
+Usage:
+
+    var abbrev = require("abbrev");
+    abbrev("foo", "fool", "folding", "flop");
+    
+    // returns:
+    { fl: 'flop'
+    , flo: 'flop'
+    , flop: 'flop'
+    , fol: 'folding'
+    , fold: 'folding'
+    , foldi: 'folding'
+    , foldin: 'folding'
+    , folding: 'folding'
+    , foo: 'foo'
+    , fool: 'fool'
+    }
+
+This is handy for command-line scripts, or other cases where you want to be able to accept shorthands.
+`,
+      "abbrev.js": `module.exports = exports = abbrev.abbrev = abbrev
+
+abbrev.monkeyPatch = monkeyPatch
+
+function monkeyPatch () {
+  Object.defineProperty(Array.prototype, 'abbrev', {
+    value: function () { return abbrev(this) },
+    enumerable: false, configurable: true, writable: true
+  })
+
+  Object.defineProperty(Object.prototype, 'abbrev', {
+    value: function () { return abbrev(Object.keys(this)) },
+    enumerable: false, configurable: true, writable: true
+  })
+}
+
+function abbrev (list) {
+  if (arguments.length !== 1 || !Array.isArray(list)) {
+    list = Array.prototype.slice.call(arguments, 0)
+  }
+  for (var i = 0, l = list.length, args = [] ; i < l ; i ++) {
+    args[i] = typeof list[i] === "string" ? list[i] : String(list[i])
+  }
+
+  // sort them lexicographically, so that they're next to their nearest kin
+  args = args.sort(lexSort)
+
+  // walk through each, seeing how much it has in common with the next and previous
+  var abbrevs = {}
+    , prev = ""
+  for (var i = 0, l = args.length ; i < l ; i ++) {
+    var current = args[i]
+      , next = args[i + 1] || ""
+      , nextMatches = true
+      , prevMatches = true
+    if (current === next) continue
+    for (var j = 0, cl = current.length ; j < cl ; j ++) {
+      var curChar = current.charAt(j)
+      nextMatches = nextMatches && curChar === next.charAt(j)
+      prevMatches = prevMatches && curChar === prev.charAt(j)
+      if (!nextMatches && !prevMatches) {
+        j ++
+        break
+      }
+    }
+    prev = current
+    if (j === cl) {
+      abbrevs[current] = current
+      continue
+    }
+    for (var a = current.substr(0, j) ; j <= cl ; j ++) {
+      abbrevs[a] = current
+      a += current.charAt(j)
+    }
+  }
+  return abbrevs
+}
+
+function lexSort (a, b) {
+  return a === b ? 0 : a > b ? 1 : -1
+}
+`,
+      "package.json": JSON.stringify({
+        "name": "abbrev",
+        "version": "1.1.1",
+        "description": "Like ruby's abbrev module, but in js",
+        "author": "Isaac Z. Schlueter <i@izs.me>",
+        "main": "abbrev.js",
+        "scripts": {
+          "test": "tap test.js --100",
+          "preversion": "npm test",
+          "postversion": "npm publish",
+          "postpublish": "git push origin --all; git push origin --tags"
+        },
+        "repository": "http://github.com/isaacs/abbrev-js",
+        "license": "ISC",
+        "devDependencies": {
+          "tap": "^10.1"
+        },
+        "files": [
+          "abbrev.js"
+        ]
+      })
+    },
+    "pkg-a": t.fixture('symlink', "../a")
+  },
+  "package-lock.json": JSON.stringify({
+    "name": "workspaces-non-simplistic",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+      "": {
+        "workspaces": [
+          "a"
+        ],
+        "devDependencies": {
+          "abbrev": "^1.0.0"
+        }
+      },
+      "a": {
+        "dependencies": {
+          "@ruyadorno/dep-bar": "^1.0.0"
+        }
+      },
+      "node_modules/@ruyadorno/dep-bar": {
+        "version": "1.0.0",
+        "resolved": "https://registry.npmjs.org/@ruyadorno/dep-bar/-/dep-bar-1.0.0.tgz",
+        "integrity": "sha512-odCQAbeN4ZPv0AAVIyVMZuX4sMYEsUgVAbAtRa+oDsLAoyz+weSQCDcefkk23sfqsJuOXTiohHJ3rcr0lN0rGA==",
+        "dependencies": {
+          "@ruyadorno/dep-foo": "^1.0.0"
+        }
+      },
+      "node_modules/@ruyadorno/dep-foo": {
+        "version": "1.0.0",
+        "resolved": "https://registry.npmjs.org/@ruyadorno/dep-foo/-/dep-foo-1.0.0.tgz",
+        "integrity": "sha512-ffU1K0OPjx+75PIZRjDQy/Iwj/tAFYczGiqYx5ak9JWDRDubLwN2VLarPq4w0QqPdZtJ7Z9AMGDLKPmLnu6iZw==",
+        "funding": {
+          "type": "Patreon",
+          "url": "https://patreon.com/ruyadorno"
+        }
+      },
+      "node_modules/abbrev": {
+        "version": "1.1.1",
+        "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+        "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+        "dev": true
+      },
+      "node_modules/pkg-a": {
+        "resolved": "a",
+        "link": true
+      }
+    },
+    "dependencies": {
+      "@ruyadorno/dep-bar": {
+        "version": "1.0.0",
+        "resolved": "https://registry.npmjs.org/@ruyadorno/dep-bar/-/dep-bar-1.0.0.tgz",
+        "integrity": "sha512-odCQAbeN4ZPv0AAVIyVMZuX4sMYEsUgVAbAtRa+oDsLAoyz+weSQCDcefkk23sfqsJuOXTiohHJ3rcr0lN0rGA==",
+        "requires": {
+          "@ruyadorno/dep-foo": "^1.0.0"
+        }
+      },
+      "@ruyadorno/dep-foo": {
+        "version": "1.0.0",
+        "resolved": "https://registry.npmjs.org/@ruyadorno/dep-foo/-/dep-foo-1.0.0.tgz",
+        "integrity": "sha512-ffU1K0OPjx+75PIZRjDQy/Iwj/tAFYczGiqYx5ak9JWDRDubLwN2VLarPq4w0QqPdZtJ7Z9AMGDLKPmLnu6iZw=="
+      },
+      "abbrev": {
+        "version": "1.1.1",
+        "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+        "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+        "dev": true
+      },
+      "pkg-a": {
+        "version": "file:a",
+        "requires": {
+          "@ruyadorno/dep-bar": "^1.0.0"
+        }
+      }
+    }
+  }),
+  "package.json": JSON.stringify({
+    "name": "workspaces-non-simplistic",
+    "workspaces": [
+      "a"
+    ],
+    "devDependencies": {
+      "abbrev": "^1.0.0"
+    }
+  })
+})
+  const {utimesSync} = require('fs')
+  const n = Date.now()
+  const {resolve} = require('path')
+  
+  utimesSync(resolve(path, "node_modules/.package-lock.json"), new Date(n), new Date(n))
+  return path
+}

--- a/test/fixtures/workspaces-non-simplistic/a/package.json
+++ b/test/fixtures/workspaces-non-simplistic/a/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "pkg-a",
+  "dependencies": {
+    "@ruyadorno/dep-bar": "^1.0.0"
+  }
+}

--- a/test/fixtures/workspaces-non-simplistic/package.json
+++ b/test/fixtures/workspaces-non-simplistic/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "workspaces-non-simplistic",
+  "workspaces": [
+    "a"
+  ],
+  "devDependencies": {
+    "abbrev": "^1.0.0"
+  }
+}


### PR DESCRIPTION
When installing from a tree that has actual/virtual trees arborist was
missing info on workspaces during build-ideal-tree leading to a reify
diff that missed all workspaces and causing all workspaces and their
dependencies to be removed from the node_modules folder.

This fixes it by making sure we append workspaces info first thing upon
reading root node in build-ideal-tree

Fixes: https://github.com/npm/cli/issues/1784
