### PR TITLE
fix: support system root path with no pkg name

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -107,13 +107,15 @@ class Node {
 
     this.name = name ||
       nameFromFolder(path || pkg.name || realpath) ||
-      pkg.name
-
-    if (!this.name)
-      throw new TypeError('could not detect node name from path or package')
+      pkg.name ||
+      null
 
     // should be equal if not a link
     this.path = path && resolve(path)
+
+    if (!this.name && (!this.path || this.path !== dirname(this.path)))
+      throw new TypeError('could not detect node name from path or package')
+
     this.realpath = !this.isLink ? this.path : resolve(realpath)
 
     this.resolved = resolved || null

--- a/scripts/actual.js
+++ b/scripts/actual.js
@@ -29,7 +29,7 @@ new Arborist(options).loadActual(options).then(tree => {
   if (!process.argv.includes('--quiet')) {
     print(tree)
   }
-  console.error(`read ${tree.inventory.size} deps in ${end[0]*1000 + end[1] / 10e6}ms`)
+  console.error(`read ${tree.inventory.size} deps in ${end[0]*1000 + end[1] / 1e6}ms`)
   if (options.save)
     tree.meta.save()
   if (options.saveHidden) {

--- a/scripts/funding.js
+++ b/scripts/funding.js
@@ -25,5 +25,5 @@ a.loadVirtual().then(tree => {
         console.log(node.name, node.location, node.package.funding)
     }
   }
-  console.error(`read ${tree.inventory.size} deps in ${end[0]*1000 + end[0] / 1000}ms`)
+  console.error(`read ${tree.inventory.size} deps in ${end[0]*1000 + end[1] / 1e6}ms`)
 })

--- a/scripts/virtual.js
+++ b/scripts/virtual.js
@@ -16,5 +16,5 @@ new Arborist({path}).loadVirtual().then(tree => {
     print(tree)
   if (process.argv.includes('--save'))
     tree.meta.save()
-  console.error(`read ${tree.inventory.size} deps in ${end[0]*1000 + end[0] / 1000}ms`)
+  console.error(`read ${tree.inventory.size} deps in ${end[0]*1000 + end[1] / 1e6}ms`)
 }).catch(er => console.error(er))

--- a/test/node.js
+++ b/test/node.js
@@ -4,6 +4,7 @@ const Node = require('../lib/node.js')
 const requireInject = require('require-inject')
 const Link = require('../lib/link.js')
 const Shrinkwrap = require('../lib/shrinkwrap.js')
+const { resolve } = require('path')
 
 const normalizePath = path => path.replace(/^[A-Z]:/, '').replace(/\\/g, '/')
 const normalizePaths = obj => {
@@ -371,7 +372,21 @@ t.test('tracks the loading error encountered', t => {
 t.throws(() => new Node({pkg: {}}), TypeError(
   'could not detect node name from path or package'))
 
+t.test('load from system-root path', t => {
+  const root = new Node({
+    path: resolve('/'),
+  })
+  t.equal(root.name, null, 'ok to have a nameless node in system root')
+  t.end()
+})
+
 t.test('load with a virtual filesystem parent', t => {
+  const Node = requireInject('../lib/node.js', {
+    '../lib/debug.js': a => a(),
+  })
+  const Link = requireInject('../lib/link.js', {
+    '../lib/node.js': Node,
+  })
   const root = new Node({
     pkg: { name: 'root', dependencies: { a: '', link: '', link2: '', link3: '' }},
     path: '/home/user/projects/root',


### PR DESCRIPTION
Right now if your cwd is `/` `npm exec`, `npm ls` (or any arborist-dependent
command) will fail with a "could not detect node name from path or
package" error.

This patches add a manual `"system-root"` name to allow arborist to build
a tree from `/`