### PR TITLE
Rollback when a fatal signal arrives during reification

### DIFF
--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -1,5 +1,6 @@
 // mixin implementing the reify method
 
+const onExit = require('../signal-handling.js')
 const pacote = require('pacote')
 const rpj = require('read-package-json-fast')
 const { updateDepSpec } = require('../dep-spec.js')
@@ -27,8 +28,9 @@ const updateRootPackageJson = require('../update-root-package-json.js')
 const _retiredPaths = Symbol('retiredPaths')
 const _retiredUnchanged = Symbol('retiredUnchanged')
 const _sparseTreeDirs = Symbol('sparseTreeDirs')
+const _sparseTreeRoots = Symbol('sparseTreeRoots')
 const _savePrefix = Symbol('savePrefix')
-const _retireShallowNodes = Symbol('retireShallowNodes')
+const _retireShallowNodes = Symbol.for('retireShallowNodes')
 const _getBundlesByDepth = Symbol('getBundlesByDepth')
 const _registryResolved = Symbol('registryResolved')
 const _addNodeToTrashList = Symbol('addNodeToTrashList')
@@ -54,7 +56,7 @@ const _awaitQuickAudit = Symbol('awaitQuickAudit')
 const _unpackNewModules = Symbol.for('unpackNewModules')
 const _moveContents = Symbol.for('moveContents')
 const _moveBackRetiredUnchanged = Symbol.for('moveBackRetiredUnchanged')
-const _build = Symbol('build')
+const _build = Symbol.for('build')
 const _removeTrash = Symbol.for('removeTrash')
 const _renamePath = Symbol.for('renamePath')
 const _rollbackRetireShallowNodes = Symbol.for('rollbackRetireShallowNodes')
@@ -102,6 +104,7 @@ module.exports = cls => class Reifier extends cls {
     this[_retiredPaths] = {}
     this[_retiredUnchanged] = {}
     this[_sparseTreeDirs] = new Set()
+    this[_sparseTreeRoots] = new Set()
     this[_trashList] = new Set()
   }
 
@@ -153,16 +156,63 @@ module.exports = cls => class Reifier extends cls {
       return this[_submitQuickAudit]()
     }
 
-    await this[_retireShallowNodes]()
-    await this[_createSparseTree]()
-    await this[_addOmitsToTrashList]()
-    await this[_loadShrinkwrapsAndUpdateTrees]()
-    await this[_loadBundlesAndUpdateTrees]()
-    await this[_submitQuickAudit]()
-    await this[_unpackNewModules]()
-    await this[_moveBackRetiredUnchanged]()
-    await this[_build]()
+    // ok, we're about to start touching the fs.  need to roll back
+    // if we get an early termination.
+    let reifyTerminated = null
+    const removeHandler = onExit(({signal}) => {
+      // only call once.  if signal hits twice, we just terminate
+      removeHandler()
+      reifyTerminated = Object.assign(new Error('process terminated'), {
+        signal,
+      })
+      return false
+    })
+
+    // [rollbackfn, [...actions]]
+    // after each step, if the process was terminated, execute the rollback
+    // note that each rollback *also* calls the previous one when it's
+    // finished, and then the first one throws the error, so we only need
+    // a new rollback step when we have a new thing that must be done to
+    // revert the install.
+    const steps = [
+      [_rollbackRetireShallowNodes, [
+        _retireShallowNodes,
+      ]],
+      [_rollbackCreateSparseTree, [
+        _createSparseTree,
+        _addOmitsToTrashList,
+        _loadShrinkwrapsAndUpdateTrees,
+        _loadBundlesAndUpdateTrees,
+        _submitQuickAudit,
+        _unpackNewModules,
+      ]],
+      [_rollbackMoveBackRetiredUnchanged, [
+        _moveBackRetiredUnchanged,
+        _build,
+      ]],
+    ]
+    for (const [rollback, actions] of steps) {
+      for (const action of actions) {
+        try {
+          await this[action]()
+          if (reifyTerminated)
+            throw reifyTerminated
+        } catch (er) {
+          await this[rollback](er)
+          /* istanbul ignore next - rollback throws, should never hit this */
+          throw er
+        }
+      }
+    }
+
+    // no rollback for this one, just exit with the error, since the
+    // install completed and can't be safely recovered at this point.
     await this[_removeTrash]()
