### PR TITLE
Avoid unbounded recursion due to self-references between node and parent fields

### DIFF
--- a/lib/arborist/load-virtual.js
+++ b/lib/arborist/load-virtual.js
@@ -214,6 +214,7 @@ module.exports = cls => class VirtualLoader extends cls {
         if (!parent)
           continue
         // Safety check: avoid self-assigning nodes as their own parents
+        /* istanbul ignore if - should be obviated by parentage skip check */
         if (parent === node)
           continue
 

--- a/lib/arborist/load-virtual.js
+++ b/lib/arborist/load-virtual.js
@@ -213,9 +213,6 @@ module.exports = cls => class VirtualLoader extends cls {
         const parent = nodes.get(ploc)
         if (!parent)
           continue
-        // Safety check: avoid self-assigning nodes as their own parents
-        if (parent === node)
-          continue
 
         const locTest = `${ploc}/node_modules/${name}`.replace(/^\//, '')
         const ptype = location === locTest

--- a/lib/arborist/load-virtual.js
+++ b/lib/arborist/load-virtual.js
@@ -210,6 +210,9 @@ module.exports = cls => class VirtualLoader extends cls {
         const parent = nodes.get(ploc)
         if (!parent)
           continue
+        // Safety check: avoid self-assigning nodes as their own parents
+        if (parent === node)
+          continue
 
         const locTest = `${ploc}/node_modules/${name}`.replace(/^\//, '')
         const ptype = location === locTest

--- a/lib/arborist/load-virtual.js
+++ b/lib/arborist/load-virtual.js
@@ -204,6 +204,9 @@ module.exports = cls => class VirtualLoader extends cls {
 
   [assignParentage] (nodes) {
     for (const [location, node] of nodes) {
+      // Skip assignment of parentage for the root package
+      if (!location)
+        continue
       const { path, name } = node
       for (const p of walkUp(dirname(path))) {
         const ploc = relpath(this.path, p)

--- a/lib/arborist/load-virtual.js
+++ b/lib/arborist/load-virtual.js
@@ -213,6 +213,9 @@ module.exports = cls => class VirtualLoader extends cls {
         const parent = nodes.get(ploc)
         if (!parent)
           continue
+        // Safety check: avoid self-assigning nodes as their own parents
+        if (parent === node)
+          continue
 
         const locTest = `${ploc}/node_modules/${name}`.replace(/^\//, '')
         const ptype = location === locTest

--- a/lib/node.js
+++ b/lib/node.js
@@ -554,6 +554,9 @@ class Node {
     if (this[_fsParent] === fsParent)
       return
 
+    if (this === fsParent)
+      return
+
     const current = this[_fsParent]
     if (current)
       current.fsChildren.delete(this)

--- a/lib/node.js
+++ b/lib/node.js
@@ -734,6 +734,9 @@ class Node {
   set parent (parent) {
     const oldParent = this[_parent]
 
+    if (this === parent)
+      return
+
     // link nodes can't contain children directly.
     // children go under the link target.
     if (parent) {

--- a/test/arborist/load-virtual.js
+++ b/test/arborist/load-virtual.js
@@ -93,6 +93,15 @@ t.test('load from fixture', t =>
       .then(tree2 => t.equal(tree2, virtualTree, 'same tree reused'))
   }))
 
+t.test('load from fixture using filesystem root path', t => {
+  const root = new Node({
+    path: '/',
+    pkg: require(fixture + '/package.json'),
+  })
+  return new Arborist({path: '/'}).loadVirtual({root})
+    .then(virtualTree => t.equal(virtualTree, root))
+})
+
 t.test('load from root that already has shrinkwrap', t =>
   Shrinkwrap.load({ path: tapAndFlow }).then(meta => {
     const root = new Node({

--- a/test/node.js
+++ b/test/node.js
@@ -520,8 +520,7 @@ t.test('attempt to assign parent to self on root node', t => {
     path: '/',
     realpath: '/'
   })
-  root.parent = root;
-  root.fsParent = root;
+  root.parent = root.fsParent = root;
   t.equal(root.parent, undefined, 'root node parent should be empty')
   t.equal(root.fsParent, null, 'root node fsParent should be empty')
   t.end();

--- a/test/node.js
+++ b/test/node.js
@@ -516,7 +516,7 @@ t.test('changing root', t => {
 
 t.test('attempt to assign parent to self on root node', t => {
   const root = new Node({
-    pkg: { name: 'root', dependencies: { a: '' }},
+    pkg: { name: 'root' },
     path: '/',
     realpath: '/'
   })

--- a/test/node.js
+++ b/test/node.js
@@ -514,13 +514,15 @@ t.test('changing root', t => {
   t.end()
 })
 
-t.test('attempt to assign fsParent to self on root node', t => {
+t.test('attempt to assign parent to self on root node', t => {
   const root = new Node({
     pkg: { name: 'root', dependencies: { a: '' }},
     path: '/',
     realpath: '/'
   })
+  root.parent = root;
   root.fsParent = root;
+  t.equal(root.parent, undefined, 'root node parent should be empty')
   t.equal(root.fsParent, null, 'root node fsParent should be empty')
   t.end();
 })

--- a/test/node.js
+++ b/test/node.js
@@ -514,6 +514,17 @@ t.test('changing root', t => {
   t.end()
 })
 
+t.test('attempt to assign fsParent to self on root node', t => {
+  const root = new Node({
+    pkg: { name: 'root', dependencies: { a: '' }},
+    path: '/',
+    realpath: '/'
+  })
+  root.fsParent = root;
+  t.equal(root.fsParent, null, 'root node fsParent should be empty')
+  t.end();
+})
+
 t.test('bundled dependencies logic', t => {
   const root = new Node({
     pkg: {


### PR DESCRIPTION
These changes are safety-related checks intended to prevent unbounded recursion when a `Node` instance contains an `fsParent` value that points to itself.

In particular this can occur when a `package.json` file is being used for an `npm install` from a system's root filesystem path (`/`); this leads to a situation where the [`relpath` for the root package](https://github.com/npm/arborist/blob/12a140b0e36c1a5ca5e8e9b6319fb539bf026628/lib/arborist/load-virtual.js#L209-L210) is empty and the [`ptype` is inferred as `fsParent`](https://github.com/npm/arborist/blob/12a140b0e36c1a5ca5e8e9b6319fb539bf026628/lib/arborist/load-virtual.js#L214-L217).

The following changes checks are applied to avoid this:

1. Virtual tree loading: Assignment of parentage is skipped for the root package
1. Virtual tree loading: Attempts to assign a node to itself as parent are skipped
1. Node class: Attempts to assign a `fsParent` value of the current instance are skipped
1. Node class: Attempts to assign a `parent` value of the current instance are skipped

Strictly speaking only the first change is required to resolve the issue; the second and third changes are safety checks at the locations where the problem was traced during debugging, and the fourth change is for logical consistency within the `Node` class.

## References
Fixes #171