### PR TITLE
missing bins are changes

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -6,6 +6,7 @@
 // for a given branch of the tree being mutated.
 
 const {depth} = require('treeverse')
+const {existsSync} = require('fs')
 
 const ssri = require('ssri')
 
@@ -54,7 +55,8 @@ const getAction = ({actual, ideal}) =>
   // that as a 'change', so that it gets re-fetched and locked down.
     ideal.integrity &&
     actual.integrity &&
-    ssri.parse(ideal.integrity).match(actual.integrity) ? null
+    ssri.parse(ideal.integrity).match(actual.integrity) &&
+    ideal.binPaths.every((path) => existsSync(path)) ? null
   : 'CHANGE'
 
 const allChildren = node => {

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -38,26 +38,35 @@ class Diff {
   }
 }
 
-const getAction = ({actual, ideal}) =>
-  !ideal ? 'REMOVE'
+const getAction = ({actual, ideal}) => {
+  if (!ideal)
+    return 'REMOVE'
+
   // bundled meta-deps are copied over to the ideal tree when we visit it,
   // so they'll appear to be missing here.  There's no need to handle them
   // in the diff, though, because they'll be replaced at reify time anyway
   // Otherwise, add the missing node.
-  : !actual ? (ideal.inDepBundle ? null : 'ADD')
+  if (!actual)
+    return ideal.inDepBundle ? null : 'ADD'
+
   // always ignore the root node
-  : ideal.isRoot && actual.isRoot ||
+  if (ideal.isRoot && actual.isRoot)
+    return null
+
+  const binsExist = ideal.binPaths.every((path) => existsSync(path))
+
   // top nodes, links, and git deps won't have integrity, but do have resolved
-    !ideal.integrity && !actual.integrity &&
-      ideal.resolved === actual.resolved ||
+  if (!ideal.integrity && !actual.integrity && ideal.resolved === actual.resolved && binsExist)
+    return null
+
   // otherwise, verify that it's the same bits
   // note that if ideal has integrity, and resolved doesn't, we treat
   // that as a 'change', so that it gets re-fetched and locked down.
-    ideal.integrity &&
-    actual.integrity &&
-    ssri.parse(ideal.integrity).match(actual.integrity) &&
-    ideal.binPaths.every((path) => existsSync(path)) ? null
-  : 'CHANGE'
+  if (!ideal.integrity || !actual.integrity || !ssri.parse(ideal.integrity).match(actual.integrity) || !binsExist)
+    return 'CHANGE'
+
+  return null
+}
 
 const allChildren = node => {
   if (!node)

--- a/tap-snapshots/test-diff.js-TAP.test.js
+++ b/tap-snapshots/test-diff.js-TAP.test.js
@@ -24,6 +24,7 @@ Diff {
     "/path/to/root/node_modules/x/node_modules/y",
     "/path/to/root/node_modules/p/node_modules/q",
     "/path/to/root/node_modules/bundler/node_modules/not-bundled",
+    "/path/to/root/node_modules/should-have-bins",
     "/path/to/root/foo/node_modules/baz",
     "/path/to/root/node_modules/i/node_modules/j",
     "/path/to/root/foo/node_modules/boo",
@@ -221,6 +222,25 @@ Diff {
           "children": Array [],
         },
       ],
+    },
+    Diff {
+      "action": "CHANGE",
+      "actual": Node {
+        "name": "should-have-bins",
+        "path": "/path/to/root/node_modules/should-have-bins",
+        "integrity": "sha512-should-have-bins",
+      },
+      "ideal": Node {
+        "name": "should-have-bins",
+        "path": "/path/to/root/node_modules/should-have-bins",
+        "integrity": "sha512-should-have-bins",
+      },
+      "leaves": Array [
+        "/path/to/root/node_modules/should-have-bins",
+      ],
+      "unchanged": Array [],
+      "removed": Array [],
+      "children": Array [],
     },
     Diff {
       "action": "CHANGE",

--- a/test/diff.js
+++ b/test/diff.js
@@ -99,6 +99,15 @@ const actual = new Node({
         },
       ],
     },
+    {
+      name: 'should-have-bins',
+      integrity: 'sha512-should-have-bins',
+      pkg: {
+        bin: {
+          'should-exist': 'should-exist.js'
+        }
+      },
+    },
   ],
 })
 
@@ -156,6 +165,15 @@ const ideal = new Node({
           integrity: 'sha512-NOT-BUNDLED',
         },
       ],
+    },
+    {
+      name: 'should-have-bins',
+      integrity: 'sha512-should-have-bins',
+      pkg: {
+        bin: {
+          'should-exist': 'should-exist.js'
+        }
+      },
     },
   ],
 })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This ensures that if a package is already installed, but for some reason the bins have not been linked, that we will flag that node as a CHANGE which will make sure that bins are linked correctly

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