+    if (reifyTerminated)
+      throw reifyTerminated
+
+    // done modifying the file system, no need to keep listening for sigs
+    removeHandler()
   }
 
   // when doing a local install, we load everything and figure it all out.
@@ -261,7 +311,6 @@ module.exports = cls => class Reifier extends cls {
     const movePromises = Object.entries(moves)
       .map(([from, to]) => this[_renamePath](from, to))
     return promiseAllRejectLate(movePromises)
-      .catch(er => this[_rollbackRetireShallowNodes](er))
       .then(() => process.emit('timeEnd', 'reify:retireShallow'))
   }
 
@@ -327,18 +376,22 @@ module.exports = cls => class Reifier extends cls {
       .map(diff => diff.ideal.path)
 
     return promiseAllRejectLate(dirs.map(d => mkdirp(d)))
-      .then(() => dirs.forEach(dir => this[_sparseTreeDirs].add(dir)))
+      .then(made => {
+        made.forEach(made => this[_sparseTreeRoots].add(made))
+        dirs.forEach(dir => this[_sparseTreeDirs].add(dir))
+      })
       .then(() => process.emit('timeEnd', 'reify:createSparse'))
-      .catch(er => this[_rollbackCreateSparseTree](er))
   }
 
   [_rollbackCreateSparseTree] (er) {
     process.emit('time', 'reify:rollback:createSparse')
-    // cut the roots of the sparse tree, not the leaves
-    const moves = this[_retiredPaths]
+    // cut the roots of the sparse tree that were created, not the leaves
+    const roots = this[_sparseTreeRoots]
+    // also delete the moves that we retired, so that we can move them back
     const failures = []
-    const unlinks = Object.entries(moves)
-      .map(([from, to]) => rimraf(from).catch(er => failures.push([from, er])))
+    const targets = [...roots, ...Object.keys(this[_retiredPaths])]
+    const unlinks = targets
+      .map(path => rimraf(path).catch(er => failures.push([path, er])))
     return promiseAllRejectLate(unlinks)
       .then(() => {
         if (failures.length)
@@ -376,7 +429,6 @@ module.exports = cls => class Reifier extends cls {
       .then(() => this[_diffTrees]())
       .then(() => this[_createSparseTree]())
       .then(() => process.emit('timeEnd', 'reify:loadShrinkwraps'))
-      .catch(er => this[_rollbackCreateSparseTree](er))
   }
 
   // create a symlink for Links, extract for Nodes
@@ -544,7 +596,6 @@ module.exports = cls => class Reifier extends cls {
         }))))
     // move onto the next level of bundled items
       .then(() => this[_loadBundlesAndUpdateTrees](depth + 1, bundlesByDepth))
-      .catch(er => this[_rollbackCreateSparseTree](er))
   }
 
   [_getBundlesByDepth] () {
@@ -678,7 +729,6 @@ module.exports = cls => class Reifier extends cls {
     })
     return promiseAllRejectLate(unpacks)
       .then(() => process.emit('timeEnd', 'reify:unpack'))
-      .catch(er => this[_rollbackCreateSparseTree](er))
   }
 
   // This is the part where we move back the unchanging nodes that were
@@ -721,7 +771,6 @@ module.exports = cls => class Reifier extends cls {
       }))
     }))
       .then(() => process.emit('timeEnd', 'reify:unretire'))
-      .catch(er => this[_rollbackMoveBackRetiredUnchanged](er))
   }
 
   // move the contents from the fromPath to the node.path
@@ -772,7 +821,6 @@ module.exports = cls => class Reifier extends cls {
 
     return this.rebuild({ nodes, handleOptionalFailure: true })
       .then(() => process.emit('timeEnd', 'reify:build'))
-      .catch(er => this[_rollbackMoveBackRetiredUnchanged](er))
   }
 
   // the tree is pretty much built now, so it's cleanup time.

