### PR TITLE
fix: pass the scope of the package to pacote

### DIFF
--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -400,7 +400,7 @@ module.exports = cls => class Reifier extends cls {
     // and no 'bundled: true' setting.
     // Do the best with what we have, or else remove it from the tree
     // entirely, since we can't possibly reify it.
-    const res = node.resolved ? this[_registryResolved](node.resolved)
+    const res = node.resolved ? `${node.name}@${this[_registryResolved](node.resolved)}`
       : node.package.name && node.version
         ? `${node.package.name}@${node.version}`
         : null
@@ -418,7 +418,6 @@ module.exports = cls => class Reifier extends cls {
       ? rimraf(node.path).then(() => this[_symlink](node))
       : pacote.extract(res, node.path, {
         ...this.options,
-        scope: node.name.charAt(0) === '@' && node.name.split('/').shift(),
         resolved: node.resolved,
         integrity: node.integrity,
       })

--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -418,6 +418,7 @@ module.exports = cls => class Reifier extends cls {
       ? rimraf(node.path).then(() => this[_symlink](node))
       : pacote.extract(res, node.path, {
         ...this.options,
+        scope: node.name.charAt(0) === '@' && node.name.split('/').shift(),
         resolved: node.resolved,
         integrity: node.integrity,
       })

--- a/tap-snapshots/test-arborist-reify.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-reify.js-TAP.test.js
@@ -27084,6 +27084,10 @@ Object {
 }
 `
 
+exports[`test/arborist/reify.js TAP scoped registries > should preserve original resolved value 1`] = `
+@ruyadorno/theoretically-private-pkg@https://npm.pkg.github.com/@ruyadorno/theoretically-private-pkg/-/theoretically-private-pkg-1.2.3.tgz
+`
+
 exports[`test/arborist/reify.js TAP store files with a custom indenting > must match snapshot 1`] = `
 {
 	"name": "tab-indented-package-json",

--- a/test/arborist/reify.js
+++ b/test/arborist/reify.js
@@ -913,6 +913,47 @@ t.test('saving the ideal tree', t => {
   t.end()
 })
 
+t.test('scoped registries', t => {
+  const path = t.testdir()
+
+  // this is a very artifical test that is setting a lot of internal things
+  // up so that we assert that the intended behavior of sending right
+  // resolved data for pacote.extract is working as intended, alternatively
+  // we might prefer to replace this with a proper parallel alternative
+  // registry server so that we can have more of an integration test instead
+  t.plan(1)
+  const pacote = {
+    extract: res => {
+      t.matchSnapshot(
+        res,
+        'should preserve original resolved value'
+      )
+      return true
+    },
+  }
+  const ArboristMock = requireInject('../../lib/arborist', {
+    rimraf: rimrafMock,
+    fs: fsMock,
+    '../../lib/node.js': Node,
+    pacote,
+  })
+  const a = new ArboristMock({
+    audit: false,
+    path,
+    cache,
+    registry,
+  })
+  const kReify = Symbol.for('reifyNode')
+
+  const node = new Node({
+    name: '@ruyadorno/theoretically-private-pkg',
+    resolved: 'https://npm.pkg.github.com/@ruyadorno/' +
+      'theoretically-private-pkg/-/theoretically-private-pkg-1.2.3.tgz',
+    pkg: { version: '1.2.3', name: '@ruyadorno/theoretically-private-pkg' },
+  })
+  a[kReify](node)
+})
+
 t.test('bin links adding and removing', t => {
   const path = t.testdir({
     'package.json': JSON.stringify({}),


### PR DESCRIPTION
this allows npm-registry-fetch to correctly identify the registry associated with the request, which resolves the issues with incorrect auth being sent

## References
https://github.com/npm/cli/issues/1959
https://github.com/npm/cli/issues/1960
https://github.com/npm/cli/issues/1800
