### PR TITLE
use @npmcli/move-file instead of fs.rename

### DIFF
--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -10,10 +10,10 @@ const {dirname, resolve, relative} = require('path')
 const {depth: dfwalk} = require('treeverse')
 const fs = require('fs')
 const {promisify} = require('util')
-const rename = promisify(fs.rename)
 const symlink = promisify(fs.symlink)
 const writeFile = promisify(fs.writeFile)
 const mkdirp = require('mkdirp-infer-owner')
+const moveFile = require('@npmcli/move-file')
 const rimraf = promisify(require('rimraf'))
 const packageContents = require('@npmcli/installed-package-contents')
 
@@ -251,7 +251,7 @@ module.exports = cls => class Reifier extends cls {
   }
 
   [_renamePath] (from, to, didMkdirp = false) {
-    return rename(from, to)
+    return moveFile(from, to)
       .catch(er => {
         // Occasionally an expected bin file might not exist in the package,
         // or a shim/symlink might have been moved aside.  If we've already
@@ -261,7 +261,7 @@ module.exports = cls => class Reifier extends cls {
           return didMkdirp ? null : mkdirp(dirname(to)).then(() =>
             this[_renamePath](from, to, true))
         } else if (er.code === 'EEXIST')
-          return rimraf(to).then(() => rename(from, to))
+          return rimraf(to).then(() => moveFile(from, to))
         else
           throw er
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@npmcli/installed-package-contents": "^1.0.5",
         "@npmcli/map-workspaces": "^1.0.1",
         "@npmcli/metavuln-calculator": "^1.0.0",
+        "@npmcli/move-file": "^1.0.1",
         "@npmcli/name-from-folder": "^1.0.1",
         "@npmcli/node-gyp": "^1.0.0",
         "@npmcli/run-script": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@npmcli/installed-package-contents": "^1.0.5",
     "@npmcli/map-workspaces": "^1.0.1",
     "@npmcli/metavuln-calculator": "^1.0.0",
+    "@npmcli/move-file": "^1.0.1",
     "@npmcli/name-from-folder": "^1.0.1",
     "@npmcli/node-gyp": "^1.0.0",
     "@npmcli/run-script": "^1.7.2",


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

switch to using @npmcli/move-file instead of fs.rename, which attempts fs.rename first but if an EXDEV error occurs falls back to a move (copy followed by unlink). this is a regression from npm 6.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes https://github.com/npm/cli/issues/606
Fixes https://github.com/npm/cli/issues/2031
