### PR TITLE
fix: should create prefix path if missing

### DIFF
--- a/tap-snapshots/test-arborist-reify.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-reify.js-TAP.test.js
@@ -156,6 +156,74 @@ exports[`test/arborist/reify.js TAP add a dep present in the tree, with v1 shrin
 {"dependencies":{"once":"^1.4.0","wrappy":"^1.0.2"}}
 `
 
+exports[`test/arborist/reify.js TAP add a new pkg to a prefix that needs to be mkdirpd > should output a successful tree in mkdirp folder 1`] = `
+Node {
+  "children": Map {
+    "abbrev" => Node {
+      "edgesIn": Set {
+        Edge {
+          "from": "",
+          "name": "abbrev",
+          "spec": "^1.1.1",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/abbrev",
+      "name": "abbrev",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+    },
+  },
+  "edgesOut": Map {
+    "abbrev" => Edge {
+      "name": "abbrev",
+      "spec": "^1.1.1",
+      "to": "node_modules/abbrev",
+      "type": "prod",
+    },
+  },
+  "location": "",
+  "name": "root",
+  "resolved": null,
+}
+`
+
+exports[`test/arborist/reify.js TAP add a new pkg to a prefix that needs to be mkdirpd > should place expected lockfile file into place 1`] = `
+{
+  "name": "root",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "abbrev": "^1.1.1"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    }
+  },
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    }
+  }
+}
+
+`
+
+exports[`test/arborist/reify.js TAP add a new pkg to a prefix that needs to be mkdirpd > should place expected package.json file into place 1`] = `
+{
+  "dependencies": {
+    "abbrev": "^1.1.1"
+  }
+}
+
+`
+
 exports[`test/arborist/reify.js TAP add multiple pkgs in a specific order > should alphabetically sort dependencies 1`] = `
 {"name":"multiple-pkgs","dependencies":{"abbrev":"^1.1.1","wrappy":"^1.0.2"}}
 `

--- a/test/arborist/reify.js
+++ b/test/arborist/reify.js
@@ -1186,6 +1186,39 @@ t.test('modules bundled by the root should be installed', async t => {
   t.matchSnapshot(fs.readFileSync(path + '/node_modules/child/package.json', 'utf8'))
 })
 
+t.test('add a new pkg to a prefix that needs to be mkdirpd', async t => {
+  const path = resolve(t.testdir(), 'missing/path/to/root')
+  const tree = await reify(path, { add: ['abbrev'] })
+  t.matchSnapshot(
+    printTree(tree),
+    'should output a successful tree in mkdirp folder'
+  )
+  t.matchSnapshot(
+    fs.readFileSync(path + '/package.json', 'utf8'),
+    'should place expected package.json file into place'
+  )
+  t.matchSnapshot(
+    fs.readFileSync(path + '/package-lock.json', 'utf8'),
+    'should place expected lockfile file into place'
+  )
+
+  t.test('dry run scenarios', async t => {
+    const path = resolve(t.testdir(), 'missing/path/to/root')
+
+    try {
+      await reify(path, { add: ['abbrev'], dryRun: true })
+    } catch (e) {
+      // TODO: should this be throwing?
+    }
+
+    t.throws(() =>
+      fs.statSync(resolve(path, 'node_modules')), { code: 'ENOENT' })
+
+    t.throws(() =>
+      fs.statSync(resolve(path, 'package.json')), { code: 'ENOENT' })
+  })
+})
+
 t.test('do not delete root-bundled deps in global update', async t => {
   const path = t.testdir()
   const file = resolve(__dirname, '../fixtures/bundle.tgz')


### PR DESCRIPTION
npm6 used to mkdir paths along the way if `--prefix` folder was missing, this seems like an unintentional change so this change fixes it by adding a proper path validation/mkdirp at the beggining of reify.

Fixes: https://github.com/npm/cli/issues/2012
