### PR TITLE
feat: add debugability to node and edge

### DIFF
--- a/lib/edge.js
+++ b/lib/edge.js
@@ -1,6 +1,7 @@
 // An edge in the dependency graph
 // Represents a dependency relationship of some kind
 
+const util = require('util')
 const npa = require('npm-package-arg')
 const depValid = require('./dep-valid.js')
 const _from = Symbol('_from')
@@ -23,6 +24,21 @@ const types = new Set([
   'peerOptional',
   'workspace',
 ])
+
+class ArboristEdge {}
+const printableEdge = (edge) => {
+  const edgeFrom = edge.from && edge.from.location
+  const edgeTo = edge.to && edge.to.location
+
+  return Object.assign(new ArboristEdge(), {
+    name: edge.name,
+    spec: edge.spec,
+    type: edge.type,
+    ...(edgeFrom != null ? { from: edgeFrom } : {}),
+    ...(edgeTo ? { to: edgeTo } : {}),
+    ...(edge.error ? { error: edge.error } : {}),
+  })
+}
 
 class Edge {
   constructor (options) {
@@ -184,6 +200,14 @@ class Edge {
 
   get to () {
     return this[_to]
+  }
+
+  toJSON () {
+    return printableEdge(this)
+  }
+
+  [util.inspect.custom] () {
+    return this.toJSON()
   }
 }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -37,6 +37,7 @@ const npa = require('npm-package-arg')
 const debug = require('./debug.js')
 
 const {resolve, relative, dirname, basename} = require('path')
+const util = require('util')
 const _package = Symbol('_package')
 const _parent = Symbol('_parent')
 const _fsParent = Symbol('_fsParent')
@@ -59,6 +60,71 @@ const _meta = Symbol('_meta')
 
 const relpath = require('./relpath.js')
 const consistentResolve = require('./consistent-resolve.js')
+
+// helper function to output a saner visualization
+// of the current node and its descendents
+class ArboristNode {}
+const printableTree = tree => Object.assign(new ArboristNode(), {
+  name: tree.name,
+  location: tree.location,
+  ...(tree.resolved != null ? { resolved: tree.resolved } : {}),
+  ...(tree.extraneous ? { extraneous: true } : {
+    ...(tree.dev ? { dev: true } : {}),
+    ...(tree.optional ? { optional: true } : {}),
+    ...(tree.devOptional && !tree.dev && !tree.optional
+      ? { devOptional: true } : {}),
+    ...(tree.peer ? { peer: true } : {}),
+  }),
+  ...(tree.inBundle ? { bundled: true } : {}),
+  // handle top-level tree error
+  ...(tree.error
+    ? {
+      error: {
+        code: tree.error.code,
+        ...(tree.error.path
+          ? { path: tree.error.path }
+          : {}),
+      },
+    } : {}),
+  // handle errors for each node
+  ...(tree.errors && tree.errors.length
+    ? {
+      errors: tree.errors.map(error => ({
+        code: error.code,
+        ...(error.path
+          ? { path: error.path }
+          : {}),
+      })),
+    } : {}),
+  ...(tree.isLink ? {
+    target: {
+      name: tree.target.name,
+      parent: tree.target.parent && tree.target.parent.location,
+    },
+  } : {}),
+  ...(tree.edgesIn.size ? {
+    edgesIn: new Set([...tree.edgesIn]
+      .sort((a, b) => a.from.location.localeCompare(b.from.location))),
+  } : {}),
+  ...(tree.edgesOut.size ? {
+    edgesOut: new Map([...tree.edgesOut.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0]))),
+  } : {}),
+  ...(!tree.fsChildren.size
+    ? {}
+    : {
+      fsChildren: new Set([...tree.fsChildren]
+        .sort((a, b) => a.path.localeCompare(b.path))
+        .map(tree => printableTree(tree))),
+    }),
+  ...(tree.target || !tree.children.size
+    ? {}
+    : {
+      children: new Map([...tree.children.entries()]
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([name, tree]) => [name, printableTree(tree)])),
+    }),
+})
 
 class Node {
   constructor (options) {
@@ -995,6 +1061,14 @@ class Node {
     const dir = dirname(nm)
     const base = scoped ? `${basename(d)}/${basename(rp)}` : basename(rp)
     return base === name && basename(nm) === 'node_modules' ? dir : false
+  }
+
+  toJSON () {
+    return printableTree(this)
+  }
+
+  [util.inspect.custom] () {
+    return this.toJSON()
   }
 }
 

--- a/test/edge.js
+++ b/test/edge.js
@@ -1,3 +1,4 @@
+const util = require('util')
 const Edge = require('../lib/edge.js')
 const t = require('tap')
 
@@ -367,3 +368,55 @@ t.test('convenience type getter flags', async t => {
   explainEdge.detach()
   t.notEqual(explainEdge.explain(), expl)
 })
+
+const printableTo = {
+  ...b,
+  location: '/node_modules/b',
+}
+const printableFrom = {
+  ...a,
+  resolve () {
+    return printableTo
+  },
+  location: '',
+}
+const printable = new Edge({
+  from: printableFrom,
+  type: 'prod',
+  name: 'b',
+  spec: '1.2.3',
+})
+t.match(
+  util.inspect(printable, {compact: true}),
+  util.inspect({
+    name: 'b',
+    spec: '1.2.3',
+    type: 'prod',
+    from: '',
+    to: '/node_modules/b',
+  }, {compact: true}),
+  'should return a human-readable representation of the edge obj'
+)
+
+const minimalPrintableFrom = {
+  ...a,
+  resolve () {
+    return null
+  },
+}
+const minimalPrintable = new Edge({
+  from: minimalPrintableFrom,
+  type: 'dev',
+  name: 'b',
+  spec: '1.2.3',
+})
+t.match(
+  minimalPrintable.toJSON(),
+  {
+    name: 'b',
+    spec: '1.2.3',
+    type: 'dev',
+    error: 'MISSING',
+  },
+  'should return a minimal human-readable representation of the edge obj'
+)


### PR DESCRIPTION
When using `console.log()` to print either `this.idealTree` or a `node` or any `Edge` it will provide a much better human-readable output.

### Examples
Taken from some random output in build-ideal-tree tests.

```js
console.log(this.idealTree)
```

```js
ArboristNode {
  name: 'outdated-no-lockfile',
  location: '',
  edgesOut: Map(2) {
    'mkdirp' => ArboristEdge {
      name: 'mkdirp',
      type: 'prod',
      spec: '1',
      from: '',
      to: 'node_modules/mkdirp'
    },
    'once' => ArboristEdge {
      name: 'once',
      type: 'prod',
      spec: '^1.3.3',
      from: '',
      to: 'node_modules/once'
    }
  },
  children: Map(3) {
    'mkdirp' => ArboristNode {
      name: 'mkdirp',
      location: 'node_modules/mkdirp',
      resolved: 'https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz',
      edgesIn: [Set]
    },
    'once' => ArboristNode {
      name: 'once',
      location: 'node_modules/once',
      resolved: 'https://registry.npmjs.org/once/-/once-1.3.3.tgz',
      edgesIn: [Set],
      edgesOut: [Map]
    },
    'wrappy' => ArboristNode {
      name: 'wrappy',
      location: 'node_modules/wrappy',
      resolved: 'https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz',
      edgesIn: [Set]
    }
  }
}
```

```js
ArboristNode {
  name: 'testing-peer-deps-nested',
  location: '',
  edgesOut: Map(1) {
    '@isaacs/testing-peer-deps' => ArboristEdge {
      name: '@isaacs/testing-peer-deps',
      type: 'prod',
      spec: '2 || 3',
      from: '',
      to: 'node_modules/@isaacs/testing-peer-deps'
    }
  },
  children: Map(4) {
    '@isaacs/testing-peer-deps' => ArboristNode {
      name: '@isaacs/testing-peer-deps',
      location: 'node_modules/@isaacs/testing-peer-deps',
      resolved: 'https://registry.npmjs.org/@isaacs/testing-peer-deps/-/testing-peer-deps-3.0.0.tgz',
      edgesIn: [Set],
      edgesOut: [Map]
    },
    '@isaacs/testing-peer-deps-b' => ArboristNode {
      name: '@isaacs/testing-peer-deps-b',
      location: 'node_modules/@isaacs/testing-peer-deps-b',
      resolved: 'https://registry.npmjs.org/@isaacs/testing-peer-deps-b/-/testing-peer-deps-b-2.0.1.tgz',
      edgesIn: [Set],
      edgesOut: [Map]
    },
    '@isaacs/testing-peer-deps-c' => ArboristNode {
      name: '@isaacs/testing-peer-deps-c',
      location: 'node_modules/@isaacs/testing-peer-deps-c',
      resolved: 'https://registry.npmjs.org/@isaacs/testing-peer-deps-c/-/testing-peer-deps-c-2.0.0.tgz',
      peer: true,
      edgesIn: [Set]
    },
    '@isaacs/testing-peer-deps-d' => ArboristNode {
      name: '@isaacs/testing-peer-deps-d',
      location: 'node_modules/@isaacs/testing-peer-deps-d',
      resolved: 'https://registry.npmjs.org/@isaacs/testing-peer-deps-d/-/testing-peer-deps-d-2.0.0.tgz',
      edgesIn: [Set],
      edgesOut: [Map],
      children: [Map]
    }
  }
}
```
