### PR TITLE
feat: debugability to nodes and edges

### DIFF
--- a/lib/edge.js
+++ b/lib/edge.js
@@ -1,6 +1,7 @@
 // An edge in the dependency graph
 // Represents a dependency relationship of some kind
 
+const util = require('util')
 const npa = require('npm-package-arg')
 const depValid = require('./dep-valid.js')
 const _from = Symbol('_from')
@@ -23,6 +24,21 @@ const types = new Set([
   'peerOptional',
   'workspace',
 ])
+
+class ArboristEdge {}
+const printableEdge = (edge) => {
+  const edgeFrom = edge.from && edge.from.location
+  const edgeTo = edge.to && edge.to.location
+
+  return Object.assign(new ArboristEdge(), {
+    name: edge.name,
+    spec: edge.spec,
+    type: edge.type,
+    ...(edgeFrom != null ? { from: edgeFrom } : {}),
+    ...(edgeTo ? { to: edgeTo } : {}),
+    ...(edge.error ? { error: edge.error } : {}),
+  })
+}
 
 class Edge {
   constructor (options) {
@@ -184,6 +200,14 @@ class Edge {
 
   get to () {
     return this[_to]
+  }
+
+  toJSON () {
+    return printableEdge(this)
+  }
+
+  [util.inspect.custom] () {
+    return this.toJSON()
   }
 }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -40,6 +40,7 @@ const treeCheck = require('./tree-check.js')
 const walkUp = require('walk-up-path')
 
 const {resolve, relative, dirname, basename} = require('path')
+const util = require('util')
 const _package = Symbol('_package')
 const _parent = Symbol('_parent')
 const _target = Symbol.for('_target')
@@ -62,6 +63,71 @@ const _meta = Symbol('_meta')
 
 const relpath = require('./relpath.js')
 const consistentResolve = require('./consistent-resolve.js')
+
+// helper function to output a clearer visualization
+// of the current node and its descendents
+class ArboristNode {}
+
+const printableTree = (tree, path = []) =>
+  (path.includes(tree) ? { location: tree.location } : (path.push(tree), Object.assign(new ArboristNode(), {
+    name: tree.name,
+    ...(tree.package && tree.package.version
+      ? { version: tree.package.version }
+      : {}),
+    location: tree.location,
+    path: tree.path,
+    realpath: tree.realpath,
+    ...(tree.isLink ? { target: printableTree(tree.target, path) } : {}),
+    ...(tree.resolved != null ? { resolved: tree.resolved } : {}),
+    ...(tree.extraneous ? { extraneous: true } : {
+      ...(tree.dev ? { dev: true } : {}),
+      ...(tree.optional ? { optional: true } : {}),
+      ...(tree.devOptional && !tree.dev && !tree.optional
+        ? { devOptional: true } : {}),
+      ...(tree.peer ? { peer: true } : {}),
+    }),
+    ...(tree.inBundle ? { bundled: true } : {}),
+    // handle top-level tree error
+    ...(tree.error
+      ? {
+        error: {
+          code: tree.error.code,
+          ...(tree.error.path
+            ? { path: tree.error.path }
+            : {}),
+        },
+      } : {}),
+    // handle errors for each node
+    ...(tree.errors && tree.errors.length
+      ? {
+        errors: tree.errors.map(error => ({
+          code: error.code,
+          ...(error.path
+            ? { path: error.path }
+            : {}),
+        })),
+      } : {}),
+    ...(tree.edgesIn && tree.edgesIn.size ? {
+      edgesIn: new Set([...tree.edgesIn]
+        .sort((a, b) => a.from.location.localeCompare(b.from.location))),
+    } : {}),
+    ...(tree.edgesOut && tree.edgesOut.size ? {
+      edgesOut: new Map([...tree.edgesOut.entries()]
+        .sort((a, b) => a[0].localeCompare(b[0]))),
+    } : {}),
+    ...(tree.fsChildren && tree.fsChildren.size ? {
+      fsChildren: new Set([...tree.fsChildren]
+        .sort((a, b) => a.path.localeCompare(b.path))
+        .map(tree => printableTree(tree, path))),
+    } : {}),
+    ...(tree.target || !tree.children || !tree.children.size
+      ? {}
+      : {
+        children: new Map([...tree.children.entries()]
+          .sort((a, b) => a[0].localeCompare(b[0]))
+          .map(([name, tree]) => [name, printableTree(tree, path)])),
+      }),
+  })))
 
 class Node {
   constructor (options) {
@@ -1144,6 +1210,14 @@ class Node {
     const dir = dirname(nm)
     const base = scoped ? `${basename(d)}/${basename(rp)}` : basename(rp)
     return base === name && basename(nm) === 'node_modules' ? dir : false
+  }
+
+  toJSON () {
+    return printableTree(this)
+  }
+
+  [util.inspect.custom] () {
+    return this.toJSON()
   }
 }
 

--- a/tap-snapshots/test-edge.js-TAP.test.js
+++ b/tap-snapshots/test-edge.js-TAP.test.js
@@ -775,6 +775,15 @@ Edge {
 }
 `
 
+exports[`test/edge.js TAP > should return a human-readable representation of the edge obj 1`] = `
+{
+name: 'b',
+spec: '1.2.3',
+type: 'prod',
+from: '',
+to: '/node_modules/b' }
+`
+
 exports[`test/edge.js TAP convenience type getter flags > explanation 1`] = `
 Object {
   "from": "a explanation",

--- a/tap-snapshots/test-node.js-TAP.test.js
+++ b/tap-snapshots/test-node.js-TAP.test.js
@@ -35,6 +35,201 @@ exports[`test/node.js TAP basic instantiation > just a lone root node 1`] = `
 }
 `
 
+exports[`test/node.js TAP printable Node extraneous tree > should print human readable representation of node tree 1`] = `
+{
+name: 'printable-node',
+version: '1.1.1',
+location: '',
+path: '/home/user/projects/root',
+realpath: '/home/user/projects/root',
+extraneous: true,
+error: { code: 'ERR', path: '/' },
+edgesOut: Map {
+'b' => {
+name: 'b',
+spec: '',
+type: 'prod',
+from: '',
+to: 'node_modules/b' },
+'missing' => {
+name: 'missing',
+spec: '',
+type: 'prod',
+from: '',
+error: 'MISSING' },
+'prod' => {
+name: 'prod',
+spec: '1.x',
+type: 'prod',
+from: '',
+to: 'node_modules/prod' } },
+children: Map {
+'b' => {
+name: 'b',
+version: '1.2.3',
+location: 'node_modules/b',
+path: '/home/user/projects/root/node_modules/b',
+realpath: '/home/user/projects/root/node_modules/b',
+resolved: 'b',
+extraneous: true,
+edgesIn: Set {
+{
+name: 'b',
+spec: '',
+type: 'prod',
+from: '',
+to: 'node_modules/b' },
+{
+name: 'b',
+spec: '',
+type: 'prod',
+from: 'node_modules/prod',
+to: 'node_modules/b' } } },
+'c' => {
+name: 'c',
+location: 'node_modules/c',
+path: '/home/user/projects/root/node_modules/c',
+realpath: '/home/user/projects/root/node_modules/c',
+resolved: 'c',
+extraneous: true },
+'prod' => {
+name: 'prod',
+version: '1.2.3',
+location: 'node_modules/prod',
+path: '/home/user/projects/root/node_modules/prod',
+realpath: '/home/user/projects/root/node_modules/prod',
+resolved: 'prod',
+extraneous: true,
+edgesIn: Set {
+{
+name: 'prod',
+spec: '1.x',
+type: 'prod',
+from: '',
+to: 'node_modules/prod' } },
+edgesOut: Map {
+'b' => {
+name: 'b',
+spec: '',
+type: 'prod',
+from: 'node_modules/prod',
+to: 'node_modules/b' },
+'meta' => {
+name: 'meta',
+spec: '',
+type: 'prod',
+from: 'node_modules/prod',
+error: 'MISSING' },
+'peer' => {
+name: 'peer',
+spec: '',
+type: 'peer',
+from: 'node_modules/prod',
+error: 'MISSING' } },
+fsChildren: Set {
+{
+name: 'bar',
+version: '1.0.0',
+location: 'node_modules/prod/bar',
+path: '/home/user/projects/root/node_modules/prod/bar',
+realpath: '/home/user/projects/root/node_modules/prod/bar',
+extraneous: true },
+{
+name: 'foo',
+version: '1.2.3',
+location: 'node_modules/prod/foo',
+path: '/home/user/projects/root/node_modules/prod/foo',
+realpath: '/home/user/projects/root/node_modules/prod/foo',
+extraneous: true,
+edgesOut: Map {
+'meta' => {
+name: 'meta',
+spec: '',
+type: 'prod',
+from: 'node_modules/prod/foo',
+error: 'MISSING' } } } } } } }
+`
+
+exports[`test/node.js TAP printable Node variations > should match non-extraneous tree representation 1`] = `
+{
+name: 'variations',
+version: '1.0.0',
+location: '',
+path: '/home/user/projects/root',
+realpath: '/home/user/projects/root',
+dev: true,
+optional: true,
+peer: true,
+error: { code: 'ERR' },
+edgesOut: Map {
+'a' => {
+name: 'a',
+spec: '^1.0.0',
+type: 'prod',
+from: '',
+to: 'node_modules/a' },
+'b' => {
+name: 'b',
+spec: '^1.0.0',
+type: 'prod',
+from: '',
+to: 'node_modules/b' } },
+fsChildren: Set {
+{
+name: 'c',
+version: '1.0.0',
+location: 'c',
+path: '/home/user/projects/root/c',
+realpath: '/home/user/projects/root/c',
+extraneous: true } },
+children: Map {
+'a' => {
+name: 'a',
+version: '1.1.1',
+location: 'node_modules/a',
+path: '/home/user/projects/root/node_modules/a',
+realpath: '/home/user/projects/root/node_modules/a',
+dev: true,
+optional: true,
+peer: true,
+bundled: true,
+errors: [ { code: 'ERR' } ],
+edgesIn: Set {
+{
+name: 'a',
+spec: '^1.0.0',
+type: 'prod',
+from: '',
+to: 'node_modules/a' } } },
+'b' => {
+name: 'b',
+version: '1.0.0',
+location: 'node_modules/b',
+path: '/home/user/projects/root/node_modules/b',
+realpath: '/home/user/projects/root/c',
+target: { location: 'c' },
+resolved: 'file:../c',
+devOptional: true,
+errors: [ { code: 'ERR',
+path: '/home/users/projects/root/node_modules/b' } ],
+edgesIn: Set {
+{
+name: 'b',
+spec: '^1.0.0',
+type: 'prod',
+from: '',
+to: 'node_modules/b' } } },
+'d' => {
+name: 'd',
+version: '1.0.0',
+location: 'node_modules/d',
+path: '/home/user/projects/root/node_modules/d',
+realpath: '/home/user/projects/root/c',
+target: { location: 'c' },
+resolved: 'file:../c',
+extraneous: true } } }
+`
+
 exports[`test/node.js TAP set workspaces > should setup edges out for each workspace 1`] = `
 &ref_1 Node {
   "children": Map {

--- a/test/edge.js
+++ b/test/edge.js
@@ -1,3 +1,4 @@
+const util = require('util')
 const Edge = require('../lib/edge.js')
 const t = require('tap')
 
@@ -373,3 +374,57 @@ t.test('convenience type getter flags', async t => {
   explainEdge.detach()
   t.notEqual(explainEdge.explain(), expl)
 })
+
+// FIXME: once we drop support to node10 we can remove this
+const normalizeNode10compatSnapshots = str =>
+  str
+    .replace(/\n +/g, '\n')
+    .replace(/\n\}/g, ' }')
+    .replace(/ArboristEdge /g, '')
+
+const printableTo = {
+  ...b,
+  location: '/node_modules/b',
+}
+const printableFrom = {
+  ...a,
+  resolve () {
+    return printableTo
+  },
+  location: '',
+}
+const printable = new Edge({
+  from: printableFrom,
+  type: 'prod',
+  name: 'b',
+  spec: '1.2.3',
+})
+t.matchSnapshot(
+  normalizeNode10compatSnapshots(
+    util.inspect(printable)
+  ),
+  'should return a human-readable representation of the edge obj'
+)
+
+const minimalPrintableFrom = {
+  ...a,
+  resolve () {
+    return null
+  },
+}
+const minimalPrintable = new Edge({
+  from: minimalPrintableFrom,
+  type: 'dev',
+  name: 'b',
+  spec: '1.2.3',
+})
+t.match(
+  minimalPrintable.toJSON(),
+  {
+    name: 'b',
+    spec: '1.2.3',
+    type: 'dev',
+    error: 'MISSING',
+  },
+  'should return a minimal human-readable representation of the edge obj'
+)


### PR DESCRIPTION
When using `console.log()` to print either `this.idealTree` or a `node` or any `Edge` it will provide a much better human-readable output.

### Examples
Taken from some random output in build-ideal-tree tests.

```js
console.log(this.idealTree)
```

```js
ArboristNode {
  name: 'outdated-no-lockfile',
  location: '',
  edgesOut: Map(2) {
    'mkdirp' => ArboristEdge {
      name: 'mkdirp',
      type: 'prod',
      spec: '1',
      from: '',
      to: 'node_modules/mkdirp'
    },
    'once' => ArboristEdge {
      name: 'once',
      type: 'prod',
      spec: '^1.3.3',
      from: '',
      to: 'node_modules/once'
    }
  },
  children: Map(3) {
    'mkdirp' => ArboristNode {
      name: 'mkdirp',
      location: 'node_modules/mkdirp',
      resolved: 'https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz',
      edgesIn: [Set]
    },
    'once' => ArboristNode {
      name: 'once',
      location: 'node_modules/once',
      resolved: 'https://registry.npmjs.org/once/-/once-1.3.3.tgz',
      edgesIn: [Set],
      edgesOut: [Map]
    },
    'wrappy' => ArboristNode {
      name: 'wrappy',
      location: 'node_modules/wrappy',
      resolved: 'https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz',
      edgesIn: [Set]
    }
  }
}
```

```js
ArboristNode {
  name: 'testing-peer-deps-nested',
  location: '',
  edgesOut: Map(1) {
    '@isaacs/testing-peer-deps' => ArboristEdge {
      name: '@isaacs/testing-peer-deps',
      type: 'prod',
      spec: '2 || 3',
      from: '',
      to: 'node_modules/@isaacs/testing-peer-deps'
    }
  },
  children: Map(4) {
    '@isaacs/testing-peer-deps' => ArboristNode {
      name: '@isaacs/testing-peer-deps',
      location: 'node_modules/@isaacs/testing-peer-deps',
      resolved: 'https://registry.npmjs.org/@isaacs/testing-peer-deps/-/testing-peer-deps-3.0.0.tgz',
      edgesIn: [Set],
      edgesOut: [Map]
    },
    '@isaacs/testing-peer-deps-b' => ArboristNode {
      name: '@isaacs/testing-peer-deps-b',
      location: 'node_modules/@isaacs/testing-peer-deps-b',
      resolved: 'https://registry.npmjs.org/@isaacs/testing-peer-deps-b/-/testing-peer-deps-b-2.0.1.tgz',
      edgesIn: [Set],
      edgesOut: [Map]
    },
    '@isaacs/testing-peer-deps-c' => ArboristNode {
      name: '@isaacs/testing-peer-deps-c',
      location: 'node_modules/@isaacs/testing-peer-deps-c',
      resolved: 'https://registry.npmjs.org/@isaacs/testing-peer-deps-c/-/testing-peer-deps-c-2.0.0.tgz',
      peer: true,
      edgesIn: [Set]
    },
    '@isaacs/testing-peer-deps-d' => ArboristNode {
      name: '@isaacs/testing-peer-deps-d',
      location: 'node_modules/@isaacs/testing-peer-deps-d',
      resolved: 'https://registry.npmjs.org/@isaacs/testing-peer-deps-d/-/testing-peer-deps-d-2.0.0.tgz',
      edgesIn: [Set],
      edgesOut: [Map],
      children: [Map]
    }
  }
}
```