--- a/lib/signal-handling.js
+++ b/lib/signal-handling.js
@@ -1,0 +1,68 @@
+const signals = require('./signals.js')
+
+// for testing, expose the process being used
+module.exports = Object.assign(fn => setup(fn), { process })
+
+// do all of this in a setup function so that we can call it
+// multiple times for multiple reifies that might be going on.
+// Otherwise, Arborist.reify() is a global action, which is a
+// new constraint we'd be adding with this behavior.
+const setup = fn => {
+  const { process } = module.exports
+
+  const sigListeners = { loaded: false }
+  sigListeners.loaded = false
+
+  const unload = () => {
+    if (!sigListeners.loaded)
+      return
+    for (const sig of signals) {
+      try {
+        process.removeListener(sig, sigListeners[sig])
+      } catch (er) {}
+    }
+    process.removeListener('beforeExit', onBeforeExit)
+    sigListeners.loaded = false
+  }
+
+  const onBeforeExit = () => {
+    // this trick ensures that we exit with the same signal we caught
+    // Ie, if you press ^C and npm gets a SIGINT, we'll do the rollback
+    // and then exit with a SIGINT signal once we've removed the handler.
+    // The timeout is there because signals are asynchronous, so we need
+    // the process to NOT exit on its own, which means we have to have
+    // something keeping the event loop looping.  Hence this hack.
+    unload()
+    process.kill(process.pid, signalReceived)
+    setTimeout(() => {}, 500)
+  }
+
+  let signalReceived = null
+  const listener = (sig, fn) => () => {
+    signalReceived = sig
+
+    // if we exit normally, but caught a signal which would have been fatal,
+    // then re-send it once we're done with whatever cleanup we have to do.
+    unload()
+    if (process.listeners(sig).length < 1)
+      process.once('beforeExit', onBeforeExit)
+
+    fn({ signal: sig })
+  }
+
+  // do the actual loading here
+  for (const sig of signals) {
+    sigListeners[sig] = listener(sig, fn)
+    const max = process.getMaxListeners()
+    try {
+      // if we call this a bunch of times, avoid triggering the warning
+      const { length } = process.listeners(sig)
+      if (length >= max)
+        process.setMaxListeners(length + 1)
+      process.on(sig, sigListeners[sig])
+    } catch (er) {}
+  }
+  sigListeners.loaded = true
+
+  return unload
+}

