### PR TITLE
fix: do not rewrite malformed package.json

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -265,7 +265,11 @@ module.exports = cls => class IdealTreeBuilder extends cls {
       this[_global] ? this[_globalRootNode]()
       : rpj(this.path + '/package.json').then(
         pkg => this[_rootNodeFromPackage](pkg),
-        er => this[_rootNodeFromPackage]({})
+        er => {
+          if (er.code === 'EJSONPARSE')
+            throw er
+          return this[_rootNodeFromPackage]({})
+        }
       ))
       .then(root => this[_loadWorkspaces](root))
       // ok to not have a virtual tree.  probably initial install.

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -111,6 +111,16 @@ t.test('fail on mismatched engine when engineStrict is set', async t => {
   }).then(() => { throw new Error('failed to fail') }), { code: 'EBADENGINE' })
 })
 
+t.test('fail on malformed package.json', t => {
+  const path = resolve(fixtures, 'malformed-json')
+
+  return t.rejects(
+    buildIdeal(path),
+    { code: 'EJSONPARSE' },
+    'should fail with EJSONPARSE error'
+  )
+})
+
 t.test('ignore mismatched engine for optional dependencies', async t => {
   const path = resolve(fixtures, 'optional-engine-specification')
   await buildIdeal(path, {

--- a/test/arborist/reify.js
+++ b/test/arborist/reify.js
@@ -199,6 +199,26 @@ t.test('packageLockOnly can add deps', async t => {
   t.throws(() => fs.statSync(path + '/node_modules'), { code: 'ENOENT' })
 })
 
+t.test('malformed package.json should not be overwitten', async t => {
+  t.plan(2)
+
+  const path = fixture(t, 'malformed-json')
+  const originalContent = fs.readFileSync(path + '/package.json', 'utf8')
+
+  try {
+    await reify(path)
+  } catch (err) {
+    t.match(err, { code: 'EJSONPARSE' }, 'should throw EJSONPARSE error')
+  }
+
+  const resultContent = fs.readFileSync(path + '/package.json', 'utf8')
+  t.equal(
+    resultContent,
+    originalContent,
+    'should not touch file contents on malformed json'
+  )
+})
+
 t.test('packageLockOnly does not work on globals', t => {
   const path = t.testdir({ 'package.json': '{}' })
   return t.rejects(() => reify(path, { global: true, packageLockOnly: true }))

--- a/test/fixtures/malformed-json/package.json
+++ b/test/fixtures/malformed-json/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "malformed-json",
+  "devDependencies": {
+    "abbrev": "^1.0.0",
+  }
+}

--- a/test/fixtures/reify-cases/malformed-json.js
+++ b/test/fixtures/reify-cases/malformed-json.js
@@ -1,0 +1,13 @@
+// generated from test/fixtures/malformed-json
+module.exports = t => {
+  const path = t.testdir({
+  "package.json": `{
+  "name": "malformed-json",
+  "devDependencies": {
+    "abbrev": "^1.0.0",
+  }
+}
+`
+})
+  return path
+}


### PR DESCRIPTION
Reify was rewiriting contents of a malformed package.json. This
changeset fixes the problem by making sure build-ideal-tree properly
throws when finding EJSONPARSE errors from the root package.json

Fixes: https://github.com/npm/cli/issues/1883
