### PR TITLE
fix cycles/ordering when peer deps require nesting

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -1023,6 +1023,7 @@ This is a one-time fix-up, please be patient...
       edge: edge.explain(),
       peerConflict,
       strictPeerDeps: this[_strictPeerDeps],
+      force: this[_force],
     }
   }
 
@@ -1040,7 +1041,7 @@ This is a one-time fix-up, please be patient...
   // place dep, requested by node, to satisfy edge
   // XXX split this out into a separate method or mixin?  It's quite a lot
   // of functionality that ought to have its own unit tests more conveniently.
-  [_placeDep] (dep, node, edge, peerEntryEdge = null) {
+  [_placeDep] (dep, node, edge, peerEntryEdge = null, peerPath = []) {
     if (edge.to &&
         !edge.error &&
         !this[_updateNames].includes(edge.name) &&
@@ -1057,7 +1058,7 @@ This is a one-time fix-up, please be patient...
     let target
     let canPlace = null
     for (let check = start; check; check = check.resolveParent) {
-      const cp = this[_canPlaceDep](dep, check, edge, peerEntryEdge)
+      const cp = this[_canPlaceDep](dep, check, edge, peerEntryEdge, peerPath)
 
       // anything other than a conflict is fine to proceed with
       if (cp !== CONFLICT) {
@@ -1095,14 +1096,30 @@ This is a one-time fix-up, please be patient...
     // Can only get KEEP here if the original edge was valid,
     // and we're checking for an update but it's already up to date.
     if (canPlace === KEEP) {
-      dep.parent = null
+      if (edge.peer && !target.children.get(edge.name).satisfies(edge)) {
+        // this is an overridden peer dep
+        this[_warnPeerConflict](edge)
+      }
+      // dep.parent = null
       return []
     }
 
     // figure out which of this node's peer deps will get placed as well
     const virtualRoot = dep.parent
 
-    const placed = [dep]
+    const newDep = new dep.constructor({
+      name: dep.name,
+      pkg: dep.package,
+      resolved: dep.resolved,
+      integrity: dep.integrity,
+      legacyPeerDeps: this.legacyPeerDeps,
+      error: dep.errors[0],
+      ...(dep.target ? { target: dep.target } : {}),
+    })
+    if (this[_loadFailures].has(dep))
+      this[_loadFailures].add(newDep)
+
+    const placed = [newDep]
     const oldChild = target.children.get(edge.name)
     if (oldChild) {
       // if we're replacing, we should also remove any nodes for edges that
@@ -1113,34 +1130,39 @@ This is a one-time fix-up, please be patient...
       // later anyway.
       const oldDeps = []
       for (const [name, edge] of oldChild.edgesOut.entries()) {
-        if (!dep.edgesOut.has(name) && edge.to)
+        if (!newDep.edgesOut.has(name) && edge.to)
           oldDeps.push(edge.to)
       }
-      dep.replace(oldChild)
-      this[_pruneForReplacement](dep, oldDeps)
+      newDep.replace(oldChild)
+      this[_pruneForReplacement](newDep, oldDeps)
       // this may also create some invalid edges, for example if we're
       // intentionally causing something to get nested which was previously
       // placed in this location.
-      for (const edge of dep.edgesIn) {
-        if (edge.invalid) {
-          this[_depsQueue].push(edge.from)
-          this[_depsSeen].delete(edge.from)
+      for (const edgeIn of newDep.edgesIn) {
+        if (edgeIn.invalid && edgeIn !== edge) {
+          this[_depsQueue].push(edgeIn.from)
+          this[_depsSeen].delete(edgeIn.from)
         }
       }
     } else
-      dep.parent = target
+      newDep.parent = target
+
+    if (edge.peer && !newDep.satisfies(edge)) {
+      // this is an overridden peer dep
+      this[_warnPeerConflict](edge)
+    }
 
     // If the edge is not an error, then we're updating something, and
     // MAY end up putting a better/identical node further up the tree in
     // a way that causes an unnecessary duplication.  If so, remove the
     // now-unnecessary node.
-    if (edge.valid && edge.to.parent !== target && dep.canReplace(edge.to))
+    if (edge.valid && edge.to.parent !== target && newDep.canReplace(edge.to))
       edge.to.parent = null
 
     // visit any dependents who are upset by this change
     // if it's an angry overridden peer edge, however, make sure we
     // skip over it!
-    for (const edgeIn of dep.edgesIn) {
+    for (const edgeIn of newDep.edgesIn) {
       if (edgeIn !== edge && !edgeIn.valid && !this[_depsSeen].has(edge.from)) {
         this.addTracker('idealTree', edgeIn.from.name, edgeIn.from.location)
         this[_depsQueue].push(edgeIn.from)
@@ -1150,12 +1172,12 @@ This is a one-time fix-up, please be patient...
     // in case we just made some duplicates that can be removed,
     // prune anything deeper in the tree that can be replaced by this
     if (this.idealTree) {
-      for (const node of this.idealTree.inventory.query('name', dep.name)) {
-        if (node !== dep &&
+      for (const node of this.idealTree.inventory.query('name', newDep.name)) {
+        if (node !== newDep &&
             node.isDescendantOf(target) &&
             !node.inShrinkwrap &&
             !node.inBundle &&
-            node.canReplaceWith(dep)) {
+            node.canReplaceWith(newDep)) {
           // don't prune if the dupe is necessary!
           // root (a, d)
           // +-- a (b, c2)
@@ -1168,35 +1190,28 @@ This is a one-time fix-up, please be patient...
 
           const mask = node.parent !== target &&
             node.parent.parent !== target &&
-            node.parent.parent.resolve(dep.name)
+            node.parent.parent.resolve(newDep.name)
 
-          if (!mask || mask === dep || node.canReplaceWith(mask))
+          if (!mask || mask === newDep || node.canReplaceWith(mask))
             node.parent = null
         }
       }
     }
 
     // also place its unmet or invalid peer deps at this location
-    // note that dep has now been removed from the virtualRoot set
+    // note that newDep has now been removed from the virtualRoot set
     // by virtue of being placed in the target's node_modules.
-    const peers = []
-    // double loop so that we don't yank things out and then fail to find
-    // them in the virtualRoot's children.
-    for (const peerEdge of dep.edgesOut.values()) {
+    // loop through any peer deps from the thing we just placed, and place
+    // those ones as well.  it's safe to do this with the virtual nodes,
+    // because we're copying rather than moving them out of the virtual root,
+    // otherwise they'd be gone and the peer set would change throughout
+    // this loop.
+    for (const peerEdge of newDep.edgesOut.values()) {
       if (!peerEdge.peer || peerEdge.valid)
         continue
       const peer = virtualRoot.children.get(peerEdge.name)
-      // since we re-use virtualRoots, it's possible that the node was
-      // already placed somewhere in the tree, and thus plucked off the
-      // virtual root.  however, in that case, it should have been no
-      // longer a missing/invalid peer dep, so something is messed up.
-      if (peer)
-        peers.push([peer, peerEdge])
-    }
-
-    for (const [peer, peerEdge] of peers) {
       const peerPlaced = this[_placeDep](
-        peer, dep, peerEdge, peerEntryEdge || edge)
+        peer, newDep, peerEdge, peerEntryEdge || edge)
       placed.push(...peerPlaced)
     }
 
@@ -1245,11 +1260,9 @@ This is a one-time fix-up, please be patient...
   // checking, because either we're leaving it alone, or it won't work anyway.
   // When we check peers, we pass along the peerEntryEdge to track the
   // original edge that caused us to load the family of peer dependencies.
-  [_canPlaceDep] (dep, target, edge, peerEntryEdge = null) {
+  [_canPlaceDep] (dep, target, edge, peerEntryEdge = null, peerPath = []) {
     const entryEdge = peerEntryEdge || edge
     const source = this[_peerSetSource].get(dep)
-    const virtualRoot = dep.parent
-    const vrEdge = virtualRoot.edgesOut.get(edge.name)
 
     const isSource = target === source
     const { isRoot, isWorkspace } = source || {}
@@ -1266,7 +1279,7 @@ This is a one-time fix-up, please be patient...
       const { version: newVer } = dep
       const tryReplace = curVer && newVer && semver.gte(newVer, curVer)
       if (tryReplace && dep.canReplace(current)) {
-        const res = this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge)
+        const res = this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge, peerPath)
         /* istanbul ignore else - It's extremely rare that a replaceable
          * node would be a conflict, if the current one wasn't a conflict,
          * but it is theoretically possible if peer deps are pinned.  In
@@ -1276,12 +1289,14 @@ This is a one-time fix-up, please be patient...
       }
 
       // ok, can't replace the current with new one, but maybe current is ok?
+      // no need to check if it's a peer that's valid to be here, because
+      // peers are always placed along with their entry source
       if (edge.satisfiedBy(current))
         return KEEP
 
       // if we prefer deduping, then try replacing newer with older
       if (this[_preferDedupe] && !tryReplace && dep.canReplace(current)) {
-        const res = this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge)
+        const res = this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge, peerPath)
         /* istanbul ignore else - It's extremely rare that a replaceable
          * node would be a conflict, if the current one wasn't a conflict,
          * but it is theoretically possible if peer deps are pinned.  In
@@ -1333,7 +1348,7 @@ This is a one-time fix-up, please be patient...
           }
         }
         if (canReplace) {
-          const ret = this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge)
+          const ret = this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge, peerPath)
           /* istanbul ignore else - extremely rare that the peer set would
            * conflict if we can replace the node in question, but theoretically
            * possible, if peer deps are pinned aggressively. */
@@ -1348,18 +1363,6 @@ This is a one-time fix-up, please be patient...
          * check so that we're not only relying on action at a distance. */
         if (!this[_strictPeerDeps] && !isMine || this[_force]) {
           this[_warnPeerConflict](edge, dep)
-          return KEEP
-        }
-      }
-
-      if (vrEdge && vrEdge.satisfiedBy(current)) {
-        /* istanbul ignore else - If the virtual root was satisfied, in
-         * such a way that it was an override, and it's NOT forced, and is
-         * ours, or is in strict mode, then it would have crashed during
-         * the creation of the peerSet.  Nevertheless, this is a good check
-         * to ensure we're not warning when we should be conflicting. */
-        if (this[_force] || !isMine && !this[_strictPeerDeps]) {
-          this[_warnPeerConflict](edge)
           return KEEP
         }
       }
@@ -1386,21 +1389,8 @@ This is a one-time fix-up, please be patient...
       // a specific name, however, or if a dep makes an incompatible change
       // to its peer dep in a non-semver-major version bump, or if the parent
       // is unbounded in its dependency list.
-      if (!targetEdge.satisfiedBy(dep)) {
-        if (isSource) {
-          // conflicted peer dep.  accept what's there, if overriding
-          /* istanbul ignore else - If it's the source, and the source's edge
-           * is not valid, then either we crashed when creating the peer set,
-           * or it's forced, or it's not ours and not strict. Keep this check
-           * to avoid relying on action at a distance, however. */
-          if (this[_force] || !isMine && !this[_strictPeerDeps]) {
-            this[_warnPeerConflict](edge)
-            return KEEP
-          }
-        }
-
+      if (!targetEdge.satisfiedBy(dep))
         return CONFLICT
-      }
     }
 
     // check to see what that name resolves to here, and who may depend on
@@ -1419,30 +1409,30 @@ This is a one-time fix-up, please be patient...
     }
 
     // no objections!  ok to place here
-    return this[_canPlacePeers](dep, target, edge, OK, peerEntryEdge)
+    return this[_canPlacePeers](dep, target, edge, OK, peerEntryEdge, peerPath)
   }
 
   // make sure the family of peer deps can live here alongside it.
   // this doesn't guarantee that THIS solution will be the one we take,
   // but it does establish that SOME solution exists at this level in
   // the tree.
-  [_canPlacePeers] (dep, target, edge, ret, peerEntryEdge) {
-    if (!dep.parent || peerEntryEdge)
+  [_canPlacePeers] (dep, target, edge, ret, peerEntryEdge, peerPath) {
+    // do not go in cycles when we're resolving a peer group
+    if (!dep.parent || peerEntryEdge && peerPath.includes(dep))
       return ret
 
+    peerPath = [...peerPath, dep]
     for (const peer of dep.parent.children.values()) {
       if (peer === dep)
         continue
 
-      const peerEdge = dep.edgesOut.get(peer.name) ||
-        [...peer.edgesIn].find(e => e.peer)
-
-      /* istanbul ignore if - pretty sure this is impossible, but just
-         being cautious */
+      // we only have to pick the first one, because ALL peer edgesIn will
+      // be checked before we decide to accept an existing dep in the tree
+      const peerEdge = [...peer.edgesIn].find(e => e.peer && e !== edge)
       if (!peerEdge)
         continue
 
-      const canPlacePeer = this[_canPlaceDep](peer, target, peerEdge, edge)
+      const canPlacePeer = this[_canPlaceDep](peer, target, peerEdge, edge, peerPath)
       if (canPlacePeer !== CONFLICT)
         continue
 
@@ -1564,6 +1554,7 @@ This is a one-time fix-up, please be patient...
     for (const node of this[_loadFailures]) {
       if (!node.optional)
         throw node.errors[0]
+
       const set = optionalSet(node)
       for (const node of set)
         node.parent = null

--- a/scripts/ideal.js
+++ b/scripts/ideal.js
@@ -15,6 +15,9 @@ process.on('timeEnd', name => {
   }
   const res = process.hrtime(timers[name])
   delete timers[name]
+  if (options.quiet)
+    return
+
   console.error(name, res[0] * 1e3 + res[1] / 1e6)
 })
 process.on('exit', () => {
@@ -28,6 +31,9 @@ const {format} = require('tcompare')
 const print = tree => console.log(format(printTree(tree), { style: 'js' }))
 const { inspect, format: fmt } = require('util')
 process.on('log', (level, ...msg) => {
+  if (options.quiet)
+    return
+
   if (false && level === 'silly') {
     const cols = process.stdout.columns || 80
     const str = fmt(level, ...msg).replace(/\n/g, '').substr(0, cols)

--- a/tap-snapshots/test-arborist-build-ideal-tree.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-build-ideal-tree.js-TAP.test.js
@@ -1261,6 +1261,305 @@ Node {
 }
 `
 
+exports[`test/arborist/build-ideal-tree.js TAP cases requiring peer sets to be nested multi > must match snapshot 1`] = `
+Node {
+  "children": Map {
+    "@isaacs/testing-peer-dep-nesting-p" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "@isaacs/testing-peer-dep-nesting-p",
+          "spec": "2",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-nesting-p",
+      "name": "@isaacs/testing-peer-dep-nesting-p",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-p/-/testing-peer-dep-nesting-p-2.0.0.tgz",
+    },
+    "@isaacs/testing-peer-dep-nesting-s" => Node {
+      "children": Map {
+        "@isaacs/testing-peer-dep-nesting-p" => Node {
+          "edgesIn": Set {
+            Edge {
+              "from": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-q",
+              "name": "@isaacs/testing-peer-dep-nesting-p",
+              "spec": "1",
+              "type": "peer",
+            },
+            Edge {
+              "from": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-x",
+              "name": "@isaacs/testing-peer-dep-nesting-p",
+              "spec": "1",
+              "type": "peer",
+            },
+          },
+          "location": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-p",
+          "name": "@isaacs/testing-peer-dep-nesting-p",
+          "peer": true,
+          "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-p/-/testing-peer-dep-nesting-p-1.0.0.tgz",
+        },
+        "@isaacs/testing-peer-dep-nesting-q" => Node {
+          "edgesIn": Set {
+            Edge {
+              "from": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-x",
+              "name": "@isaacs/testing-peer-dep-nesting-q",
+              "spec": "1",
+              "type": "peer",
+            },
+          },
+          "edgesOut": Map {
+            "@isaacs/testing-peer-dep-nesting-p" => Edge {
+              "name": "@isaacs/testing-peer-dep-nesting-p",
+              "spec": "1",
+              "to": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-p",
+              "type": "peer",
+            },
+          },
+          "location": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-q",
+          "name": "@isaacs/testing-peer-dep-nesting-q",
+          "peer": true,
+          "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-q/-/testing-peer-dep-nesting-q-1.0.0.tgz",
+        },
+        "@isaacs/testing-peer-dep-nesting-x" => Node {
+          "edgesIn": Set {
+            Edge {
+              "from": "node_modules/@isaacs/testing-peer-dep-nesting-s",
+              "name": "@isaacs/testing-peer-dep-nesting-x",
+              "spec": "",
+              "type": "prod",
+            },
+          },
+          "edgesOut": Map {
+            "@isaacs/testing-peer-dep-nesting-p" => Edge {
+              "name": "@isaacs/testing-peer-dep-nesting-p",
+              "spec": "1",
+              "to": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-p",
+              "type": "peer",
+            },
+            "@isaacs/testing-peer-dep-nesting-q" => Edge {
+              "name": "@isaacs/testing-peer-dep-nesting-q",
+              "spec": "1",
+              "to": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-q",
+              "type": "peer",
+            },
+          },
+          "location": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-x",
+          "name": "@isaacs/testing-peer-dep-nesting-x",
+          "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-x/-/testing-peer-dep-nesting-x-1.0.0.tgz",
+        },
+      },
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "@isaacs/testing-peer-dep-nesting-s",
+          "spec": "2",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-nesting-x" => Edge {
+          "name": "@isaacs/testing-peer-dep-nesting-x",
+          "spec": "",
+          "to": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-x",
+          "type": "prod",
+        },
+        "@isaacs/testing-peer-dep-nesting-y" => Edge {
+          "name": "@isaacs/testing-peer-dep-nesting-y",
+          "spec": "",
+          "to": "node_modules/@isaacs/testing-peer-dep-nesting-y",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-nesting-s",
+      "name": "@isaacs/testing-peer-dep-nesting-s",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-s/-/testing-peer-dep-nesting-s-2.0.0.tgz",
+    },
+    "@isaacs/testing-peer-dep-nesting-y" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@isaacs/testing-peer-dep-nesting-s",
+          "name": "@isaacs/testing-peer-dep-nesting-y",
+          "spec": "",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-nesting-z" => Edge {
+          "name": "@isaacs/testing-peer-dep-nesting-z",
+          "spec": "",
+          "to": "node_modules/@isaacs/testing-peer-dep-nesting-z",
+          "type": "peer",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-nesting-y",
+      "name": "@isaacs/testing-peer-dep-nesting-y",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-y/-/testing-peer-dep-nesting-y-1.0.0.tgz",
+    },
+    "@isaacs/testing-peer-dep-nesting-z" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "node_modules/@isaacs/testing-peer-dep-nesting-y",
+          "name": "@isaacs/testing-peer-dep-nesting-z",
+          "spec": "",
+          "type": "peer",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-nesting-z",
+      "name": "@isaacs/testing-peer-dep-nesting-z",
+      "peer": true,
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-z/-/testing-peer-dep-nesting-z-1.0.0.tgz",
+    },
+  },
+  "edgesOut": Map {
+    "@isaacs/testing-peer-dep-nesting-p" => Edge {
+      "name": "@isaacs/testing-peer-dep-nesting-p",
+      "spec": "2",
+      "to": "node_modules/@isaacs/testing-peer-dep-nesting-p",
+      "type": "prod",
+    },
+    "@isaacs/testing-peer-dep-nesting-s" => Edge {
+      "name": "@isaacs/testing-peer-dep-nesting-s",
+      "spec": "2",
+      "to": "node_modules/@isaacs/testing-peer-dep-nesting-s",
+      "type": "prod",
+    },
+  },
+  "location": "",
+  "name": "multi",
+  "resolved": null,
+}
+`
+
+exports[`test/arborist/build-ideal-tree.js TAP cases requiring peer sets to be nested simple > must match snapshot 1`] = `
+Node {
+  "children": Map {
+    "@isaacs/testing-peer-dep-nesting-p" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "@isaacs/testing-peer-dep-nesting-p",
+          "spec": "2",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-nesting-p",
+      "name": "@isaacs/testing-peer-dep-nesting-p",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-p/-/testing-peer-dep-nesting-p-2.0.0.tgz",
+    },
+    "@isaacs/testing-peer-dep-nesting-s" => Node {
+      "children": Map {
+        "@isaacs/testing-peer-dep-nesting-p" => Node {
+          "edgesIn": Set {
+            Edge {
+              "from": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-q",
+              "name": "@isaacs/testing-peer-dep-nesting-p",
+              "spec": "1",
+              "type": "peer",
+            },
+            Edge {
+              "from": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-x",
+              "name": "@isaacs/testing-peer-dep-nesting-p",
+              "spec": "1",
+              "type": "peer",
+            },
+          },
+          "location": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-p",
+          "name": "@isaacs/testing-peer-dep-nesting-p",
+          "peer": true,
+          "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-p/-/testing-peer-dep-nesting-p-1.0.0.tgz",
+        },
+        "@isaacs/testing-peer-dep-nesting-q" => Node {
+          "edgesIn": Set {
+            Edge {
+              "from": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-x",
+              "name": "@isaacs/testing-peer-dep-nesting-q",
+              "spec": "1",
+              "type": "peer",
+            },
+          },
+          "edgesOut": Map {
+            "@isaacs/testing-peer-dep-nesting-p" => Edge {
+              "name": "@isaacs/testing-peer-dep-nesting-p",
+              "spec": "1",
+              "to": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-p",
+              "type": "peer",
+            },
+          },
+          "location": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-q",
+          "name": "@isaacs/testing-peer-dep-nesting-q",
+          "peer": true,
+          "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-q/-/testing-peer-dep-nesting-q-1.0.0.tgz",
+        },
+        "@isaacs/testing-peer-dep-nesting-x" => Node {
+          "edgesIn": Set {
+            Edge {
+              "from": "node_modules/@isaacs/testing-peer-dep-nesting-s",
+              "name": "@isaacs/testing-peer-dep-nesting-x",
+              "spec": "",
+              "type": "prod",
+            },
+          },
+          "edgesOut": Map {
+            "@isaacs/testing-peer-dep-nesting-p" => Edge {
+              "name": "@isaacs/testing-peer-dep-nesting-p",
+              "spec": "1",
+              "to": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-p",
+              "type": "peer",
+            },
+            "@isaacs/testing-peer-dep-nesting-q" => Edge {
+              "name": "@isaacs/testing-peer-dep-nesting-q",
+              "spec": "1",
+              "to": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-q",
+              "type": "peer",
+            },
+          },
+          "location": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-x",
+          "name": "@isaacs/testing-peer-dep-nesting-x",
+          "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-x/-/testing-peer-dep-nesting-x-1.0.0.tgz",
+        },
+      },
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "@isaacs/testing-peer-dep-nesting-s",
+          "spec": "1",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "@isaacs/testing-peer-dep-nesting-x" => Edge {
+          "name": "@isaacs/testing-peer-dep-nesting-x",
+          "spec": "",
+          "to": "node_modules/@isaacs/testing-peer-dep-nesting-s/node_modules/@isaacs/testing-peer-dep-nesting-x",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-peer-dep-nesting-s",
+      "name": "@isaacs/testing-peer-dep-nesting-s",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-s/-/testing-peer-dep-nesting-s-1.0.0.tgz",
+    },
+  },
+  "edgesOut": Map {
+    "@isaacs/testing-peer-dep-nesting-p" => Edge {
+      "name": "@isaacs/testing-peer-dep-nesting-p",
+      "spec": "2",
+      "to": "node_modules/@isaacs/testing-peer-dep-nesting-p",
+      "type": "prod",
+    },
+    "@isaacs/testing-peer-dep-nesting-s" => Edge {
+      "name": "@isaacs/testing-peer-dep-nesting-s",
+      "spec": "1",
+      "to": "node_modules/@isaacs/testing-peer-dep-nesting-s",
+      "type": "prod",
+    },
+  },
+  "location": "",
+  "name": "simple",
+  "resolved": null,
+}
+`
+
 exports[`test/arborist/build-ideal-tree.js TAP complete build for project with old lockfile > must match snapshot 1`] = `
 Node {
   "children": Map {
@@ -24294,7 +24593,7 @@ Node {
       "name": "aaaaaa",
       "resolved": "file:abbrev",
       "target": Object {
-        "name": "zzzzzz",
+        "name": "aaaaaa",
         "parent": null,
       },
     },
@@ -24501,7 +24800,7 @@ Node {
       "name": "aaaaaa",
       "resolved": "file:abbrev",
       "target": Object {
-        "name": "zzzzzz",
+        "name": "aaaaaa",
         "parent": null,
       },
     },
@@ -32098,188 +32397,7 @@ Array [
         "spec": "2",
         "type": "peer",
       },
-      "peerConflict": null,
-      "strictPeerDeps": false,
-    },
-  ],
-  Array [
-    "ERESOLVE",
-    "overriding peer dependency",
-    Object {
-      "code": "ERESOLVE",
-      "current": Object {
-        "dependents": Array [
-          Object {
-            "from": Object {
-              "dependents": Array [
-                Object {
-                  "from": Object {
-                    "location": "{CWD}/test/arborist/build-ideal-tree-more-peer-dep-conflicts-metadep-conflict-that-warns-because-source-is-target",
-                  },
-                  "name": "@isaacs/testing-peer-dep-conflict-chain-i",
-                  "spec": "1",
-                  "type": "prod",
-                },
-              ],
-              "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-i",
-              "name": "@isaacs/testing-peer-dep-conflict-chain-i",
-              "version": "1.0.0",
-            },
-            "name": "@isaacs/testing-peer-dep-conflict-chain-a",
-            "spec": "1",
-            "type": "prod",
-          },
-          Object {
-            "from": Object {
-              "dependents": Array [
-                Object {
-                  "from": Object {
-                    "location": "{CWD}/test/arborist/build-ideal-tree-more-peer-dep-conflicts-metadep-conflict-that-warns-because-source-is-target",
-                  },
-                  "name": "@isaacs/testing-peer-dep-conflict-chain-p",
-                  "spec": "2",
-                  "type": "prod",
-                },
-              ],
-              "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-p",
-              "name": "@isaacs/testing-peer-dep-conflict-chain-p",
-              "version": "2.0.0",
-            },
-            "name": "@isaacs/testing-peer-dep-conflict-chain-a",
-            "spec": "1",
-            "type": "prod",
-          },
-          Object {
-            "from": Object {
-              "dependents": Array [
-                Object {
-                  "from": Object {
-                    "dependents": Array [
-                      Object {
-                        "from": Object {
-                          "dependents": Array [
-                            Object {
-                              "from": Object {
-                                "dependents": Array [
-                                  Object {
-                                    "from": Object {
-                                      "name": "@isaacs/testing-peer-dep-conflict-chain-a",
-                                      "version": "1.0.0",
-                                    },
-                                    "name": "@isaacs/testing-peer-dep-conflict-chain-b",
-                                    "spec": "1",
-                                    "type": "peer",
-                                  },
-                                ],
-                                "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-b",
-                                "name": "@isaacs/testing-peer-dep-conflict-chain-b",
-                                "version": "1.0.0",
-                              },
-                              "name": "@isaacs/testing-peer-dep-conflict-chain-c",
-                              "spec": "1",
-                              "type": "peer",
-                            },
-                          ],
-                          "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-c",
-                          "name": "@isaacs/testing-peer-dep-conflict-chain-c",
-                          "version": "1.0.0",
-                        },
-                        "name": "@isaacs/testing-peer-dep-conflict-chain-d",
-                        "spec": "1",
-                        "type": "peer",
-                      },
-                    ],
-                    "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-d",
-                    "name": "@isaacs/testing-peer-dep-conflict-chain-d",
-                    "version": "1.0.0",
-                  },
-                  "name": "@isaacs/testing-peer-dep-conflict-chain-e",
-                  "spec": "1",
-                  "type": "peer",
-                },
-              ],
-              "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-e",
-              "name": "@isaacs/testing-peer-dep-conflict-chain-e",
-              "version": "1.0.0",
-            },
-            "name": "@isaacs/testing-peer-dep-conflict-chain-a",
-            "spec": "1",
-            "type": "peer",
-          },
-        ],
-        "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
-        "name": "@isaacs/testing-peer-dep-conflict-chain-a",
-        "version": "1.0.0",
-      },
-      "edge": Object {
-        "error": "INVALID",
-        "from": Object {
-          "dependents": Array [
-            Object {
-              "from": Object {
-                "dependents": Array [
-                  Object {
-                    "from": Object {
-                      "dependents": Array [
-                        Object {
-                          "from": Object {
-                            "dependents": Array [
-                              Object {
-                                "from": Object {
-                                  "dependents": Array [
-                                    Object {
-                                      "from": Object {
-                                        "location": "{CWD}/test/arborist/build-ideal-tree-more-peer-dep-conflicts-metadep-conflict-that-warns-because-source-is-target",
-                                      },
-                                      "name": "@isaacs/testing-peer-dep-conflict-chain-p",
-                                      "spec": "2",
-                                      "type": "prod",
-                                    },
-                                  ],
-                                  "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-p",
-                                  "name": "@isaacs/testing-peer-dep-conflict-chain-p",
-                                  "version": "2.0.0",
-                                },
-                                "name": "@isaacs/testing-peer-dep-conflict-chain-b",
-                                "spec": "2",
-                                "type": "prod",
-                              },
-                            ],
-                            "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-p/node_modules/@isaacs/testing-peer-dep-conflict-chain-b",
-                            "name": "@isaacs/testing-peer-dep-conflict-chain-b",
-                            "version": "2.0.0",
-                          },
-                          "name": "@isaacs/testing-peer-dep-conflict-chain-c",
-                          "spec": "2",
-                          "type": "peer",
-                        },
-                      ],
-                      "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-p/node_modules/@isaacs/testing-peer-dep-conflict-chain-c",
-                      "name": "@isaacs/testing-peer-dep-conflict-chain-c",
-                      "version": "2.0.0",
-                    },
-                    "name": "@isaacs/testing-peer-dep-conflict-chain-d",
-                    "spec": "2",
-                    "type": "peer",
-                  },
-                ],
-                "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-p/node_modules/@isaacs/testing-peer-dep-conflict-chain-d",
-                "name": "@isaacs/testing-peer-dep-conflict-chain-d",
-                "version": "2.0.0",
-              },
-              "name": "@isaacs/testing-peer-dep-conflict-chain-e",
-              "spec": "2",
-              "type": "peer",
-            },
-          ],
-          "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-p/node_modules/@isaacs/testing-peer-dep-conflict-chain-e",
-          "name": "@isaacs/testing-peer-dep-conflict-chain-e",
-          "version": "2.0.0",
-        },
-        "name": "@isaacs/testing-peer-dep-conflict-chain-a",
-        "spec": "2",
-        "type": "peer",
-      },
+      "force": false,
       "peerConflict": null,
       "strictPeerDeps": false,
     },
@@ -32882,6 +33000,7 @@ Array [
         "spec": "1",
         "type": "peer",
       },
+      "force": false,
       "peerConflict": null,
       "strictPeerDeps": false,
     },
@@ -32987,6 +33106,7 @@ Array [
         "spec": "2",
         "type": "peer",
       },
+      "force": false,
       "peerConflict": null,
       "strictPeerDeps": false,
     },
@@ -34810,6 +34930,12 @@ Node {
     "@isaacs/peer-dep-cycle-a" => Node {
       "edgesIn": Set {
         Edge {
+          "from": "",
+          "name": "@isaacs/peer-dep-cycle-a",
+          "spec": "2.x",
+          "type": "prod",
+        },
+        Edge {
           "from": "node_modules/@isaacs/peer-dep-cycle-c",
           "name": "@isaacs/peer-dep-cycle-a",
           "spec": "2",
@@ -34826,7 +34952,6 @@ Node {
       },
       "location": "node_modules/@isaacs/peer-dep-cycle-a",
       "name": "@isaacs/peer-dep-cycle-a",
-      "peer": true,
       "resolved": "https://registry.npmjs.org/@isaacs/peer-dep-cycle-a/-/peer-dep-cycle-a-2.0.0.tgz",
     },
     "@isaacs/peer-dep-cycle-b" => Node {
@@ -34886,6 +35011,12 @@ Node {
       "to": "node_modules/@isaacs/peer-dep-cycle",
       "type": "prod",
     },
+    "@isaacs/peer-dep-cycle-a" => Edge {
+      "name": "@isaacs/peer-dep-cycle-a",
+      "spec": "2.x",
+      "to": "node_modules/@isaacs/peer-dep-cycle-a",
+      "type": "prod",
+    },
     "@isaacs/peer-dep-cycle-b" => Edge {
       "name": "@isaacs/peer-dep-cycle-b",
       "spec": "https://registry.npmjs.org/@isaacs/peer-dep-cycle-b/-/peer-dep-cycle-b-2.0.0.tgz",
@@ -34899,7 +35030,7 @@ Node {
 }
 `
 
-exports[`test/arborist/build-ideal-tree.js TAP nested cyclical peer deps peer-dep-cycle-nested > upgrade c 1`] = `
+exports[`test/arborist/build-ideal-tree.js TAP nested cyclical peer deps peer-dep-cycle-nested > upgrade c, forcibly 1`] = `
 Node {
   "children": Map {
     "@isaacs/peer-dep-cycle" => Node {
@@ -35485,6 +35616,12 @@ Node {
     "@isaacs/peer-dep-cycle-a" => Node {
       "edgesIn": Set {
         Edge {
+          "from": "",
+          "name": "@isaacs/peer-dep-cycle-a",
+          "spec": "2.x",
+          "type": "prod",
+        },
+        Edge {
           "from": "node_modules/@isaacs/peer-dep-cycle-c",
           "name": "@isaacs/peer-dep-cycle-a",
           "spec": "2",
@@ -35501,7 +35638,6 @@ Node {
       },
       "location": "node_modules/@isaacs/peer-dep-cycle-a",
       "name": "@isaacs/peer-dep-cycle-a",
-      "peer": true,
       "resolved": "https://registry.npmjs.org/@isaacs/peer-dep-cycle-a/-/peer-dep-cycle-a-2.0.0.tgz",
     },
     "@isaacs/peer-dep-cycle-b" => Node {
@@ -35561,6 +35697,12 @@ Node {
       "to": "node_modules/@isaacs/peer-dep-cycle",
       "type": "prod",
     },
+    "@isaacs/peer-dep-cycle-a" => Edge {
+      "name": "@isaacs/peer-dep-cycle-a",
+      "spec": "2.x",
+      "to": "node_modules/@isaacs/peer-dep-cycle-a",
+      "type": "prod",
+    },
     "@isaacs/peer-dep-cycle-b" => Edge {
       "name": "@isaacs/peer-dep-cycle-b",
       "spec": "https://registry.npmjs.org/@isaacs/peer-dep-cycle-b/-/peer-dep-cycle-b-2.0.0.tgz",
@@ -35574,7 +35716,7 @@ Node {
 }
 `
 
-exports[`test/arborist/build-ideal-tree.js TAP nested cyclical peer deps peer-dep-cycle-nested-with-sw > upgrade c 1`] = `
+exports[`test/arborist/build-ideal-tree.js TAP nested cyclical peer deps peer-dep-cycle-nested-with-sw > upgrade c, forcibly 1`] = `
 Node {
   "children": Map {
     "@isaacs/peer-dep-cycle" => Node {
@@ -36337,7 +36479,6 @@ Node {
     "@isaacs/testing-peer-dep-conflict-chain-a" => Node {
       "edgesIn": Set {
         Edge {
-          "error": "INVALID",
           "from": "",
           "name": "@isaacs/testing-peer-dep-conflict-chain-a",
           "spec": "2",
@@ -36346,10 +36487,11 @@ Node {
         Edge {
           "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-e",
           "name": "@isaacs/testing-peer-dep-conflict-chain-a",
-          "spec": "1",
+          "spec": "2",
           "type": "peer",
         },
         Edge {
+          "error": "INVALID",
           "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-v",
           "name": "@isaacs/testing-peer-dep-conflict-chain-a",
           "spec": "1",
@@ -36359,7 +36501,7 @@ Node {
       "edgesOut": Map {
         "@isaacs/testing-peer-dep-conflict-chain-b" => Edge {
           "name": "@isaacs/testing-peer-dep-conflict-chain-b",
-          "spec": "1",
+          "spec": "2",
           "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-b",
           "type": "peer",
         },
@@ -36367,21 +36509,21 @@ Node {
       "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
       "name": "@isaacs/testing-peer-dep-conflict-chain-a",
       "peer": true,
-      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-a/-/testing-peer-dep-conflict-chain-a-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-a/-/testing-peer-dep-conflict-chain-a-2.0.0.tgz",
     },
     "@isaacs/testing-peer-dep-conflict-chain-b" => Node {
       "edgesIn": Set {
         Edge {
           "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
           "name": "@isaacs/testing-peer-dep-conflict-chain-b",
-          "spec": "1",
+          "spec": "2",
           "type": "peer",
         },
       },
       "edgesOut": Map {
         "@isaacs/testing-peer-dep-conflict-chain-c" => Edge {
           "name": "@isaacs/testing-peer-dep-conflict-chain-c",
-          "spec": "1",
+          "spec": "2",
           "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-c",
           "type": "peer",
         },
@@ -36389,21 +36531,21 @@ Node {
       "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-b",
       "name": "@isaacs/testing-peer-dep-conflict-chain-b",
       "peer": true,
-      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-b/-/testing-peer-dep-conflict-chain-b-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-b/-/testing-peer-dep-conflict-chain-b-2.0.0.tgz",
     },
     "@isaacs/testing-peer-dep-conflict-chain-c" => Node {
       "edgesIn": Set {
         Edge {
           "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-b",
           "name": "@isaacs/testing-peer-dep-conflict-chain-c",
-          "spec": "1",
+          "spec": "2",
           "type": "peer",
         },
       },
       "edgesOut": Map {
         "@isaacs/testing-peer-dep-conflict-chain-d" => Edge {
           "name": "@isaacs/testing-peer-dep-conflict-chain-d",
-          "spec": "1",
+          "spec": "2",
           "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-d",
           "type": "peer",
         },
@@ -36411,21 +36553,21 @@ Node {
       "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-c",
       "name": "@isaacs/testing-peer-dep-conflict-chain-c",
       "peer": true,
-      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-c/-/testing-peer-dep-conflict-chain-c-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-c/-/testing-peer-dep-conflict-chain-c-2.0.0.tgz",
     },
     "@isaacs/testing-peer-dep-conflict-chain-d" => Node {
       "edgesIn": Set {
         Edge {
           "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-c",
           "name": "@isaacs/testing-peer-dep-conflict-chain-d",
-          "spec": "1",
+          "spec": "2",
           "type": "peer",
         },
       },
       "edgesOut": Map {
         "@isaacs/testing-peer-dep-conflict-chain-e" => Edge {
           "name": "@isaacs/testing-peer-dep-conflict-chain-e",
-          "spec": "1",
+          "spec": "2",
           "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-e",
           "type": "peer",
         },
@@ -36433,21 +36575,21 @@ Node {
       "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-d",
       "name": "@isaacs/testing-peer-dep-conflict-chain-d",
       "peer": true,
-      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-d/-/testing-peer-dep-conflict-chain-d-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-d/-/testing-peer-dep-conflict-chain-d-2.0.0.tgz",
     },
     "@isaacs/testing-peer-dep-conflict-chain-e" => Node {
       "edgesIn": Set {
         Edge {
           "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-d",
           "name": "@isaacs/testing-peer-dep-conflict-chain-e",
-          "spec": "1",
+          "spec": "2",
           "type": "peer",
         },
       },
       "edgesOut": Map {
         "@isaacs/testing-peer-dep-conflict-chain-a" => Edge {
           "name": "@isaacs/testing-peer-dep-conflict-chain-a",
-          "spec": "1",
+          "spec": "2",
           "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
           "type": "peer",
         },
@@ -36455,7 +36597,7 @@ Node {
       "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-e",
       "name": "@isaacs/testing-peer-dep-conflict-chain-e",
       "peer": true,
-      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-e/-/testing-peer-dep-conflict-chain-e-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-e/-/testing-peer-dep-conflict-chain-e-2.0.0.tgz",
     },
     "@isaacs/testing-peer-dep-conflict-chain-v" => Node {
       "edgesIn": Set {
@@ -36468,6 +36610,7 @@ Node {
       },
       "edgesOut": Map {
         "@isaacs/testing-peer-dep-conflict-chain-a" => Edge {
+          "error": "INVALID",
           "name": "@isaacs/testing-peer-dep-conflict-chain-a",
           "spec": "1",
           "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
@@ -36481,7 +36624,6 @@ Node {
   },
   "edgesOut": Map {
     "@isaacs/testing-peer-dep-conflict-chain-a" => Edge {
-      "error": "INVALID",
       "name": "@isaacs/testing-peer-dep-conflict-chain-a",
       "spec": "2",
       "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
@@ -36506,7 +36648,6 @@ Node {
     "@isaacs/testing-peer-dep-conflict-chain-a" => Node {
       "edgesIn": Set {
         Edge {
-          "error": "INVALID",
           "from": "",
           "name": "@isaacs/testing-peer-dep-conflict-chain-a",
           "spec": "2",
@@ -36515,10 +36656,11 @@ Node {
         Edge {
           "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-e",
           "name": "@isaacs/testing-peer-dep-conflict-chain-a",
-          "spec": "1",
+          "spec": "2",
           "type": "peer",
         },
         Edge {
+          "error": "INVALID",
           "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-v",
           "name": "@isaacs/testing-peer-dep-conflict-chain-a",
           "spec": "1",
@@ -36528,7 +36670,7 @@ Node {
       "edgesOut": Map {
         "@isaacs/testing-peer-dep-conflict-chain-b" => Edge {
           "name": "@isaacs/testing-peer-dep-conflict-chain-b",
-          "spec": "1",
+          "spec": "2",
           "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-b",
           "type": "peer",
         },
@@ -36536,21 +36678,21 @@ Node {
       "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
       "name": "@isaacs/testing-peer-dep-conflict-chain-a",
       "peer": true,
-      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-a/-/testing-peer-dep-conflict-chain-a-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-a/-/testing-peer-dep-conflict-chain-a-2.0.0.tgz",
     },
     "@isaacs/testing-peer-dep-conflict-chain-b" => Node {
       "edgesIn": Set {
         Edge {
           "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
           "name": "@isaacs/testing-peer-dep-conflict-chain-b",
-          "spec": "1",
+          "spec": "2",
           "type": "peer",
         },
       },
       "edgesOut": Map {
         "@isaacs/testing-peer-dep-conflict-chain-c" => Edge {
           "name": "@isaacs/testing-peer-dep-conflict-chain-c",
-          "spec": "1",
+          "spec": "2",
           "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-c",
           "type": "peer",
         },
@@ -36558,21 +36700,21 @@ Node {
       "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-b",
       "name": "@isaacs/testing-peer-dep-conflict-chain-b",
       "peer": true,
-      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-b/-/testing-peer-dep-conflict-chain-b-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-b/-/testing-peer-dep-conflict-chain-b-2.0.0.tgz",
     },
     "@isaacs/testing-peer-dep-conflict-chain-c" => Node {
       "edgesIn": Set {
         Edge {
           "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-b",
           "name": "@isaacs/testing-peer-dep-conflict-chain-c",
-          "spec": "1",
+          "spec": "2",
           "type": "peer",
         },
       },
       "edgesOut": Map {
         "@isaacs/testing-peer-dep-conflict-chain-d" => Edge {
           "name": "@isaacs/testing-peer-dep-conflict-chain-d",
-          "spec": "1",
+          "spec": "2",
           "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-d",
           "type": "peer",
         },
@@ -36580,21 +36722,21 @@ Node {
       "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-c",
       "name": "@isaacs/testing-peer-dep-conflict-chain-c",
       "peer": true,
-      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-c/-/testing-peer-dep-conflict-chain-c-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-c/-/testing-peer-dep-conflict-chain-c-2.0.0.tgz",
     },
     "@isaacs/testing-peer-dep-conflict-chain-d" => Node {
       "edgesIn": Set {
         Edge {
           "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-c",
           "name": "@isaacs/testing-peer-dep-conflict-chain-d",
-          "spec": "1",
+          "spec": "2",
           "type": "peer",
         },
       },
       "edgesOut": Map {
         "@isaacs/testing-peer-dep-conflict-chain-e" => Edge {
           "name": "@isaacs/testing-peer-dep-conflict-chain-e",
-          "spec": "1",
+          "spec": "2",
           "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-e",
           "type": "peer",
         },
@@ -36602,21 +36744,21 @@ Node {
       "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-d",
       "name": "@isaacs/testing-peer-dep-conflict-chain-d",
       "peer": true,
-      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-d/-/testing-peer-dep-conflict-chain-d-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-d/-/testing-peer-dep-conflict-chain-d-2.0.0.tgz",
     },
     "@isaacs/testing-peer-dep-conflict-chain-e" => Node {
       "edgesIn": Set {
         Edge {
           "from": "node_modules/@isaacs/testing-peer-dep-conflict-chain-d",
           "name": "@isaacs/testing-peer-dep-conflict-chain-e",
-          "spec": "1",
+          "spec": "2",
           "type": "peer",
         },
       },
       "edgesOut": Map {
         "@isaacs/testing-peer-dep-conflict-chain-a" => Edge {
           "name": "@isaacs/testing-peer-dep-conflict-chain-a",
-          "spec": "1",
+          "spec": "2",
           "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
           "type": "peer",
         },
@@ -36624,7 +36766,7 @@ Node {
       "location": "node_modules/@isaacs/testing-peer-dep-conflict-chain-e",
       "name": "@isaacs/testing-peer-dep-conflict-chain-e",
       "peer": true,
-      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-e/-/testing-peer-dep-conflict-chain-e-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-e/-/testing-peer-dep-conflict-chain-e-2.0.0.tgz",
     },
     "@isaacs/testing-peer-dep-conflict-chain-v" => Node {
       "edgesIn": Set {
@@ -36637,6 +36779,7 @@ Node {
       },
       "edgesOut": Map {
         "@isaacs/testing-peer-dep-conflict-chain-a" => Edge {
+          "error": "INVALID",
           "name": "@isaacs/testing-peer-dep-conflict-chain-a",
           "spec": "1",
           "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",
@@ -36650,7 +36793,6 @@ Node {
   },
   "edgesOut": Map {
     "@isaacs/testing-peer-dep-conflict-chain-a" => Edge {
-      "error": "INVALID",
       "name": "@isaacs/testing-peer-dep-conflict-chain-a",
       "spec": "2",
       "to": "node_modules/@isaacs/testing-peer-dep-conflict-chain-a",

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-p.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-p.json
@@ -1,0 +1,86 @@
+{
+  "_id": "@isaacs/testing-peer-dep-nesting-p",
+  "_rev": "1-0bf8fecd30180ad97633b8e9014ae6a3",
+  "name": "@isaacs/testing-peer-dep-nesting-p",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-p",
+      "version": "1.0.0",
+      "_id": "@isaacs/testing-peer-dep-nesting-p@1.0.0",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "7.0.0",
+      "dist": {
+        "integrity": "sha512-u5nmSKdGev1i4v4SrDnJwgJPuh8jtsuXKJ++xzGv6uaVbjtRDdbE03Dj0ag+sbTE+Kw8H7uf7Y1wytHjmY/nfw==",
+        "shasum": "df80f2f7d6fcbdaa16bcb85b03079674af82064b",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-p/-/testing-peer-dep-nesting-p-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 73,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh3uSCRA9TVsSAnZWagAAliYP/3mrRmSViJz9Fey3g/Lu\nOVlpLgcUOr9bT5MkY9TZd4zQJHt9CvrrRI1OR7yCOp0DMkQGhO3Mlf10G4x5\nPUSePlkzMgpNsOI/6O8UWudEJprbFHE9993uzRjlSwbwv4Pt/FVhSJaC6/Nu\ngZ1Tf3XL0xt1Y1hi4ktJLH+DRl0hlYGxekgEUa78KcuLXP1jePjAOd1Pl093\nR/SabfQGnPfZq8Wi0mR+gbX0UV1WmHgMwyG+R10Ivzp2kkbNF1ZentbGM8da\nDUiqS7eObFCEOQ5WlsEOCfq7/8TuwU0cLD7bTUyeBG1G9uL/1DT8cMAyDQI7\nj0A64fiu+neJi62DCa63+kM286pBTQeEUZFgTOeymZdHjFEkDyAAh321Kc2g\nZlQrrnZG3wC0m4zo4XWthIwfnXhdw+6a2eNMj68Fja0m4tqTRXfgotm20ZzL\nEO41wMfDXCbi5mlb5TJ6j6JZHQM8T5RoSDEjAR7mIKiJlWJs82gINWYVr/yL\nOxPABKucaruwcUjEu4TqS2oH3+mdzmNf+u01ZQUVoQCMWG193W6Aqx3n9VDv\nsYBL4Tg6QdJUtNy3bm8KA9eVGlpfi7HYiJ3llV2NHECIbloZ6XVf+8y1DXEJ\n6G8EmUwzaZLR2CYCXGbhqZkoomP4xDU5ErUy0sYrVqM6T/nzdkEuPZjYx67k\nPkIz\r\n=Ag0L\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-nesting-p_1.0.0_1602714514015_0.4977098843396395"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-p",
+      "version": "2.0.0",
+      "_id": "@isaacs/testing-peer-dep-nesting-p@2.0.0",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "7.0.0",
+      "dist": {
+        "integrity": "sha512-e/Hx7lKTnGBlPObOtYUvZRseduFJ8rvSoDgz0g9af4cith0A41H/1pElj8S2IZGNZgKiGnS5dSmzSC8nu0A1qA==",
+        "shasum": "a2ef120bf07d1b0a3721df9864a30e07092d389b",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-p/-/testing-peer-dep-nesting-p-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 73,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh3uVCRA9TVsSAnZWagAAaH8P/jCTcqUrBhXW/TQWueO4\nSrTOmM58zw+q59TcW35+ZlzreALQwMz/nNQJKTekt+Lo0H/P/j9o8BOHmF2V\nlSP5Z99ct1JJdjULZHg7yb2cnPCpZNFCkNVpuaUhjWZNcYViad/YuCzdOe6K\nmqJ9x3QA4rhs/60Q80w+aYmyd9hSep/BKxW48g5vWxzMxEV94cbh6/Ki5Dqe\nKAGxXIcTWzwPHA2TcG3qPTRQd7VvaQgmQgX4ESBN2dMEJiN/BaA1juKzZs6h\ngwpIoqyfXDLSlUBAxjHsTaqEGlv/z0xgQAgYWkC397+esf06Z8ygSSSxrGjL\nCa3TXdzl2KeUHEXX59SE9/jd+Sp/YACrhucoYj0nqH0QD73J+qPkuwJyldxS\ntSUn3PoI0Oc6pxNlz165smVLEY2r+4U5FtcAyToPtqKOauD5giZj98+nU3ca\nxn/wOnwKFHuln9kwSKEC/NH0ijpfJfIEcSAVOs9/dlaQ/4hHon0y+gPEIMLM\nEEhZc93BHCa7BjOZqqGuFoYscy2wALUhP20oGVaK3VEnG9fkvJaGGM6d2fFN\nUOdR2XQGfXSqGekO43u/27XqlDRTVdgc4bkmR2oUV7aYHNUvtFWzKqkfFkSL\nMJiQpamkH1KAckov3PAIX0bsy9cYYIF1fVK7hIyW7RjyI4mGT1SUmuB/vjLB\nKH9w\r\n=bFuX\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-nesting-p_2.0.0_1602714517203_0.06727455861772458"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2020-10-14T22:28:33.966Z",
+    "1.0.0": "2020-10-14T22:28:34.119Z",
+    "modified": "2020-10-14T22:28:39.517Z",
+    "2.0.0": "2020-10-14T22:28:37.320Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-p.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-p.min.json
@@ -1,0 +1,33 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-p",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-p",
+      "version": "1.0.0",
+      "dist": {
+        "integrity": "sha512-u5nmSKdGev1i4v4SrDnJwgJPuh8jtsuXKJ++xzGv6uaVbjtRDdbE03Dj0ag+sbTE+Kw8H7uf7Y1wytHjmY/nfw==",
+        "shasum": "df80f2f7d6fcbdaa16bcb85b03079674af82064b",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-p/-/testing-peer-dep-nesting-p-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 73,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh3uSCRA9TVsSAnZWagAAliYP/3mrRmSViJz9Fey3g/Lu\nOVlpLgcUOr9bT5MkY9TZd4zQJHt9CvrrRI1OR7yCOp0DMkQGhO3Mlf10G4x5\nPUSePlkzMgpNsOI/6O8UWudEJprbFHE9993uzRjlSwbwv4Pt/FVhSJaC6/Nu\ngZ1Tf3XL0xt1Y1hi4ktJLH+DRl0hlYGxekgEUa78KcuLXP1jePjAOd1Pl093\nR/SabfQGnPfZq8Wi0mR+gbX0UV1WmHgMwyG+R10Ivzp2kkbNF1ZentbGM8da\nDUiqS7eObFCEOQ5WlsEOCfq7/8TuwU0cLD7bTUyeBG1G9uL/1DT8cMAyDQI7\nj0A64fiu+neJi62DCa63+kM286pBTQeEUZFgTOeymZdHjFEkDyAAh321Kc2g\nZlQrrnZG3wC0m4zo4XWthIwfnXhdw+6a2eNMj68Fja0m4tqTRXfgotm20ZzL\nEO41wMfDXCbi5mlb5TJ6j6JZHQM8T5RoSDEjAR7mIKiJlWJs82gINWYVr/yL\nOxPABKucaruwcUjEu4TqS2oH3+mdzmNf+u01ZQUVoQCMWG193W6Aqx3n9VDv\nsYBL4Tg6QdJUtNy3bm8KA9eVGlpfi7HYiJ3llV2NHECIbloZ6XVf+8y1DXEJ\n6G8EmUwzaZLR2CYCXGbhqZkoomP4xDU5ErUy0sYrVqM6T/nzdkEuPZjYx67k\nPkIz\r\n=Ag0L\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-p",
+      "version": "2.0.0",
+      "dist": {
+        "integrity": "sha512-e/Hx7lKTnGBlPObOtYUvZRseduFJ8rvSoDgz0g9af4cith0A41H/1pElj8S2IZGNZgKiGnS5dSmzSC8nu0A1qA==",
+        "shasum": "a2ef120bf07d1b0a3721df9864a30e07092d389b",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-p/-/testing-peer-dep-nesting-p-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 73,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh3uVCRA9TVsSAnZWagAAaH8P/jCTcqUrBhXW/TQWueO4\nSrTOmM58zw+q59TcW35+ZlzreALQwMz/nNQJKTekt+Lo0H/P/j9o8BOHmF2V\nlSP5Z99ct1JJdjULZHg7yb2cnPCpZNFCkNVpuaUhjWZNcYViad/YuCzdOe6K\nmqJ9x3QA4rhs/60Q80w+aYmyd9hSep/BKxW48g5vWxzMxEV94cbh6/Ki5Dqe\nKAGxXIcTWzwPHA2TcG3qPTRQd7VvaQgmQgX4ESBN2dMEJiN/BaA1juKzZs6h\ngwpIoqyfXDLSlUBAxjHsTaqEGlv/z0xgQAgYWkC397+esf06Z8ygSSSxrGjL\nCa3TXdzl2KeUHEXX59SE9/jd+Sp/YACrhucoYj0nqH0QD73J+qPkuwJyldxS\ntSUn3PoI0Oc6pxNlz165smVLEY2r+4U5FtcAyToPtqKOauD5giZj98+nU3ca\nxn/wOnwKFHuln9kwSKEC/NH0ijpfJfIEcSAVOs9/dlaQ/4hHon0y+gPEIMLM\nEEhZc93BHCa7BjOZqqGuFoYscy2wALUhP20oGVaK3VEnG9fkvJaGGM6d2fFN\nUOdR2XQGfXSqGekO43u/27XqlDRTVdgc4bkmR2oUV7aYHNUvtFWzKqkfFkSL\nMJiQpamkH1KAckov3PAIX0bsy9cYYIF1fVK7hIyW7RjyI4mGT1SUmuB/vjLB\nKH9w\r\n=bFuX\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-10-14T22:28:39.517Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-q.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-q.json
@@ -1,0 +1,56 @@
+{
+  "_id": "@isaacs/testing-peer-dep-nesting-q",
+  "name": "@isaacs/testing-peer-dep-nesting-q",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-q",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-nesting-p": "1"
+      },
+      "_id": "@isaacs/testing-peer-dep-nesting-q@1.0.0",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "7.0.0",
+      "dist": {
+        "integrity": "sha512-h9xsHVi9ToO++a+yY6rIJnvsEt1TheFD65JFpvQD+xbfhh4D3sxnYN0EKfmewAEDPJXlizy0bOJctN1co5Ve9A==",
+        "shasum": "8938b4b71c733a74b3e4c3840b03bdc62a315ba4",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-q/-/testing-peer-dep-nesting-q-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 148,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh3ubCRA9TVsSAnZWagAASEYP/Re4LS8hHi8/w1Tt12aU\n6ZOi9CnUXhq/oIdPYlacgVp86GHYac7GtjFE/rCKVMi7t/bjsgV+BQcytPTm\n7lOcZ4wBmsmNM51gu0qqkoR5wRnd2va1FoEWj5Hw8J4mc+8hNOu10hZMM6Gz\nZpyum2ZBvnJALZ/tY7NBIGy4SRu521ylKJEGNfJGR8kne4haCQo9cfMygg2R\nPLGt9lMjU5/YT8LDirJUKpnloQA1cXq1c45JIHnBGRlXCY2d3+epLWJ3tVnm\nJHZAWqjyKQSFSfEOzNzizbuDrCFBpVokMOeqDff6OuJ4mqjJwlTg/qus6bwm\nhFm49kT0NbcIrgJYxp7xqxH5RR+tICGGLb48XcqCp1gB6LO4dqpW68/cDC3N\nXWGqqFO+ai/IgD9KinSVinqF/WcoSoTJcAHeA3/leNQ9IXygTBtkyz+TV8kD\nvfsedNIJKvcm0IZhV0fqMPoG34NTTjSM+p6OpUW/9hMX1wq1f52JtxSYEsN/\n9oL5Sn+A+s/+W8Qeap1YD7V+sBC+isJmaV67TDOIsxzjoPaC97sQdmcXE9mI\njLC39x7/ZgFl6ClqlDPWECdgHxnqWN9D3pGiFlMBAjZV/bONypOv99jAdZ3L\n9e22fJUD+Q3ESe5tOL2GwDzG2Sc+uuzF0XGBnG7/SbklTWwqn10S8plgKUJu\nKaUf\r\n=l4H2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-nesting-q_1.0.0_1602714523619_0.6429142883627736"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2020-10-14T22:28:43.586Z",
+    "1.0.0": "2020-10-14T22:28:43.740Z",
+    "modified": "2020-10-14T22:28:45.957Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-q.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-q.min.json
@@ -1,0 +1,24 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-q",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-q",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-nesting-p": "1"
+      },
+      "dist": {
+        "integrity": "sha512-h9xsHVi9ToO++a+yY6rIJnvsEt1TheFD65JFpvQD+xbfhh4D3sxnYN0EKfmewAEDPJXlizy0bOJctN1co5Ve9A==",
+        "shasum": "8938b4b71c733a74b3e4c3840b03bdc62a315ba4",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-q/-/testing-peer-dep-nesting-q-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 148,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh3ubCRA9TVsSAnZWagAASEYP/Re4LS8hHi8/w1Tt12aU\n6ZOi9CnUXhq/oIdPYlacgVp86GHYac7GtjFE/rCKVMi7t/bjsgV+BQcytPTm\n7lOcZ4wBmsmNM51gu0qqkoR5wRnd2va1FoEWj5Hw8J4mc+8hNOu10hZMM6Gz\nZpyum2ZBvnJALZ/tY7NBIGy4SRu521ylKJEGNfJGR8kne4haCQo9cfMygg2R\nPLGt9lMjU5/YT8LDirJUKpnloQA1cXq1c45JIHnBGRlXCY2d3+epLWJ3tVnm\nJHZAWqjyKQSFSfEOzNzizbuDrCFBpVokMOeqDff6OuJ4mqjJwlTg/qus6bwm\nhFm49kT0NbcIrgJYxp7xqxH5RR+tICGGLb48XcqCp1gB6LO4dqpW68/cDC3N\nXWGqqFO+ai/IgD9KinSVinqF/WcoSoTJcAHeA3/leNQ9IXygTBtkyz+TV8kD\nvfsedNIJKvcm0IZhV0fqMPoG34NTTjSM+p6OpUW/9hMX1wq1f52JtxSYEsN/\n9oL5Sn+A+s/+W8Qeap1YD7V+sBC+isJmaV67TDOIsxzjoPaC97sQdmcXE9mI\njLC39x7/ZgFl6ClqlDPWECdgHxnqWN9D3pGiFlMBAjZV/bONypOv99jAdZ3L\n9e22fJUD+Q3ESe5tOL2GwDzG2Sc+uuzF0XGBnG7/SbklTWwqn10S8plgKUJu\nKaUf\r\n=l4H2\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-10-14T22:28:45.957Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-s.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-s.json
@@ -1,0 +1,93 @@
+{
+  "_id": "@isaacs/testing-peer-dep-nesting-s",
+  "_rev": "1-5cbb0399fc9db0cacd8bd422c5f9587d",
+  "name": "@isaacs/testing-peer-dep-nesting-s",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-s",
+      "version": "1.0.0",
+      "dependencies": {
+        "@isaacs/testing-peer-dep-nesting-x": ""
+      },
+      "_id": "@isaacs/testing-peer-dep-nesting-s@1.0.0",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "7.0.0",
+      "dist": {
+        "integrity": "sha512-M44jY3zMyM1sp/p53mp7QVr8DF4R4XRFa2TbaH/yQ0bo7/JOMrMEwcxyjUw8oDHbPE8926yoUwqBr8Jivp7kTg==",
+        "shasum": "c4f43f86673b77e0b85fb290ec3f542f9870604e",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-s/-/testing-peer-dep-nesting-s-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 143,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh3uOCRA9TVsSAnZWagAAkz0QAIS1HbM8mDnonhmujx9O\nLHJ4UvvKAjhtpBZQdi0gnWm5s9UMVpLf8Ih6hM6AWiFEgftIuS9kI35nniWY\nb844BdQIUnqC8/nloLE8OoiDekRrd6Ww7g8mI7pDn2GCsb01oEKhM/+eZWy+\nyIzVCPNEkKoQfYVbohGOzj8Js0aLFtWC8poJCAALupP74c0gixbuqhnJKbK9\n8MT/+/Qo/X2YXo3lsEj0kSLTCrNOflL7pPJjrv3Nc0BDdPoDCfXzKNVgZB8Z\n0On7X8ogkd1UOG9ZNPPqDhcvSVESd8n3B4MBZQ0rA67LRP0GgSjFQ3/PVdmi\nM6N6h/Sdz08+/5Nra3EBZSGX3fqM6ii+cst24p1W1p6bKvGrFbDKZku8qsQk\nK2YGL3QynCG3Q2rlTQm5UBep7wIE/WZhsA8N8zpr6iLlqZaakqnPuIiOxNmV\nNbY+in5BQUX1yBmyD16OiAArxfBn5ZcENcVrQajOci8e1ktFqPcdi2ogM7R6\nEQEuSwQAPtZZVo0I60/d8/dwEQuZxI+zLEfU4wXbmwJLb1oyk2K+KwuyRliz\ntGVajZGfynOXtwpTAiORE3/Ki0c9on6+S2MN6kYstnSm19q8mYMDDs43HzS8\nrc70hRTKXNkxuDF4tbMyL6By2LYCPZcA0PLRnlaWJoq2PSkN6U4Y7x2vmbIi\nMsUQ\r\n=wejX\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-nesting-s_1.0.0_1602714510055_0.6056304457889243"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-s",
+      "version": "2.0.0",
+      "dependencies": {
+        "@isaacs/testing-peer-dep-nesting-x": "",
+        "@isaacs/testing-peer-dep-nesting-y": ""
+      },
+      "_id": "@isaacs/testing-peer-dep-nesting-s@2.0.0",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "7.0.0",
+      "dist": {
+        "integrity": "sha512-YDwpDd/L37TeXDZgsLtUdRrH+QDBc2taarh9fKTjc29pnhwrwU4WWFPtfzL5kfjKMwWSqMcLjd5egljquwuIJg==",
+        "shasum": "58b288c2ebc06dc9658ae0757549eecd508cd72c",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-s/-/testing-peer-dep-nesting-s-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 189,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh30jCRA9TVsSAnZWagAAiaYP/24F3+qzoTHQiobiRrco\nCSvzBjr408+Nk4TVOimzqIDG7mj/Loj7DawHs7vqkESS0sova1hrD31brJxW\nM5ImbFyII/VRmRCXyHvsANUBbrRcLDXw1a83PKfrIYS5FkB+oTf2BMkXvESf\nwXBkYTf+3okj8aZg4ku+dAD2jNhnTju6a/i6ceA3quMcSRZc1GWOJ2rqnYtw\nZA6fsirZj2ooVKyzEiGEuB6i4VV/CYo5ojywRhtYIsFx9bu0ek4hFnAk5hPk\nLyGlr3/NFXP1a03tMfJtpsA99+4+YEmwzZsZnNhtzFySM6K5ZHnKwRt3W4bF\n0qpCOJ2jSiLQ9YXhqU2lI6rOOxsWP42bC+CkqE+GSYZjsWtWy0WN93siYdP9\nAWOrV4VCkulUL3Lg5uSI3ayKP8iUKBTayTgNbjcaltuC79+yj0CJe8NsUvN1\nAvUA9YdZaRLOj4pR7skFqEFv88PlyHpOlsQ6c8VOO1XAzOjjdl1oixqC9dce\nOUN5qJx5NeI95/XSHEfUVYJ2P5ZxMnfC8PDFpH6dsHYxBU8qkYbTyrHR/0CE\nmgLKtbmTrWrBQ60OKEvzPDVUx8+rpCeEkznimKX1Q31a7V36dStxlpjxpeQ6\nALCGmO2+HLMbcN2BWrnAEkzSYw2qZv/y0Kewr01gAfz/WTfLAOQ9J1k9klse\nlbNb\r\n=7M21\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-nesting-s_2.0.0_1602714913535_0.5544685647434773"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2020-10-14T22:28:29.992Z",
+    "1.0.0": "2020-10-14T22:28:30.271Z",
+    "modified": "2020-10-14T22:35:17.896Z",
+    "2.0.0": "2020-10-14T22:35:15.608Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-s.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-s.min.json
@@ -1,0 +1,40 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-s",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-s",
+      "version": "1.0.0",
+      "dependencies": {
+        "@isaacs/testing-peer-dep-nesting-x": ""
+      },
+      "dist": {
+        "integrity": "sha512-M44jY3zMyM1sp/p53mp7QVr8DF4R4XRFa2TbaH/yQ0bo7/JOMrMEwcxyjUw8oDHbPE8926yoUwqBr8Jivp7kTg==",
+        "shasum": "c4f43f86673b77e0b85fb290ec3f542f9870604e",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-s/-/testing-peer-dep-nesting-s-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 143,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh3uOCRA9TVsSAnZWagAAkz0QAIS1HbM8mDnonhmujx9O\nLHJ4UvvKAjhtpBZQdi0gnWm5s9UMVpLf8Ih6hM6AWiFEgftIuS9kI35nniWY\nb844BdQIUnqC8/nloLE8OoiDekRrd6Ww7g8mI7pDn2GCsb01oEKhM/+eZWy+\nyIzVCPNEkKoQfYVbohGOzj8Js0aLFtWC8poJCAALupP74c0gixbuqhnJKbK9\n8MT/+/Qo/X2YXo3lsEj0kSLTCrNOflL7pPJjrv3Nc0BDdPoDCfXzKNVgZB8Z\n0On7X8ogkd1UOG9ZNPPqDhcvSVESd8n3B4MBZQ0rA67LRP0GgSjFQ3/PVdmi\nM6N6h/Sdz08+/5Nra3EBZSGX3fqM6ii+cst24p1W1p6bKvGrFbDKZku8qsQk\nK2YGL3QynCG3Q2rlTQm5UBep7wIE/WZhsA8N8zpr6iLlqZaakqnPuIiOxNmV\nNbY+in5BQUX1yBmyD16OiAArxfBn5ZcENcVrQajOci8e1ktFqPcdi2ogM7R6\nEQEuSwQAPtZZVo0I60/d8/dwEQuZxI+zLEfU4wXbmwJLb1oyk2K+KwuyRliz\ntGVajZGfynOXtwpTAiORE3/Ki0c9on6+S2MN6kYstnSm19q8mYMDDs43HzS8\nrc70hRTKXNkxuDF4tbMyL6By2LYCPZcA0PLRnlaWJoq2PSkN6U4Y7x2vmbIi\nMsUQ\r\n=wejX\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-s",
+      "version": "2.0.0",
+      "dependencies": {
+        "@isaacs/testing-peer-dep-nesting-x": "",
+        "@isaacs/testing-peer-dep-nesting-y": ""
+      },
+      "dist": {
+        "integrity": "sha512-YDwpDd/L37TeXDZgsLtUdRrH+QDBc2taarh9fKTjc29pnhwrwU4WWFPtfzL5kfjKMwWSqMcLjd5egljquwuIJg==",
+        "shasum": "58b288c2ebc06dc9658ae0757549eecd508cd72c",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-s/-/testing-peer-dep-nesting-s-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 189,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh30jCRA9TVsSAnZWagAAiaYP/24F3+qzoTHQiobiRrco\nCSvzBjr408+Nk4TVOimzqIDG7mj/Loj7DawHs7vqkESS0sova1hrD31brJxW\nM5ImbFyII/VRmRCXyHvsANUBbrRcLDXw1a83PKfrIYS5FkB+oTf2BMkXvESf\nwXBkYTf+3okj8aZg4ku+dAD2jNhnTju6a/i6ceA3quMcSRZc1GWOJ2rqnYtw\nZA6fsirZj2ooVKyzEiGEuB6i4VV/CYo5ojywRhtYIsFx9bu0ek4hFnAk5hPk\nLyGlr3/NFXP1a03tMfJtpsA99+4+YEmwzZsZnNhtzFySM6K5ZHnKwRt3W4bF\n0qpCOJ2jSiLQ9YXhqU2lI6rOOxsWP42bC+CkqE+GSYZjsWtWy0WN93siYdP9\nAWOrV4VCkulUL3Lg5uSI3ayKP8iUKBTayTgNbjcaltuC79+yj0CJe8NsUvN1\nAvUA9YdZaRLOj4pR7skFqEFv88PlyHpOlsQ6c8VOO1XAzOjjdl1oixqC9dce\nOUN5qJx5NeI95/XSHEfUVYJ2P5ZxMnfC8PDFpH6dsHYxBU8qkYbTyrHR/0CE\nmgLKtbmTrWrBQ60OKEvzPDVUx8+rpCeEkznimKX1Q31a7V36dStxlpjxpeQ6\nALCGmO2+HLMbcN2BWrnAEkzSYw2qZv/y0Kewr01gAfz/WTfLAOQ9J1k9klse\nlbNb\r\n=7M21\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-10-14T22:35:17.896Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-x.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-x.json
@@ -1,0 +1,57 @@
+{
+  "_id": "@isaacs/testing-peer-dep-nesting-x",
+  "name": "@isaacs/testing-peer-dep-nesting-x",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-x",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-nesting-p": "1",
+        "@isaacs/testing-peer-dep-nesting-q": "1"
+      },
+      "_id": "@isaacs/testing-peer-dep-nesting-x@1.0.0",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "7.0.0",
+      "dist": {
+        "integrity": "sha512-2mBmTa03/phLosQub/I3VXWXQblcEag8YFDRXXyyzSEwSSkWM3JxxYVzLAop2uuAtm3YBY89NT8bDb8kDOyu+g==",
+        "shasum": "b4a1e3407a3a2f82cb51ba3d4d88161f148d2b01",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-x/-/testing-peer-dep-nesting-x-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 195,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh3uYCRA9TVsSAnZWagAAQeEQAJW/zK8AxKVGKYID82eT\nG1Zcb9b+TDCl9BMCY4fdPHHyL9YOh2OglW5wfBmV1LI20vIuhZDNEW5J35RN\n4L6/TQhOsMMSRGUr2iDsewXmRFCWJwDs2vUMTngZVbEP0bIFIU3bUK5Qttim\npoX3Dep1CGY7vbrHQegd0qncxTVvY/LXIGzFPIDJrkMZG+iDAOObGb5AMX0B\nhg/mmilbmiO6sUkrnmFCbQBxa1N2bscsMGwp22WPz3p/wxmXkJoUm1axndiO\nryExey0A7ZS3vB8TyDx6eu7NSyJnAWjdwC7BAhTM8wdDcUTkwCFlettoc04D\nFiu2x2Csc8nhpRfhgxbsInFj7K+RJupIYfKIoXLTtQ8Gb4bm/md9sQPGk8zA\nakJ2Vkb562uy0ym9F38uNl6UVapWQllGSICn4/L5KYmyCM13Yz9rM2UTbT8d\norEOmgFaKIWX/JTgGUYR9iM1K1TPna9PBZnX76HXm4sSqIW/B9sngx7p5mH1\noU828GyCEho59ZIm21b7NnB+UEacDljrIf7QdtOn4nZ6iTinqAee1cUJYA+g\n6+HjWywK9RF+E85U6xswhb3wzKJHpUqGXqroNzrJwyvD3DgyI6TrrOPHV5no\ncwIimjKiBdr6JK3G/6S2GoH2G8zb4zqfrx+93Q0AiN/6W3t+gpn2QBfEQxP2\nCgS1\r\n=p0q6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-nesting-x_1.0.0_1602714520423_0.6145507876693845"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2020-10-14T22:28:40.372Z",
+    "1.0.0": "2020-10-14T22:28:40.529Z",
+    "modified": "2020-10-14T22:28:42.746Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-x.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-x.min.json
@@ -1,0 +1,25 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-x",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-x",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-nesting-p": "1",
+        "@isaacs/testing-peer-dep-nesting-q": "1"
+      },
+      "dist": {
+        "integrity": "sha512-2mBmTa03/phLosQub/I3VXWXQblcEag8YFDRXXyyzSEwSSkWM3JxxYVzLAop2uuAtm3YBY89NT8bDb8kDOyu+g==",
+        "shasum": "b4a1e3407a3a2f82cb51ba3d4d88161f148d2b01",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-x/-/testing-peer-dep-nesting-x-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 195,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh3uYCRA9TVsSAnZWagAAQeEQAJW/zK8AxKVGKYID82eT\nG1Zcb9b+TDCl9BMCY4fdPHHyL9YOh2OglW5wfBmV1LI20vIuhZDNEW5J35RN\n4L6/TQhOsMMSRGUr2iDsewXmRFCWJwDs2vUMTngZVbEP0bIFIU3bUK5Qttim\npoX3Dep1CGY7vbrHQegd0qncxTVvY/LXIGzFPIDJrkMZG+iDAOObGb5AMX0B\nhg/mmilbmiO6sUkrnmFCbQBxa1N2bscsMGwp22WPz3p/wxmXkJoUm1axndiO\nryExey0A7ZS3vB8TyDx6eu7NSyJnAWjdwC7BAhTM8wdDcUTkwCFlettoc04D\nFiu2x2Csc8nhpRfhgxbsInFj7K+RJupIYfKIoXLTtQ8Gb4bm/md9sQPGk8zA\nakJ2Vkb562uy0ym9F38uNl6UVapWQllGSICn4/L5KYmyCM13Yz9rM2UTbT8d\norEOmgFaKIWX/JTgGUYR9iM1K1TPna9PBZnX76HXm4sSqIW/B9sngx7p5mH1\noU828GyCEho59ZIm21b7NnB+UEacDljrIf7QdtOn4nZ6iTinqAee1cUJYA+g\n6+HjWywK9RF+E85U6xswhb3wzKJHpUqGXqroNzrJwyvD3DgyI6TrrOPHV5no\ncwIimjKiBdr6JK3G/6S2GoH2G8zb4zqfrx+93Q0AiN/6W3t+gpn2QBfEQxP2\nCgS1\r\n=p0q6\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-10-14T22:28:42.746Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-y.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-y.json
@@ -1,0 +1,56 @@
+{
+  "_id": "@isaacs/testing-peer-dep-nesting-y",
+  "name": "@isaacs/testing-peer-dep-nesting-y",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-y",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-nesting-z": ""
+      },
+      "_id": "@isaacs/testing-peer-dep-nesting-y@1.0.0",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "7.0.0",
+      "dist": {
+        "integrity": "sha512-0w3pnRbgkC2bPg9C2zYoB5j81Yi8fYlxKvsxbSshe9PYF6LF7pN7UMhc5i+uEcTJ9+aHyf6Jvy84V5P9VppY5Q==",
+        "shasum": "4f79305a0096a531d45ccbdc02faa440c3433005",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-y/-/testing-peer-dep-nesting-y-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 147,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh3wyCRA9TVsSAnZWagAA23EP/0aiYUah8MMRTPWxI+7I\nbvtIU9HKXwEMK6AMjqfRSfqPmntvYlHH8Vkpzz8nHpiAbPV/uhyngkB1j2+P\n0IHa1Zn2/YUgDrCqy16lJVGE8UU2c4SM7kRblJB6kfQwL6JGstX5HAODSs/H\nCfqvLYKEQQetxIFSRgbMuUZqu1hZJxpTRegScBkmRitqDmIWwTEcMFIZNnWf\nlPf3nvYrO4sS/MsWI8O+42TXWxAUss/9XPWDqNB9L9Bl8R2qcm4Li0jrZtF2\nXU5UmlV60dU/bTteE1YkNKj8/hdIc4mIuJmMYnpRpPLjSiA+gP5eMdk4IUJw\nnpkHQs3HypMl7RgJMsTYBcaB9AFMfTkrvkc9zffQnHkq+8XNZEnYtsM43KZ8\neSP4By3zAd9/AkY9gvZfuSQ4GlZ10fIm8xQPTUkLrhW6NRqajrvAp8D4lfJB\nr0wNA+eb+Eq0/28X+DZLVhSJBpw+lWHJkiep8+VyP9dZNfa6bmB96+9zzMrm\ngb68cDOmOKOBGpWAgDiHyGWKxcRIX0sARb7WyNLvqV2BrDKIIGXu5+L6nurp\n0gK7U/10IVDH3F1/cMmmJZjE9PHwZALRiF24Daoh8HU1FlqBwlhMXYOl+0dd\nB8pTdKNtfuW2VVoyaOkjtaFDRJtg/OAQyQpr4kmw1802FeXipKKrvFHtvAz2\nVy9W\r\n=yFty\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-nesting-y_1.0.0_1602714673881_0.6489361170723489"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2020-10-14T22:31:13.828Z",
+    "1.0.0": "2020-10-14T22:31:14.004Z",
+    "modified": "2020-10-14T22:31:17.945Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-y.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-y.min.json
@@ -1,0 +1,24 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-y",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-y",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-nesting-z": ""
+      },
+      "dist": {
+        "integrity": "sha512-0w3pnRbgkC2bPg9C2zYoB5j81Yi8fYlxKvsxbSshe9PYF6LF7pN7UMhc5i+uEcTJ9+aHyf6Jvy84V5P9VppY5Q==",
+        "shasum": "4f79305a0096a531d45ccbdc02faa440c3433005",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-y/-/testing-peer-dep-nesting-y-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 147,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh3wyCRA9TVsSAnZWagAA23EP/0aiYUah8MMRTPWxI+7I\nbvtIU9HKXwEMK6AMjqfRSfqPmntvYlHH8Vkpzz8nHpiAbPV/uhyngkB1j2+P\n0IHa1Zn2/YUgDrCqy16lJVGE8UU2c4SM7kRblJB6kfQwL6JGstX5HAODSs/H\nCfqvLYKEQQetxIFSRgbMuUZqu1hZJxpTRegScBkmRitqDmIWwTEcMFIZNnWf\nlPf3nvYrO4sS/MsWI8O+42TXWxAUss/9XPWDqNB9L9Bl8R2qcm4Li0jrZtF2\nXU5UmlV60dU/bTteE1YkNKj8/hdIc4mIuJmMYnpRpPLjSiA+gP5eMdk4IUJw\nnpkHQs3HypMl7RgJMsTYBcaB9AFMfTkrvkc9zffQnHkq+8XNZEnYtsM43KZ8\neSP4By3zAd9/AkY9gvZfuSQ4GlZ10fIm8xQPTUkLrhW6NRqajrvAp8D4lfJB\nr0wNA+eb+Eq0/28X+DZLVhSJBpw+lWHJkiep8+VyP9dZNfa6bmB96+9zzMrm\ngb68cDOmOKOBGpWAgDiHyGWKxcRIX0sARb7WyNLvqV2BrDKIIGXu5+L6nurp\n0gK7U/10IVDH3F1/cMmmJZjE9PHwZALRiF24Daoh8HU1FlqBwlhMXYOl+0dd\nB8pTdKNtfuW2VVoyaOkjtaFDRJtg/OAQyQpr4kmw1802FeXipKKrvFHtvAz2\nVy9W\r\n=yFty\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-10-14T22:31:17.945Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-z.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-z.json
@@ -1,0 +1,53 @@
+{
+  "_id": "@isaacs/testing-peer-dep-nesting-z",
+  "name": "@isaacs/testing-peer-dep-nesting-z",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-z",
+      "version": "1.0.0",
+      "_id": "@isaacs/testing-peer-dep-nesting-z@1.0.0",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "7.0.0",
+      "dist": {
+        "integrity": "sha512-cb4vKDm41mlVUH6EwTui9yvS16cTaNSgmqFyHxfvRR026zRxJ3UKLVCk03Gw+h5kTwnqm+YjDdqtJr4qmL1xFA==",
+        "shasum": "3640dd1b752727a07f86eec6bdf1b109efc8cd4c",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-z/-/testing-peer-dep-nesting-z-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 73,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh3w3CRA9TVsSAnZWagAAH1sP/2t3Jjq6n6vpmcq0XhZG\nAt9XB/w28JawDTKlbAeu9+u/wLk4Ixiww3emcCAdb4W7zwpDFzcLx2d1Foce\nuQoTj1ZKnWDT0SxbTIlmQF+d8kDtz/N0iFe0GqwQlaugyepSLfN0woeB5Cht\nmcGI4y6JrY8YPcUjtjImYx932wHEQ8QUwCt128Ut2H0wI5r+/Y/AojkZtwx2\nFe3rJ/t+KTR5DPPfHrZIMJ16leXxauugV/Yg0nn4KbqkXibSNU4rkf/Og/5X\nfOl+MbPjAYY71BBLE+7BH9Vw9bWWC3GgFc3kFMAGdeUFhJtIPWLF70qfx3Ad\nYj5eeSvB2AKEEjrfCg0CvHdDnbVktRubKSldcg4lPp6G7GZjCGUvPeS+hQrm\n7pku4d0yfgUDKQVSu5nPoTGaQCD6aadJe6XZsE7EQluzeKToCZE+nHFk3KJg\nVMRIrAPUi8L5164igE7WdlqfbD3YQ85GLDpGR4FfPJLJ542A5HW9ZZutom5e\nSVme4vdiNvKwdZhjSKBbOlsfAg0f4HlVjOF72VfO8YZcP+L3j+xtDSTRlIDa\nQxeLNvs9j6x1J7pBxUDuWlwF4vfoDN5jol8yaI+4amiTFYLQuPZYET4MfS4S\n11XUub6ze1rB202bv3rnO2nSUEf/TkmVaZy3LmGgSJz3dubl4DFd/fwlwwAY\n64T4\r\n=Gh5o\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-nesting-z_1.0.0_1602714678939_0.016293477521818645"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2020-10-14T22:31:18.891Z",
+    "1.0.0": "2020-10-14T22:31:19.051Z",
+    "modified": "2020-10-14T22:31:21.358Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-z.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-nesting-z.min.json
@@ -1,0 +1,21 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-z",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-dep-nesting-z",
+      "version": "1.0.0",
+      "dist": {
+        "integrity": "sha512-cb4vKDm41mlVUH6EwTui9yvS16cTaNSgmqFyHxfvRR026zRxJ3UKLVCk03Gw+h5kTwnqm+YjDdqtJr4qmL1xFA==",
+        "shasum": "3640dd1b752727a07f86eec6bdf1b109efc8cd4c",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-nesting-z/-/testing-peer-dep-nesting-z-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 73,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfh3w3CRA9TVsSAnZWagAAH1sP/2t3Jjq6n6vpmcq0XhZG\nAt9XB/w28JawDTKlbAeu9+u/wLk4Ixiww3emcCAdb4W7zwpDFzcLx2d1Foce\nuQoTj1ZKnWDT0SxbTIlmQF+d8kDtz/N0iFe0GqwQlaugyepSLfN0woeB5Cht\nmcGI4y6JrY8YPcUjtjImYx932wHEQ8QUwCt128Ut2H0wI5r+/Y/AojkZtwx2\nFe3rJ/t+KTR5DPPfHrZIMJ16leXxauugV/Yg0nn4KbqkXibSNU4rkf/Og/5X\nfOl+MbPjAYY71BBLE+7BH9Vw9bWWC3GgFc3kFMAGdeUFhJtIPWLF70qfx3Ad\nYj5eeSvB2AKEEjrfCg0CvHdDnbVktRubKSldcg4lPp6G7GZjCGUvPeS+hQrm\n7pku4d0yfgUDKQVSu5nPoTGaQCD6aadJe6XZsE7EQluzeKToCZE+nHFk3KJg\nVMRIrAPUi8L5164igE7WdlqfbD3YQ85GLDpGR4FfPJLJ542A5HW9ZZutom5e\nSVme4vdiNvKwdZhjSKBbOlsfAg0f4HlVjOF72VfO8YZcP+L3j+xtDSTRlIDa\nQxeLNvs9j6x1J7pBxUDuWlwF4vfoDN5jol8yaI+4amiTFYLQuPZYET4MfS4S\n11XUub6ze1rB202bv3rnO2nSUEf/TkmVaZy3LmGgSJz3dubl4DFd/fwlwwAY\n64T4\r\n=Gh5o\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-10-14T22:31:21.358Z"
+}

--- a/test/fixtures/testing-peer-dep-nesting/README.md
+++ b/test/fixtures/testing-peer-dep-nesting/README.md
@@ -1,0 +1,44 @@
+
+# CASE A
+
+```
+root -> (s@1, p@2)
+s@1 -> (x)
+x -> PEER(p@1, q)
+q -> PEER(p@1)
+```
+
+Expect:
+
+```
+root
++-- p@2
++-- s@1
+    +-- x
+    +-- p@1
+    +-- q
+```
+
+
+## CASE B
+
+```
+root -> (s@2, p@2)
+s@2 -> (x, y)
+x -> PEER(p@1, q)
+q -> PEER(p@1)
+y -> PEER(z)
+```
+
+Expect:
+
+```
+root
++-- p@2
++-- s@2
+|   +-- x
+|   +-- p@1
+|   +-- q@1
++-- y
++-- z
+```

--- a/test/fixtures/testing-peer-dep-nesting/multi/package.json
+++ b/test/fixtures/testing-peer-dep-nesting/multi/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-multi",
+  "version": "1.0.0",
+  "dependencies": {
+    "@isaacs/testing-peer-dep-nesting-p": "2",
+    "@isaacs/testing-peer-dep-nesting-s": "2"
+  }
+}

--- a/test/fixtures/testing-peer-dep-nesting/p/1/package.json
+++ b/test/fixtures/testing-peer-dep-nesting/p/1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-p",
+  "version": "1.0.0"
+}

--- a/test/fixtures/testing-peer-dep-nesting/p/2/package.json
+++ b/test/fixtures/testing-peer-dep-nesting/p/2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-p",
+  "version": "2.0.0"
+}

--- a/test/fixtures/testing-peer-dep-nesting/q/package.json
+++ b/test/fixtures/testing-peer-dep-nesting/q/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-q",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-dep-nesting-p": "1"
+  }
+}

--- a/test/fixtures/testing-peer-dep-nesting/s/1/package.json
+++ b/test/fixtures/testing-peer-dep-nesting/s/1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-s",
+  "version": "1.0.0",
+  "dependencies": {
+    "@isaacs/testing-peer-dep-nesting-x": ""
+  }
+}

--- a/test/fixtures/testing-peer-dep-nesting/s/2/package.json
+++ b/test/fixtures/testing-peer-dep-nesting/s/2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-s",
+  "version": "2.0.0",
+  "dependencies": {
+    "@isaacs/testing-peer-dep-nesting-x": "",
+    "@isaacs/testing-peer-dep-nesting-y": ""
+  }
+}

--- a/test/fixtures/testing-peer-dep-nesting/simple/package.json
+++ b/test/fixtures/testing-peer-dep-nesting/simple/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-simple",
+  "version": "1.0.0",
+  "dependencies": {
+    "@isaacs/testing-peer-dep-nesting-p": "2",
+    "@isaacs/testing-peer-dep-nesting-s": "1"
+  }
+}

--- a/test/fixtures/testing-peer-dep-nesting/x/package.json
+++ b/test/fixtures/testing-peer-dep-nesting/x/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-x",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-dep-nesting-p": "1",
+    "@isaacs/testing-peer-dep-nesting-q": "1"
+  }
+}

--- a/test/fixtures/testing-peer-dep-nesting/y/package.json
+++ b/test/fixtures/testing-peer-dep-nesting/y/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-y",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-dep-nesting-z": ""
+  }
+}

--- a/test/fixtures/testing-peer-dep-nesting/z/package.json
+++ b/test/fixtures/testing-peer-dep-nesting/z/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-dep-nesting-z",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Previously, there were cases where a peer dependency group might cycle
back in on itself, in such a way that we added a node and its peers
_prior_ to another member of the peer set that also peer-depended upon
the peer dependency.  Since the nodes were being moved rather than
copied, this meant that the conflicting peer was not around to be
checked, and so we would trigger peer conflict ERESOLVES when we tried
to resolve the dependencies of the second peer dependent at a higher
level.

By copying out of the virtual root peerSet, rather than moving, and
tracking which edges have already been overridden, we can avoid a lot of
other checks later on in the process, while ensuring that the
appropriate set of peer dependencies are being loaded at the optimal
level each time.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
