### PR TITLE
use junctions instead of symlinks

### DIFF
--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -427,7 +427,7 @@ module.exports = cls => class Reifier extends cls {
     const dir = dirname(node.path)
     const target = node.realpath
     const rel = relative(dir, target)
-    return symlink(rel, node.path, 'dir')
+    return symlink(rel, node.path, 'junction')
   }
 
   [_warnDeprecated] (node) {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

in windows we should use junctions, not symlinks, as junctions can be created by non-admin users while symlinks require elevated permissions. this change was made in npm 6 and regressed in npm 7.

note that it's unnecessary to put a conditional around the parameter, as well as unnecessary to make the target an absolute path, per nodejs docs:

> The type argument is only available on Windows and ignored on other platforms. It can be set to 'dir', 'file', or 'junction'. If the type argument is not set, Node.js will autodetect target type and use 'file' or 'dir'. If the target does not exist, 'file' will be used. Windows junction points require the destination path to be absolute. When using 'junction', the target argument will automatically be normalized to absolute path.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes https://github.com/npm/cli/issues/2079
Fixes https://github.com/npm/cli/issues/1923

