### PR TITLE
Fixes consistent-resolve.js so that it returns git URLs with the same protocol as originally entered

### DIFF
--- a/lib/consistent-resolve.js
+++ b/lib/consistent-resolve.js
@@ -20,7 +20,7 @@ const consistentResolve = (resolved, fromPath, toPath, relPaths = false) => {
     const isPath = type === 'file' || type === 'directory'
     return isPath && !relPaths ? `file:${fetchSpec}`
       : isPath ? 'file:' + (toPath ? relpath(toPath, fetchSpec) : fetchSpec)
-      : hosted ? 'git+' + hosted.sshurl({ noCommittish: false })
+      : hosted ? hosted.toString({ noGitPlus: false, noCommittish: false })
       : type === 'git' ? saveSpec
       // always return something.  'foo' is interpreted as 'foo@' otherwise.
       : rawSpec === '' && raw.slice(-1) !== '@' ? raw

--- a/tap-snapshots/test-arborist-load-actual.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-load-actual.js-TAP.test.js
@@ -2340,11 +2340,11 @@ Node {
       },
       "full-git-url": Object {
         "from": "full-git-url@git+https://github.com/isaacs/abbrev-js.git",
-        "version": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+        "version": "git+https://github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
       },
       "ghshort": Object {
         "from": "ghshort@github:isaacs/abbrev-js",
-        "version": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+        "version": "github:isaacs/abbrev-js#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
       },
       "ghtgz": Object {
         "extraneous": true,
@@ -2551,13 +2551,13 @@ Node {
       "node_modules/full-git-url": Object {
         "license": "ISC",
         "name": "abbrev",
-        "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+        "resolved": "git+https://github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
         "version": "1.1.1",
       },
       "node_modules/ghshort": Object {
         "license": "ISC",
         "name": "abbrev",
-        "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+        "resolved": "github:isaacs/abbrev-js#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
         "version": "1.1.1",
       },
       "node_modules/ghtgz": Object {

--- a/tap-snapshots/test-arborist-load-virtual.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-load-virtual.js-TAP.test.js
@@ -14125,7 +14125,7 @@ Node {
         "name": "full-git-url",
         "version": undefined,
       },
-      "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+      "resolved": "git+https://github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
     },
     "ghshort" => Node {
       "edgesIn": Set {
@@ -14142,7 +14142,7 @@ Node {
         "name": "ghshort",
         "version": undefined,
       },
-      "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+      "resolved": "github:isaacs/abbrev-js#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
     },
     "ghtgz" => Node {
       "location": "node_modules/ghtgz",
@@ -14860,7 +14860,7 @@ Node {
         "name": "full-git-url",
         "version": undefined,
       },
-      "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+      "resolved": "git+https://github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
     },
     "ghshort" => Node {
       "edgesIn": Set {
@@ -14877,7 +14877,7 @@ Node {
         "name": "ghshort",
         "version": undefined,
       },
-      "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+      "resolved": "github:isaacs/abbrev-js#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
     },
     "ghtgz" => Node {
       "location": "node_modules/ghtgz",
@@ -15595,7 +15595,7 @@ Node {
         "name": "full-git-url",
         "version": undefined,
       },
-      "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+      "resolved": "git+https://github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
     },
     "ghshort" => Node {
       "edgesIn": Set {
@@ -15612,7 +15612,7 @@ Node {
         "name": "ghshort",
         "version": undefined,
       },
-      "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+      "resolved": "github:isaacs/abbrev-js#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
     },
     "ghtgz" => Node {
       "location": "node_modules/ghtgz",
@@ -16306,7 +16306,7 @@ Node {
         "name": "full-git-url",
         "version": undefined,
       },
-      "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+      "resolved": "git+https://github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
     },
     "ghshort" => Node {
       "location": "node_modules/ghshort",
@@ -16315,7 +16315,7 @@ Node {
         "name": "ghshort",
         "version": undefined,
       },
-      "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+      "resolved": "github:isaacs/abbrev-js#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
     },
     "ghtgz" => Node {
       "location": "node_modules/ghtgz",

--- a/tap-snapshots/test-shrinkwrap.js-TAP.test.js
+++ b/tap-snapshots/test-shrinkwrap.js-TAP.test.js
@@ -498,7 +498,7 @@ Object {
         "url": "https://example.com/payme",
       },
       "name": "link",
-      "resolved": "git+ssh://git@github.com/isaacs/foobarbaz.git#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "resolved": "github:isaacs/foobarbaz#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "version": "1.2.3",
     },
   },
@@ -564,7 +564,7 @@ Object {
     "url": "https://example.com/payme",
   },
   "name": "link",
-  "resolved": "git+ssh://git@github.com/isaacs/foobarbaz.git#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "resolved": "github:isaacs/foobarbaz#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "version": "1.2.3",
 }
 `
@@ -1004,10 +1004,10 @@ Object {
       "version": "1.0.0",
     },
     "node_modules/full-git-url": Object {
-      "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+      "resolved": "git+https://github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
     },
     "node_modules/ghshort": Object {
-      "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+      "resolved": "github:isaacs/abbrev-js#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
     },
     "node_modules/ghtgz": Object {
       "integrity": "sha512-yowslMd9y/lGBCDVO0RwZoXRK5X0zMsf6XECM6DdeqN7qwVnFQ6IAwJai7BD4mVe1xOdWWqWNkuzyuStvSBnHw==",
@@ -1895,11 +1895,11 @@ Object {
     },
     "full-git-url": Object {
       "from": "full-git-url@git+https://github.com/isaacs/abbrev-js.git",
-      "version": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+      "version": "git+https://github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
     },
     "ghshort": Object {
       "from": "ghshort@github:isaacs/abbrev-js",
-      "version": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+      "version": "github:isaacs/abbrev-js#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
     },
     "ghtgz": Object {
       "extraneous": true,
@@ -2106,13 +2106,13 @@ Object {
     "node_modules/full-git-url": Object {
       "license": "ISC",
       "name": "abbrev",
-      "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+      "resolved": "git+https://github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
       "version": "1.1.1",
     },
     "node_modules/ghshort": Object {
       "license": "ISC",
       "name": "abbrev",
-      "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+      "resolved": "github:isaacs/abbrev-js#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
       "version": "1.1.1",
     },
     "node_modules/ghtgz": Object {
@@ -14230,7 +14230,7 @@ Object {
 
 exports[`test/shrinkwrap.js TAP look up from locks and such lockfile > full git 1`] = `
 Object {
-  "resolved": "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
+  "resolved": "git+https://github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
 }
 `
 
@@ -14251,6 +14251,9 @@ Object {
     "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
     "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
     "version": "1.1.1",
+  },
+  "node_modules/full-git-url": Object {
+    "resolved": "git+https://github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
   },
 }
 `

--- a/tap-snapshots/test-shrinkwrap.js-TAP.test.js
+++ b/tap-snapshots/test-shrinkwrap.js-TAP.test.js
@@ -14252,9 +14252,6 @@ Object {
     "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
     "version": "1.1.1",
   },
-  "node_modules/full-git-url": Object {
-    "resolved": "git+https://github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb",
-  },
 }
 `
 

--- a/tap-snapshots/test-yarn-lock.js-TAP.test.js
+++ b/tap-snapshots/test-yarn-lock.js-TAP.test.js
@@ -121,11 +121,11 @@ exports[`test/yarn-lock.js TAP load a yarn lock from an actual tree install-type
   "version" "1.0.0"
 
 "full-git-url@git+https://github.com/isaacs/abbrev-js.git":
-  "resolved" "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb"
+  "resolved" "git+https://github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb"
   "version" "1.1.1"
 
 "ghshort@github:isaacs/abbrev-js":
-  "resolved" "git+ssh://git@github.com/isaacs/abbrev-js.git#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb"
+  "resolved" "github:isaacs/abbrev-js#a9ee72ebc8fe3975f1b0c7aeb3a8f2a806a432eb"
   "version" "1.1.1"
 
 "glob@^7.1.3":

--- a/test/consistent-resolve.js
+++ b/test/consistent-resolve.js
@@ -55,33 +55,45 @@ t.test('file and directories made consistent if toPath not set', t => {
 })
 
 t.test('consistent hosted git info urls', t => {
-  const expect = 'git+ssh://git@github.com/a/b.git'
-  t.equal(cr('a/b'), expect)
-  t.equal(cr('github:a/b'), expect)
-  t.equal(cr('git+https://github.com/a/b'), expect)
-  t.equal(cr('git://github.com/a/b'), expect)
-  t.equal(cr('git+ssh://git@github.com/a/b'), expect)
-  t.equal(cr('git+https://github.com/a/b.git'), expect)
-  t.equal(cr('git://github.com/a/b.git'), expect)
-  t.equal(cr('git+ssh://git@github.com/a/b.git'), expect)
+  const auth_user = 'git@'
+  const variations = [
+    {},
+    { auth: auth_user },
+    { hash: '#0000000000000000000000000000000000000000' },
+  ]
 
-  const hash = '#0000000000000000000000000000000000000000'
-  t.equal(cr('a/b' + hash), expect + hash)
-  t.equal(cr('github:a/b' + hash), expect + hash)
-  t.equal(cr('git+https://github.com/a/b' + hash), expect + hash)
-  t.equal(cr('git://github.com/a/b' + hash), expect + hash)
-  t.equal(cr('git+ssh://git@github.com/a/b' + hash), expect + hash)
-  t.equal(cr('git+https://github.com/a/b.git' + hash), expect + hash)
-  t.equal(cr('git://github.com/a/b.git' + hash), expect + hash)
-  t.equal(cr('git+ssh://git@github.com/a/b.git' + hash), expect + hash)
-  t.equal(cr('xyz@a/b' + hash), expect + hash)
-  t.equal(cr('xyz@github:a/b' + hash), expect + hash)
-  t.equal(cr('xyz@git+https://github.com/a/b' + hash), expect + hash)
-  t.equal(cr('xyz@git://github.com/a/b' + hash), expect + hash)
-  t.equal(cr('xyz@git+ssh://git@github.com/a/b' + hash), expect + hash)
-  t.equal(cr('xyz@git+https://github.com/a/b.git' + hash), expect + hash)
-  t.equal(cr('xyz@git://github.com/a/b.git' + hash), expect + hash)
-  t.equal(cr('xyz@git+ssh://git@github.com/a/b.git' + hash), expect + hash)
+  let auth, hash;
+  const expect_url = 'github.com/a/b.git';
+
+  variations.forEach((opts) => {
+    auth = opts.auth ? opts.auth : '';
+    hash = opts.hash ? opts.hash : '';
+
+    let expect_github = 'github:' + 'a/b' + hash
+    t.equal(cr('a/b' + hash), expect_github)
+    t.equal(cr('github:a/b' + hash), expect_github)
+    t.equal(cr('xyz@a/b' + hash), expect_github)
+    t.equal(cr('xyz@github:a/b' + hash), expect_github)
+
+    let expect_git = 'git://' + auth + expect_url + hash
+    t.equal(cr('git://' + auth + 'github.com/a/b' + hash), expect_git)
+    t.equal(cr('git://' + auth + 'github.com/a/b.git' + hash), expect_git)
+    t.equal(cr('xyz@git://' + auth + 'github.com/a/b' + hash), expect_git)
+    t.equal(cr('xyz@git://' + auth + 'github.com/a/b.git' + hash), expect_git)
+
+    let expect_https = 'git+https://' + auth + expect_url + hash
+    t.equal(cr('git+https://' + auth + 'github.com/a/b' + hash), expect_https)
+    t.equal(cr('git+https://' + auth + 'github.com/a/b.git' + hash), expect_https)
+    t.equal(cr('xyz@git+https://' + auth + 'github.com/a/b' + hash), expect_https)
+    t.equal(cr('xyz@git+https://' + auth + 'github.com/a/b.git' + hash), expect_https)
+
+    let expect_ssh = 'git+ssh://' + auth_user + expect_url + hash // always has an auth
+    t.equal(cr('git+ssh://' + auth + 'github.com/a/b' + hash), expect_ssh)
+    t.equal(cr('git+ssh://' + auth + 'github.com/a/b.git' + hash), expect_ssh)
+    t.equal(cr('xyz@git+ssh://' + auth + 'github.com/a/b' + hash), expect_ssh)
+    t.equal(cr('xyz@git+ssh://' + auth + 'github.com/a/b.git' + hash), expect_ssh)
+  });
+
   t.end()
 })
 


### PR DESCRIPTION
Fixes consistent-resolve.js so that it returns git URLs with the same protocol as originally entered

## References
  Fixes #196 and https://github.com/npm/cli/issues/2389 (for NPM 7.x)
  Closes #196 