--- a/lib/signal-handling.js
+++ b/lib/signal-handling.js
@@ -11,7 +11,6 @@ const setup = fn => {
   const { process } = module.exports
 
   const sigListeners = { loaded: false }
-  sigListeners.loaded = false
 
   const unload = () => {
     if (!sigListeners.loaded)

--- a/lib/signals.js
+++ b/lib/signals.js
@@ -1,0 +1,58 @@
+// copied from signal-exit
+
+// This is not the set of all possible signals.
+//
+// It IS, however, the set of all signals that trigger
+// an exit on either Linux or BSD systems.  Linux is a
+// superset of the signal names supported on BSD, and
+// the unknown signals just fail to register, so we can
+// catch that easily enough.
+//
+// Don't bother with SIGKILL.  It's uncatchable, which
+// means that we can't fire any callbacks anyway.
+//
+// If a user does happen to register a handler on a non-
+// fatal signal like SIGWINCH or something, and then
+// exit, it'll end up firing `process.emit('exit')`, so
+// the handler will be fired anyway.
+//
+// SIGBUS, SIGFPE, SIGSEGV and SIGILL, when not raised
+// artificially, inherently leave the process in a
+// state from which it is not safe to try and enter JS
+// listeners.
+
+const platform = global.__ARBORIST_FAKE_PLATFORM__ || process.platform
+
+module.exports = [
+  'SIGABRT',
+  'SIGALRM',
+  'SIGHUP',
+  'SIGINT',
+  'SIGTERM',
+]
+
+if (platform !== 'win32') {
+  module.exports.push(
+    'SIGVTALRM',
+    'SIGXCPU',
+    'SIGXFSZ',
+    'SIGUSR2',
+    'SIGTRAP',
+    'SIGSYS',
+    'SIGQUIT',
+    'SIGIOT'
+    // should detect profiler and enable/disable accordingly.
+    // see #21
+    // 'SIGPROF'
+  )
+}
+
+if (platform === 'linux') {
+  module.exports.push(
+    'SIGIO',
+    'SIGPOLL',
+    'SIGPWR',
+    'SIGSTKFLT',
+    'SIGUNUSED'
+  )
+}

--- a/tap-snapshots/test-signals.js-TAP.test.js
+++ b/tap-snapshots/test-signals.js-TAP.test.js
@@ -1,0 +1,57 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/signals.js TAP signals on darwin > must match snapshot 1`] = `
+Array [
+  "SIGABRT",
+  "SIGALRM",
+  "SIGHUP",
+  "SIGINT",
+  "SIGTERM",
+  "SIGVTALRM",
+  "SIGXCPU",
+  "SIGXFSZ",
+  "SIGUSR2",
+  "SIGTRAP",
+  "SIGSYS",
+  "SIGQUIT",
+  "SIGIOT",
+]
+`
+
+exports[`test/signals.js TAP signals on linux > must match snapshot 1`] = `
+Array [
+  "SIGABRT",
+  "SIGALRM",
+  "SIGHUP",
+  "SIGINT",
+  "SIGTERM",
+  "SIGVTALRM",
+  "SIGXCPU",
+  "SIGXFSZ",
+  "SIGUSR2",
+  "SIGTRAP",
+  "SIGSYS",
+  "SIGQUIT",
+  "SIGIOT",
+  "SIGIO",
+  "SIGPOLL",
+  "SIGPWR",
+  "SIGSTKFLT",
+  "SIGUNUSED",
+]
+`
+
+exports[`test/signals.js TAP signals on win32 > must match snapshot 1`] = `
+Array [
+  "SIGABRT",
+  "SIGALRM",
+  "SIGHUP",
+  "SIGINT",
+  "SIGTERM",
+]
+`

--- a/test/signal-handling.js
+++ b/test/signal-handling.js
@@ -1,0 +1,124 @@
+const t = require('tap')
+
+const onExit = require('../lib/signal-handling.js')
+t.equal(onExit.process, process, 'uses the real process by default')
+
+// ok, from here on out, use our mock
+const EE = require('events')
+const proc = onExit.process = new class MockProcess extends EE {
+  constructor () {
+    super()
+    this.pid = process.pid
+  }
+
+  // yes, yes, the actual process.kill doesn't return a promise, but
+  // we need to know when this async action is done to know when to
+  // continue on to other parts of the test.
+  kill (pid, signal) {
+    if (pid !== this.pid) {
+      throw Object.assign(new Error('wrong pid sent to kill() method'), {
+        expect: this.pid,
+        actual: pid,
+      })
+    }
+    return new Promise(res => process.nextTick(() => {
+      this.emit(signal)
+      res()
+    }))
+  }
+}
+
+t.test('load and unload', async t => {
+  t.plan(2)
+
+  const unload = onExit(({ signal }) => t.equal(signal, 'SIGINT'))
+  unload()
+
+  // should not trigger for these
+  await Promise.all([
+    proc.kill(process.pid, 'SIGINT'),
+    proc.kill(process.pid, 'SIGINT'),
+    proc.kill(process.pid, 'SIGINT'),
+  ])
+
+  t.equal(proc.listeners('beforeExit').length, 0, 'did not leave beforeExit')
+  t.equal(proc.listeners('SIGINT').length, 0, 'did not leave SIGINT')
+
+  // calling multiple times is safe
+  unload()
+  unload()
+})
+
+t.test('load only listens to one event', async t => {
+  t.plan(2)
+  const unload = onExit(({ signal }) => t.equal(signal, 'SIGINT'))
+  await proc.kill(process.pid, 'SIGINT')
+  // should not trigger our onExit handler, but WILL call this one,
+  // since the beforeExit handler was assigned
+  proc.once('SIGINT', () => t.pass('got follow-up signal'))
+  proc.emit('beforeExit')
+  // give it a moment for the synthetic kill timeout to fire
+  await new Promise(res => setTimeout(res))
+})
+
+t.test('only respond to first signal', async t => {
+  t.plan(5)
+  const unload = onExit(({ signal }) => t.equal(signal, 'SIGINT'))
+  await proc.kill(process.pid, 'SIGINT')
+  await proc.kill(process.pid, 'SIGHUP')
+  await proc.kill(process.pid, 'SIGTERM')
+  proc.emit('beforeExit')
+  t.equal(proc.listeners('beforeExit').length, 0, 'did not leave beforeExit')
+  t.equal(proc.listeners('SIGINT').length, 0, 'did not leave SIGINT')
+  t.equal(proc.listeners('SIGHUP').length, 0, 'did not leave SIGHUP')
+  t.equal(proc.listeners('SIGTERM').length, 0, 'did not leave SIGTERM')
+})
+
+t.test('can do multiple loads in parallel', t => {
+  t.plan(2)
+
+  t.test('running two handlers', async t => {
+    t.plan(3)
+    const unload1 = onExit(({ signal }) => t.equal(signal, 'SIGINT', '1'))
+    const unload2 = onExit(({ signal }) => t.equal(signal, 'SIGINT', '2'))
+    await proc.kill(process.pid, 'SIGINT')
+    // should not trigger our onExit handler, but WILL call this one,
+    // since the beforeExit handler was assigned
+    proc.once('SIGINT', () => t.pass('got follow-up signal'))
+    proc.emit('beforeExit')
+    // give it a moment for the synthetic kill timeout to fire
+    await new Promise(res => setTimeout(res))
+  })
+
+  t.test('verify cleanup after both are finished', t => {
+    t.plan(4)
+    t.equal(proc.listeners('beforeExit').length, 0, 'did not leave beforeExit')
+    t.equal(proc.listeners('SIGINT').length, 0, 'did not leave SIGINT')
+    t.equal(proc.listeners('SIGHUP').length, 0, 'did not leave SIGHUP')
+    t.equal(proc.listeners('SIGTERM').length, 0, 'did not leave SIGTERM')
+  })
+})
+
+t.test('no max listener warning', t => {
+  t.plan(1)
+  const { emitWarning } = process
+  Object.defineProperty(process, 'emitWarning', {
+    value: (...args) => {
+      emitWarning.call(process, ...args)
+      throw new Error('no warnings should be emitted')
+    },
+    configurable: true,
+  })
+  t.teardown(() => Object.defineProperty(process, 'emitWarning', {
+    value: emitWarning,
+    configurable: true,
+  }))
+
+  const unloads = []
+  for (let i = 0; i < 1000; i++)
+    unloads.push(onExit(() => {}))
+  for (const unload of unloads)
+    unload()
+
+  t.pass('if no throw, then it worked')
+})

--- a/test/signals.js
+++ b/test/signals.js
@@ -1,0 +1,12 @@
+const t = require('tap')
+const requireInject = require('require-inject')
+
+const runTest = platform => async t => {
+  global.__ARBORIST_FAKE_PLATFORM__ = process.platform === platform ? null
+  : platform
+  t.matchSnapshot(requireInject('../lib/signals.js'))
+}
+
+t.test('signals on darwin', runTest('darwin'))
+t.test('signals on linux', runTest('linux'))
+t.test('signals on win32', runTest('win32'))


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Rollback when a fatal signal arrives during reification

This also fixes an issue where the rollback did not properly restore the
state if installing a _new_ package, since there was no move required
when creating the sparse tree in that case, resulting in potentially
half-installed deps being left behind.  Found while combing through
testing every rollback for signal handling.

Fix: https://github.com/npm/cli/issues/2312
