### PR TITLE
fix removing global packages when prefix is a symlink

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -72,6 +72,11 @@ const allChildren = node => {
   if (!node)
     return new Map()
 
+  // if the node is a global root, and also a link, then what we really
+  // want is to traverse the target's children
+  if (node.global && node.isRoot && node.isLink)
+    return allChildren(node.target)
+
   const kids = new Map()
   for (const n of [node, ...node.fsChildren]) {
     for (const kid of n.children.values())

--- a/tap-snapshots/test-diff.js-TAP.test.js
+++ b/tap-snapshots/test-diff.js-TAP.test.js
@@ -266,3 +266,43 @@ Diff {
   ],
 }
 `
+
+exports[`test/diff.js TAP when a global root is a link, traverse the target children > correctly removes the child node 1`] = `
+Diff {
+  "action": null,
+  "actual": Link {
+    "name": "path",
+    "path": "/some/linked/path",
+    "integrity": null,
+  },
+  "ideal": Node {
+    "name": "path",
+    "path": "/some/real/path",
+    "integrity": null,
+  },
+  "leaves": Array [
+    "/some/real/path/node_modules/child",
+  ],
+  "unchanged": Array [],
+  "removed": Array [
+    "/some/real/path/node_modules/child",
+  ],
+  "children": Array [
+    Diff {
+      "action": "REMOVE",
+      "actual": Node {
+        "name": "child",
+        "path": "/some/real/path/node_modules/child",
+        "integrity": null,
+      },
+      "ideal": undefined,
+      "leaves": Array [
+        "/some/real/path/node_modules/child",
+      ],
+      "unchanged": Array [],
+      "removed": Array [],
+      "children": Array [],
+    },
+  ],
+}
+`

--- a/test/diff.js
+++ b/test/diff.js
@@ -1,6 +1,7 @@
 const Diff = require('../lib/diff.js')
 const t = require('tap')
 const Node = require('../lib/node.js')
+const Link = require('../lib/link.js')
 
 
 // don't print the full node objects because we don't need to track that
@@ -184,3 +185,34 @@ t.matchSnapshot(d, 'diff two trees')
 t.equal(d.parent, null, 'root has no parent')
 t.equal([...d.children][0].parent, d, 'parent of root child is root')
 t.equal(d.action, null, 'root has no action')
+
+t.test('when a global root is a link, traverse the target children', async (t) => {
+  const actual = new Link({
+    global: true,
+    path: '/some/linked/path',
+    realpath: '/some/real/path',
+  })
+
+  actual.target = new Node({
+    global: true,
+    path: '/some/real/path',
+    pkg: {},
+    children: [{
+      name: 'child',
+      pkg: {
+        name: 'child',
+        version: '1.2.3'
+      }
+    }]
+  })
+
+  const ideal = new Node({
+    path: '/some/real/path',
+    realpath: '/some/real/path',
+    children: []
+  })
+
+  const diff = Diff.calculate({ actual, ideal })
+  t.matchSnapshot(diff, 'correctly removes the child node')
+  t.equal(diff.removed.length, 1, 'identifies the need to remove the child')
+})


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
currently, when your prefix is a symlink, you cannot remove any global dependencies on any operating system.

i was able to track this down to how the diff library iterates children, essentially because the root is a link and the children getter returns an empty map, we never detect that the global module was installed in the first place, so we fail to identify it needs to be removed.

the tweak here makes it so if a Link class represents the global root, we return the target's children instead of an explicit empty map.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes https://github.com/npm/cli/issues/1869