### PR TITLE
Detect conflicts among nested peerOptional deps

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -1032,19 +1032,20 @@ This is a one-time fix-up, please be patient...
   // deps to override, but throw if no preference can be determined.
   async [_loadPeerSet] (node) {
     const peerEdges = [...node.edgesOut.values()]
-      // we only care about peers here, and don't install peerOptionals
-      .filter(e => e.peer && !e.valid && !e.optional)
+      // we typically only install non-optional peers, but we have to
+      // factor them into the peerSet so that we can avoid conflicts
+      .filter(e => e.peer && !(e.valid && e.to))
       .sort(({name: a}, {name: b}) => a.localeCompare(b))
 
     for (const edge of peerEdges) {
       // already placed this one, and we're happy with it.
-      if (edge.valid)
+      if (edge.valid && edge.to)
         continue
 
       const parentEdge = node.parent.edgesOut.get(edge.name)
       const {isRoot, isWorkspace} = node.parent.sourceReference
       const isMine = isRoot || isWorkspace
-      if (edge.missing) {
+      if (!edge.to) {
         if (!parentEdge) {
           // easy, just put the thing there
           await this[_nodeFromEdge](edge, node.parent)

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -2283,3 +2283,26 @@ t.test('remove deps when initializing tree from actual tree', async t => {
   const tree = await arb.buildIdealTree({ rm: ['foo'] })
   t.equal(tree.children.get('foo'), undefined, 'removed foo child')
 })
+
+t.test('detect conflicts in transitive peerOptional deps', t => {
+  t.plan(2)
+  const base = resolve(fixtures, 'test-conflicted-optional-peer-dep')
+
+  t.test('nest when peerOptional conflicts', async t => {
+    const path = resolve(base, 'nest-peer-optional')
+    const tree = await buildIdeal(path)
+    t.matchSnapshot(printTree(tree))
+    const name = '@isaacs/test-conflicted-optional-peer-dep-peer'
+    const peers = tree.inventory.query('name', name)
+    t.equal(peers.size, 2, 'installed the peer dep twice to avoid conflict')
+  })
+
+  t.test('omit peerOptionals when not needed for conflicts', async t => {
+    const path = resolve(base, 'omit-peer-optional')
+    const tree = await buildIdeal(path)
+    t.matchSnapshot(printTree(tree))
+    const name = '@isaacs/test-conflicted-optional-peer-dep-peer'
+    const peers = tree.inventory.query('name', name)
+    t.equal(peers.size, 0, 'omit peerOptional, not needed')
+  })
+})

--- a/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-has-peer-optional.json
+++ b/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-has-peer-optional.json
@@ -1,0 +1,61 @@
+{
+  "_id": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+  "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+      "version": "1.0.0",
+      "peerDependenciesMeta": {
+        "@isaacs/test-conflicted-optional-peer-dep-peer": {
+          "optional": true
+        }
+      },
+      "peerDependencies": {
+        "@isaacs/test-conflicted-optional-peer-dep-peer": "2"
+      },
+      "_id": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.4.2",
+      "dist": {
+        "integrity": "sha512-T7Q34SzRbR04Cvg8/pV4DgpJypYcsN57yDdhwVdHfZkLjbUTAM44Yk5875JtmeVzlN0jdBo9vMING1CDubp8rA==",
+        "shasum": "73fccf22f73b66c8824cc1fc9d32f38167e43e14",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional/-/test-conflicted-optional-peer-dep-has-peer-optional-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 303,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIQwCRA9TVsSAnZWagAAsXIP/07lucPaj4WdlPbTVm5O\nh90XaVkib9xE+8g/DTD2dQEAAeb31B1Mls9BIHVMJy9Zhz2aWJLiq1al5xsI\nBBJIwlTpg6k4PLKFlXEFBszufN0tL5zpwhp0HDb/3vCPFSqaIrcYdCSIYlxX\n3nmSUD7a24ygDE7fIHW1GImz1Bscc725P7umXpPV4XfsVW7iwjnrX1vTYYiA\nZvte6lsDiyCQNnX6ovMKjfwzx4r5rrIDhfogSUgyyN87+fqQnqmP4CsZmiUq\nXOB59SBjPG+60eEgPJ86RmSOXQ3/c76BfHZAyi15V6+JaPovbWpHMVrp+qN5\nHYZIFeraNy0YazOMckY5a5+MEypf/MHDTJb14rp26/XWvs0WZjwDEmjJqIYH\nB4L/KkImVtSkgQ/1umCrXiwnTh+vwpap/QuVy+RlEIVFego3Jj8MbP+snjq4\n/8TEbAtgCt44lCsnYmcYCpvMa4dSHR9mjDz74PkU5rbnvz/XS4CdNxYM1TrF\nDuqT0E07Z7dUHLdldP4xToYB8RCL8cMePTkmk2a8DgUd1bd47WDls42ZWMKj\n7aBeKmcBJLtQjKML/hseAJMXvjrVsQBb4h+fTjW3ysBPeLr6ZlXPqjQ8XJa+\nabNlG0Z6cwZu0EuW6YVd088lrXYNW2XV2+B40ljGBXkRw1xxGNDoPIZx847R\npjon\r\n=JZKC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/test-conflicted-optional-peer-dep-has-peer-optional_1.0.0_1611695152056_0.7052189338101718"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-01-26T21:05:52.003Z",
+    "1.0.0": "2021-01-26T21:05:52.209Z",
+    "modified": "2021-01-26T21:05:54.467Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-has-peer-optional.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-has-peer-optional.min.json
@@ -1,0 +1,29 @@
+{
+  "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/test-conflicted-optional-peer-dep-peer": "2"
+      },
+      "dist": {
+        "integrity": "sha512-T7Q34SzRbR04Cvg8/pV4DgpJypYcsN57yDdhwVdHfZkLjbUTAM44Yk5875JtmeVzlN0jdBo9vMING1CDubp8rA==",
+        "shasum": "73fccf22f73b66c8824cc1fc9d32f38167e43e14",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional/-/test-conflicted-optional-peer-dep-has-peer-optional-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 303,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIQwCRA9TVsSAnZWagAAsXIP/07lucPaj4WdlPbTVm5O\nh90XaVkib9xE+8g/DTD2dQEAAeb31B1Mls9BIHVMJy9Zhz2aWJLiq1al5xsI\nBBJIwlTpg6k4PLKFlXEFBszufN0tL5zpwhp0HDb/3vCPFSqaIrcYdCSIYlxX\n3nmSUD7a24ygDE7fIHW1GImz1Bscc725P7umXpPV4XfsVW7iwjnrX1vTYYiA\nZvte6lsDiyCQNnX6ovMKjfwzx4r5rrIDhfogSUgyyN87+fqQnqmP4CsZmiUq\nXOB59SBjPG+60eEgPJ86RmSOXQ3/c76BfHZAyi15V6+JaPovbWpHMVrp+qN5\nHYZIFeraNy0YazOMckY5a5+MEypf/MHDTJb14rp26/XWvs0WZjwDEmjJqIYH\nB4L/KkImVtSkgQ/1umCrXiwnTh+vwpap/QuVy+RlEIVFego3Jj8MbP+snjq4\n/8TEbAtgCt44lCsnYmcYCpvMa4dSHR9mjDz74PkU5rbnvz/XS4CdNxYM1TrF\nDuqT0E07Z7dUHLdldP4xToYB8RCL8cMePTkmk2a8DgUd1bd47WDls42ZWMKj\n7aBeKmcBJLtQjKML/hseAJMXvjrVsQBb4h+fTjW3ysBPeLr6ZlXPqjQ8XJa+\nabNlG0Z6cwZu0EuW6YVd088lrXYNW2XV2+B40ljGBXkRw1xxGNDoPIZx847R\npjon\r\n=JZKC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/test-conflicted-optional-peer-dep-peer": {
+          "optional": true
+        }
+      }
+    }
+  },
+  "modified": "2021-01-26T21:05:54.467Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-has-peer.json
+++ b/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-has-peer.json
@@ -1,0 +1,56 @@
+{
+  "_id": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
+  "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/test-conflicted-optional-peer-dep-peer": "1"
+      },
+      "_id": "@isaacs/test-conflicted-optional-peer-dep-has-peer@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.4.2",
+      "dist": {
+        "integrity": "sha512-asey7Jpi/z+ViT7qkAC5I8xsCY3TYDE6L/EFB78gd1ARClKtM670t6mudqpc9i0wzaXRP8LQ3y/AD6Wwa4SSLQ==",
+        "shasum": "74715ae753e1cce44cb82eb10fdefb42c74817d6",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-has-peer/-/test-conflicted-optional-peer-dep-has-peer-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 176,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIQtCRA9TVsSAnZWagAAooEP/i+M6Yieb2T2uws8Oh4N\n/QmLwOPPQIGpF8N04EjW3gE4HrGCrMnBsS5zX5K21xcijAfmxhCUw7VNFoVd\nDaDstxTbg+qF+C12Y8pycYJq+8dGq1OhGPr7xvHCEUJCYDWSLm+W1bkESiiK\nMZ7S1Ckr9K1ldCU8Fwz5QJlk/LqZa/GeOdI/N7dOtNXR8Wuv9nlL6PfhzlBy\nE4Zgv4JjT+bX8EneptbWaGcAF5IePQ2OMSuBWvwBRxp2/aKf6FxGLPm5tCDy\n5Xh13tCzADj+9apf9gBadWylQNunggOOW/VSumGp4sqqi+IX32rGbGRcK/Hi\n6+1Es2zh7iquS1k9wYHVTiLMCQfbd3eBDS3WwYxJVtaUKb1X2RVDZZkdL9jU\nbVmeGxUuCbplmKagWnfUHbpR8g297/N0X3dLrZ8s9tRfLF0Dpoclk+PA/LXQ\nDDkIY/CNj6/jDoreijPiJB1UUR7eySBXWsgPGJjtPZjWfjOqUEeCjs5FcVus\n21E19QSNUhJoeGjEioGobMIOtUkjSl0/eRxTS5VhIscaJ3hY/mU8U8vHFXwe\nR+WUuY7Y44deWmkFNGjQ2E1m1PIcR60poMj68vTjuvRie601234ikGyKpTj7\nQa85m4ler0fj0dACMZuvTshwzgVRLAUmf7XAKPFrya/AGPyzD5Dj2gSG8GG2\nhapB\r\n=wtu5\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/test-conflicted-optional-peer-dep-has-peer_1.0.0_1611695148624_0.48635937119503536"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-01-26T21:05:48.578Z",
+    "1.0.0": "2021-01-26T21:05:48.746Z",
+    "modified": "2021-01-26T21:05:51.091Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-has-peer.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-has-peer.min.json
@@ -1,0 +1,24 @@
+{
+  "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/test-conflicted-optional-peer-dep-peer": "1"
+      },
+      "dist": {
+        "integrity": "sha512-asey7Jpi/z+ViT7qkAC5I8xsCY3TYDE6L/EFB78gd1ARClKtM670t6mudqpc9i0wzaXRP8LQ3y/AD6Wwa4SSLQ==",
+        "shasum": "74715ae753e1cce44cb82eb10fdefb42c74817d6",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-has-peer/-/test-conflicted-optional-peer-dep-has-peer-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 176,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIQtCRA9TVsSAnZWagAAooEP/i+M6Yieb2T2uws8Oh4N\n/QmLwOPPQIGpF8N04EjW3gE4HrGCrMnBsS5zX5K21xcijAfmxhCUw7VNFoVd\nDaDstxTbg+qF+C12Y8pycYJq+8dGq1OhGPr7xvHCEUJCYDWSLm+W1bkESiiK\nMZ7S1Ckr9K1ldCU8Fwz5QJlk/LqZa/GeOdI/N7dOtNXR8Wuv9nlL6PfhzlBy\nE4Zgv4JjT+bX8EneptbWaGcAF5IePQ2OMSuBWvwBRxp2/aKf6FxGLPm5tCDy\n5Xh13tCzADj+9apf9gBadWylQNunggOOW/VSumGp4sqqi+IX32rGbGRcK/Hi\n6+1Es2zh7iquS1k9wYHVTiLMCQfbd3eBDS3WwYxJVtaUKb1X2RVDZZkdL9jU\nbVmeGxUuCbplmKagWnfUHbpR8g297/N0X3dLrZ8s9tRfLF0Dpoclk+PA/LXQ\nDDkIY/CNj6/jDoreijPiJB1UUR7eySBXWsgPGJjtPZjWfjOqUEeCjs5FcVus\n21E19QSNUhJoeGjEioGobMIOtUkjSl0/eRxTS5VhIscaJ3hY/mU8U8vHFXwe\nR+WUuY7Y44deWmkFNGjQ2E1m1PIcR60poMj68vTjuvRie601234ikGyKpTj7\nQa85m4ler0fj0dACMZuvTshwzgVRLAUmf7XAKPFrya/AGPyzD5Dj2gSG8GG2\nhapB\r\n=wtu5\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-01-26T21:05:51.091Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-meta-peer-optional.json
+++ b/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-meta-peer-optional.json
@@ -1,0 +1,56 @@
+{
+  "_id": "@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional",
+  "name": "@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional",
+      "version": "1.0.0",
+      "dependencies": {
+        "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional": "1"
+      },
+      "_id": "@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.4.2",
+      "dist": {
+        "integrity": "sha512-bprq1pq7/oB6t4D+x/KwxaQWicKifsxtbqmjSmoqwF3aDj98ch9cwM0QwVS4JavoeFFg9evVFuO+8on9FSL+hA==",
+        "shasum": "d25be026b0a1998eee5bee1275b2b811c3096fe1",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/-/test-conflicted-optional-peer-dep-meta-peer-optional-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 195,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIQ3CRA9TVsSAnZWagAACxsP/ieDWcWGg1JUZoMXpfrZ\nfJz8dcWwFCCyGrDRxbGE3u2Q907yDSrwmUIbr5aaSYTEqPRUdch/X5o39FeB\nkqlrTRrEySdTmn7v9SudYiBCoBp+PL/aBSwhQw/3V1dzOD7rlJILmmzbGZ9s\neskbnSCz1zIBJmXvJOFTPd7jhPn7Vm652HtK+YI94JPQSNY+cMssCAigyMTF\nttUtMTHLGysknBiaTyE99M4D9wfSCCcfFaOMqGDTf8VqVhGbMWAI5JgXQU49\nxCT5FZ/G3Ws0kVAwAKTJpSiOqZcfRqxIKbQz7tXoA+c3IJGpsFROiAxaofMP\nN49m2GJb8gIwBuQvgt6FjQGp8TYEYJmOuHrize3dBizkq0o/6zJeMrwTt7Bk\nU3JfSmdXaERibcD1zvnSRlNpVwyWVtRqZIANt4O2tRa5hv6T2DKgywt9+Y8R\nwIq005U43aSsAryT8l35GrJHt5g/rEaAp9m1TdcPEriPuPg5qo+nqw1dfW5+\nB3kJ2EskYZo7dW3qATlAkGrkKsC5A9oR8qOZ7dJWV0IT8owNrw3K++aGShyl\nYNhczzwXMuxsUzyVgomVlTKwWwA5ebWweFvK06uJ66pQzyjaYY8zHMAoP01R\nwLjofrNzzuDaMExJc5/V+Dc/qXFA+eyv5ZkHRtkPbCLpnYu9nJ3HDZ7EfXD8\nR1pL\r\n=Doa7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/test-conflicted-optional-peer-dep-meta-peer-optional_1.0.0_1611695158810_0.1181667977309151"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-01-26T21:05:58.749Z",
+    "1.0.0": "2021-01-26T21:05:58.938Z",
+    "modified": "2021-01-26T21:06:02.358Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-meta-peer-optional.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-meta-peer-optional.min.json
@@ -1,0 +1,24 @@
+{
+  "name": "@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional",
+      "version": "1.0.0",
+      "dependencies": {
+        "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional": "1"
+      },
+      "dist": {
+        "integrity": "sha512-bprq1pq7/oB6t4D+x/KwxaQWicKifsxtbqmjSmoqwF3aDj98ch9cwM0QwVS4JavoeFFg9evVFuO+8on9FSL+hA==",
+        "shasum": "d25be026b0a1998eee5bee1275b2b811c3096fe1",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/-/test-conflicted-optional-peer-dep-meta-peer-optional-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 195,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIQ3CRA9TVsSAnZWagAACxsP/ieDWcWGg1JUZoMXpfrZ\nfJz8dcWwFCCyGrDRxbGE3u2Q907yDSrwmUIbr5aaSYTEqPRUdch/X5o39FeB\nkqlrTRrEySdTmn7v9SudYiBCoBp+PL/aBSwhQw/3V1dzOD7rlJILmmzbGZ9s\neskbnSCz1zIBJmXvJOFTPd7jhPn7Vm652HtK+YI94JPQSNY+cMssCAigyMTF\nttUtMTHLGysknBiaTyE99M4D9wfSCCcfFaOMqGDTf8VqVhGbMWAI5JgXQU49\nxCT5FZ/G3Ws0kVAwAKTJpSiOqZcfRqxIKbQz7tXoA+c3IJGpsFROiAxaofMP\nN49m2GJb8gIwBuQvgt6FjQGp8TYEYJmOuHrize3dBizkq0o/6zJeMrwTt7Bk\nU3JfSmdXaERibcD1zvnSRlNpVwyWVtRqZIANt4O2tRa5hv6T2DKgywt9+Y8R\nwIq005U43aSsAryT8l35GrJHt5g/rEaAp9m1TdcPEriPuPg5qo+nqw1dfW5+\nB3kJ2EskYZo7dW3qATlAkGrkKsC5A9oR8qOZ7dJWV0IT8owNrw3K++aGShyl\nYNhczzwXMuxsUzyVgomVlTKwWwA5ebWweFvK06uJ66pQzyjaYY8zHMAoP01R\nwLjofrNzzuDaMExJc5/V+Dc/qXFA+eyv5ZkHRtkPbCLpnYu9nJ3HDZ7EfXD8\nR1pL\r\n=Doa7\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-01-26T21:06:02.358Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-meta-peer.json
+++ b/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-meta-peer.json
@@ -1,0 +1,56 @@
+{
+  "_id": "@isaacs/test-conflicted-optional-peer-dep-meta-peer",
+  "name": "@isaacs/test-conflicted-optional-peer-dep-meta-peer",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/test-conflicted-optional-peer-dep-meta-peer",
+      "version": "1.0.0",
+      "dependencies": {
+        "@isaacs/test-conflicted-optional-peer-dep-has-peer": "1"
+      },
+      "_id": "@isaacs/test-conflicted-optional-peer-dep-meta-peer@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.4.2",
+      "dist": {
+        "integrity": "sha512-KGNaUC0BaGnf9eIPQykmIQ5PH+6lX3UIXH3Julk7UroWpgRgdl9OyK/VkGY8O4D//iZzsqatFUWfHhg7+SJ+UA==",
+        "shasum": "69cc421e999ec70922c60c28e2d6d438c6d4ea9a",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-meta-peer/-/test-conflicted-optional-peer-dep-meta-peer-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 177,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIQzCRA9TVsSAnZWagAAVTEP/AsJgON5c3MOWQGD8eGu\nRRX69ga3j4J6TTc1SGz5brWuvXt6vGiTEAYykZ2EqC9ygSwKRNPYClXfst+P\naDnFXqWeVYbqOI7MoikyL9pTMH2arLyXbutO7tZy/1pOn4Szns0Sx/azJ7hR\nMQtPWFGLauuD7aor+R6bkNuYRfmPAFgHLQ3YtTzxZmsEBU6dz4HKMBtX5Obe\nacR9c0mQ6yUIn2VFh3sIPPIxcT688j5kRG1Mhujd0wie3L7vtB3u/ag9eWqv\nnXCZrGj6RkGmtxYm3lkuHs7l1dw/qhh4/yVy2g9va48WezaPUXWUFRWEAY6l\nkcLeKnoz10RSI+tXtY9YJc3hRzhKvxkPW2Xxt+BT0FzUsWgGbBTw330JIjmX\n0cYaatPq5FHcJWZSCmugqffKT7+9edmyO2YRbCtyOzlrLQe5RMFoNb7cELb+\nRXPal3hNeqFuaLwgCeCtJhy8rRWKNFlujZm5cxBAOwkavl6G5Pfjf6Rfls+n\nOG05VCW7oAopMWj8RFQHYOiwNfXF4KgX3Xrk2E/IS+pwoRkpbTvJHQJvgi3X\nVE43HEFb65FgmlFikCr7OiTss4BUf2CMxBDdvUtW1vXIjwo+GdVxpxnw6nKs\nMWe++yTIUV3p4FqNRkF/pm76bS66hKL01+KCCpv8/rbsb97Vo1VLNSAhTsWM\nqjMB\r\n=eDZu\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/test-conflicted-optional-peer-dep-meta-peer_1.0.0_1611695155391_0.5730118067448928"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-01-26T21:05:55.357Z",
+    "1.0.0": "2021-01-26T21:05:55.496Z",
+    "modified": "2021-01-26T21:05:57.846Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-meta-peer.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-meta-peer.min.json
@@ -1,0 +1,24 @@
+{
+  "name": "@isaacs/test-conflicted-optional-peer-dep-meta-peer",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/test-conflicted-optional-peer-dep-meta-peer",
+      "version": "1.0.0",
+      "dependencies": {
+        "@isaacs/test-conflicted-optional-peer-dep-has-peer": "1"
+      },
+      "dist": {
+        "integrity": "sha512-KGNaUC0BaGnf9eIPQykmIQ5PH+6lX3UIXH3Julk7UroWpgRgdl9OyK/VkGY8O4D//iZzsqatFUWfHhg7+SJ+UA==",
+        "shasum": "69cc421e999ec70922c60c28e2d6d438c6d4ea9a",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-meta-peer/-/test-conflicted-optional-peer-dep-meta-peer-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 177,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIQzCRA9TVsSAnZWagAAVTEP/AsJgON5c3MOWQGD8eGu\nRRX69ga3j4J6TTc1SGz5brWuvXt6vGiTEAYykZ2EqC9ygSwKRNPYClXfst+P\naDnFXqWeVYbqOI7MoikyL9pTMH2arLyXbutO7tZy/1pOn4Szns0Sx/azJ7hR\nMQtPWFGLauuD7aor+R6bkNuYRfmPAFgHLQ3YtTzxZmsEBU6dz4HKMBtX5Obe\nacR9c0mQ6yUIn2VFh3sIPPIxcT688j5kRG1Mhujd0wie3L7vtB3u/ag9eWqv\nnXCZrGj6RkGmtxYm3lkuHs7l1dw/qhh4/yVy2g9va48WezaPUXWUFRWEAY6l\nkcLeKnoz10RSI+tXtY9YJc3hRzhKvxkPW2Xxt+BT0FzUsWgGbBTw330JIjmX\n0cYaatPq5FHcJWZSCmugqffKT7+9edmyO2YRbCtyOzlrLQe5RMFoNb7cELb+\nRXPal3hNeqFuaLwgCeCtJhy8rRWKNFlujZm5cxBAOwkavl6G5Pfjf6Rfls+n\nOG05VCW7oAopMWj8RFQHYOiwNfXF4KgX3Xrk2E/IS+pwoRkpbTvJHQJvgi3X\nVE43HEFb65FgmlFikCr7OiTss4BUf2CMxBDdvUtW1vXIjwo+GdVxpxnw6nKs\nMWe++yTIUV3p4FqNRkF/pm76bS66hKL01+KCCpv8/rbsb97Vo1VLNSAhTsWM\nqjMB\r\n=eDZu\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-01-26T21:05:57.846Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-peer.json
+++ b/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-peer.json
@@ -1,0 +1,86 @@
+{
+  "_id": "@isaacs/test-conflicted-optional-peer-dep-peer",
+  "_rev": "1-01db157b943e2d40a721dbaf24d35cd2",
+  "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+      "version": "1.0.0",
+      "_id": "@isaacs/test-conflicted-optional-peer-dep-peer@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.4.2",
+      "dist": {
+        "integrity": "sha512-mKz78cfkkQMunvHlumRqYz7YDv3aeswwX427NsL7+u0+FJHwhBisfaepvRce0w52mf40+p0eekB/ukShpVMDPw==",
+        "shasum": "806e667985dd2b4c76d2b2f151188e8a327b7296",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-peer/-/test-conflicted-optional-peer-dep-peer-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 85,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIQ7CRA9TVsSAnZWagAAZWcP/R8xBdty9UwE7+QVevnY\njNIUr8UFlhwcyn0QlQic8wwkkgrkChuivwjJHkZESEJBIPqoQNCS2PfLT8y5\nZJGU7k9PsCYxu1RAurCvYu6Nxww4qZMtOvz50mKBoVU8MsvcfK5P4l2F4Pup\n9lUD6g6wQ3LiO3Cby5KHc0lPFGBmA+aBBO9zPK88PpDF+sGHBsEAUO7HqxyN\nAiL1nl0S0MIqFYHUmTr4qGYeQ/IPH0cG1j4rdtiz5m/foSWyUgFJf36mRnw/\nXvBgiPGinpCPfvY+o7tlkO2xnUU0R0kc+xV5wEdx/tsWT3XOeTmb2fAjnlPz\nUDUcQPzdG1l79x9MZTigFLOhJ1lsJqh0EIpZMj52ltRu+dMo+D8ljMNS8yZ2\nK255SsIDHtNDa1orHV8fpeM5mz8YKuoDV1LtZqNxeAAohCJla+JkHksszdCc\npV0oIZ9P3ENPtsfawXQvPUvpSC4j1qy25JWRbZeDiVYyROb0kuOjNpaC6Sii\neEsJ+Mju3v7GxvRJMff0hVjD4Z/7Y6w0UscCKNGVMe442MRSqtNuj6JAncqU\niLu50HxFnjDUOS3rlGIRKl7T0IwYL3o1lf99aW+hi/4sMJfnhWK8FID9HnAy\ngFqpTPEyz+pU2Sk9PQ/ufkYt+ZOt06e0EuVcHul4xBKcIikhWSU3+uT/jrtb\n1eqh\r\n=Pz5P\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/test-conflicted-optional-peer-dep-peer_1.0.0_1611695163377_0.48763232062110284"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+      "version": "2.0.0",
+      "_id": "@isaacs/test-conflicted-optional-peer-dep-peer@2.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.4.2",
+      "dist": {
+        "integrity": "sha512-BG4PCKGtDpG/pOkdcxhKdMPY9hgvgCmjB2T8SL2aER/OESuYPK6Au15lIIQCiywAvtDx9CfcAunIcY9qgHtUIw==",
+        "shasum": "7c7178509de659eef90632ea275694298990c2da",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-peer/-/test-conflicted-optional-peer-dep-peer-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 85,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIQ/CRA9TVsSAnZWagAAdFEP/REyL19dCtYu0olrNQwe\n6xVM2GCalJRyY2IXP4vfbQUqxg9/+yHLB72khk9dJ9YDmk8HonT6PMoBNV18\n45pONRaul0V0wNL/tc0NSrFTzqEHRbg18KowVGvgBTu3Ej5HTw343ipuAphb\nB3o7sAS8Zyaa3HYfNJJvwf+t7SsfavkaqX5lfRb5w8RYlOMwBR/QanDuHkM8\nY2sAvhbi9J79nq/NhJ0mfUa5Eso6+AZ7JSm7v5YqnHqcRFtKHfxuHVv06pfZ\nXU9B8bCvZ1qjkERSCe/LXZHfWn2Bu0MqkqCDgwAoi+AcyF1aX2smd/cmVy92\nw8cP/K5DHZlLix7ya9Y2eKPUUPNBnJsIQ+EqaSZoutR9ezvxqo4To9Ig3ogb\n5ZJCGQthP5RZ2fbRcNottToV1qbwKARNP+51WDsb9wfX2TMboGqwqEPgUjWC\nAT1Co6qDdLWTLBHHuMK8O8/3T+KVRm7V6VACE/vtdeFHSAazAZYfdmZSOoMo\nScyEoTupjI4EX3V2XhE4e5Xg7P37qptA4YM25jk7A7/RwBAZpby8aybM1G2G\nGztVlaDWw34Z9OC23Yvq3XpqXbmJ67kvZ4CHRpKWJWmiDAyNMHcyLbXTzgs5\nAQL+FLqaeXZ8P4uYhtfENq6AsV4NxXL3ebqg+9OvwRKUY1cJMb1p6MICCdn8\nkuyz\r\n=/nMf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/test-conflicted-optional-peer-dep-peer_2.0.0_1611695166708_0.5797929621840854"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-01-26T21:06:03.320Z",
+    "1.0.0": "2021-01-26T21:06:03.461Z",
+    "modified": "2021-01-26T21:06:09.037Z",
+    "2.0.0": "2021-01-26T21:06:06.840Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-peer.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/test-conflicted-optional-peer-dep-peer.min.json
@@ -1,0 +1,33 @@
+{
+  "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+      "version": "1.0.0",
+      "dist": {
+        "integrity": "sha512-mKz78cfkkQMunvHlumRqYz7YDv3aeswwX427NsL7+u0+FJHwhBisfaepvRce0w52mf40+p0eekB/ukShpVMDPw==",
+        "shasum": "806e667985dd2b4c76d2b2f151188e8a327b7296",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-peer/-/test-conflicted-optional-peer-dep-peer-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 85,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIQ7CRA9TVsSAnZWagAAZWcP/R8xBdty9UwE7+QVevnY\njNIUr8UFlhwcyn0QlQic8wwkkgrkChuivwjJHkZESEJBIPqoQNCS2PfLT8y5\nZJGU7k9PsCYxu1RAurCvYu6Nxww4qZMtOvz50mKBoVU8MsvcfK5P4l2F4Pup\n9lUD6g6wQ3LiO3Cby5KHc0lPFGBmA+aBBO9zPK88PpDF+sGHBsEAUO7HqxyN\nAiL1nl0S0MIqFYHUmTr4qGYeQ/IPH0cG1j4rdtiz5m/foSWyUgFJf36mRnw/\nXvBgiPGinpCPfvY+o7tlkO2xnUU0R0kc+xV5wEdx/tsWT3XOeTmb2fAjnlPz\nUDUcQPzdG1l79x9MZTigFLOhJ1lsJqh0EIpZMj52ltRu+dMo+D8ljMNS8yZ2\nK255SsIDHtNDa1orHV8fpeM5mz8YKuoDV1LtZqNxeAAohCJla+JkHksszdCc\npV0oIZ9P3ENPtsfawXQvPUvpSC4j1qy25JWRbZeDiVYyROb0kuOjNpaC6Sii\neEsJ+Mju3v7GxvRJMff0hVjD4Z/7Y6w0UscCKNGVMe442MRSqtNuj6JAncqU\niLu50HxFnjDUOS3rlGIRKl7T0IwYL3o1lf99aW+hi/4sMJfnhWK8FID9HnAy\ngFqpTPEyz+pU2Sk9PQ/ufkYt+ZOt06e0EuVcHul4xBKcIikhWSU3+uT/jrtb\n1eqh\r\n=Pz5P\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+      "version": "2.0.0",
+      "dist": {
+        "integrity": "sha512-BG4PCKGtDpG/pOkdcxhKdMPY9hgvgCmjB2T8SL2aER/OESuYPK6Au15lIIQCiywAvtDx9CfcAunIcY9qgHtUIw==",
+        "shasum": "7c7178509de659eef90632ea275694298990c2da",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-peer/-/test-conflicted-optional-peer-dep-peer-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 85,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIQ/CRA9TVsSAnZWagAAdFEP/REyL19dCtYu0olrNQwe\n6xVM2GCalJRyY2IXP4vfbQUqxg9/+yHLB72khk9dJ9YDmk8HonT6PMoBNV18\n45pONRaul0V0wNL/tc0NSrFTzqEHRbg18KowVGvgBTu3Ej5HTw343ipuAphb\nB3o7sAS8Zyaa3HYfNJJvwf+t7SsfavkaqX5lfRb5w8RYlOMwBR/QanDuHkM8\nY2sAvhbi9J79nq/NhJ0mfUa5Eso6+AZ7JSm7v5YqnHqcRFtKHfxuHVv06pfZ\nXU9B8bCvZ1qjkERSCe/LXZHfWn2Bu0MqkqCDgwAoi+AcyF1aX2smd/cmVy92\nw8cP/K5DHZlLix7ya9Y2eKPUUPNBnJsIQ+EqaSZoutR9ezvxqo4To9Ig3ogb\n5ZJCGQthP5RZ2fbRcNottToV1qbwKARNP+51WDsb9wfX2TMboGqwqEPgUjWC\nAT1Co6qDdLWTLBHHuMK8O8/3T+KVRm7V6VACE/vtdeFHSAazAZYfdmZSOoMo\nScyEoTupjI4EX3V2XhE4e5Xg7P37qptA4YM25jk7A7/RwBAZpby8aybM1G2G\nGztVlaDWw34Z9OC23Yvq3XpqXbmJ67kvZ4CHRpKWJWmiDAyNMHcyLbXTzgs5\nAQL+FLqaeXZ8P4uYhtfENq6AsV4NxXL3ebqg+9OvwRKUY1cJMb1p6MICCdn8\nkuyz\r\n=/nMf\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-01-26T21:06:09.037Z"
+}

--- a/test/fixtures/test-conflicted-optional-peer-dep/has-peer-optional/package.json
+++ b/test/fixtures/test-conflicted-optional-peer-dep/has-peer-optional/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+  "version": "1.0.0",
+  "peerDependenciesMeta": {
+    "@isaacs/test-conflicted-optional-peer-dep-peer": {
+      "optional": true
+    }
+  },
+  "peerDependencies": {
+    "@isaacs/test-conflicted-optional-peer-dep-peer": "2"
+  }
+}

--- a/test/fixtures/test-conflicted-optional-peer-dep/has-peer/package.json
+++ b/test/fixtures/test-conflicted-optional-peer-dep/has-peer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/test-conflicted-optional-peer-dep-peer": "1"
+  }
+}

--- a/test/fixtures/test-conflicted-optional-peer-dep/meta-peer-optional/package.json
+++ b/test/fixtures/test-conflicted-optional-peer-dep/meta-peer-optional/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional",
+  "version": "1.0.0",
+  "dependencies": {
+    "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional": "1"
+  }
+}

--- a/test/fixtures/test-conflicted-optional-peer-dep/meta-peer/package.json
+++ b/test/fixtures/test-conflicted-optional-peer-dep/meta-peer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/test-conflicted-optional-peer-dep-meta-peer",
+  "version": "1.0.0",
+  "dependencies": {
+    "@isaacs/test-conflicted-optional-peer-dep-has-peer": "1"
+  }
+}

--- a/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/package.json
+++ b/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@isaacs/test-conflicted-optional-peer-dep",
+  "version": "1.0.0",
+  "description": "a peerOptional dep that must be nested",
+  "dependencies": {
+    "@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional": "1",
+    "@isaacs/test-conflicted-optional-peer-dep-meta-peer": "1"
+  }
+}

--- a/test/fixtures/test-conflicted-optional-peer-dep/omit-peer-optional/package.json
+++ b/test/fixtures/test-conflicted-optional-peer-dep/omit-peer-optional/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@isaacs/test-conflicted-optional-peer-dep",
+  "version": "1.0.0",
+  "description": "a peerOptional dep that should not be installed anyway",
+  "dependencies": {
+    "@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional": "1"
+  }
+}

--- a/test/fixtures/test-conflicted-optional-peer-dep/peer/1/package.json
+++ b/test/fixtures/test-conflicted-optional-peer-dep/peer/1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+  "version": "1.0.0"
+}

--- a/test/fixtures/test-conflicted-optional-peer-dep/peer/2/package.json
+++ b/test/fixtures/test-conflicted-optional-peer-dep/peer/2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+  "version": "2.0.0"
+}


### PR DESCRIPTION
Detect conflicts among nested peerOptional deps

We do not normally install optional peerDependencies, so we were
skipping over them when building up the peer set that is evaluated for
placement within the tree.

However, if an optional peer dep _conflicts_ with something in the tree,
then it will be seen as an invalid edge, and attempt resolution.

This results in a problem in the following scenario:

```
root -> (a, x)
a -> b
b -> PEER(k@1)
x -> y
y -> PEEROPTIONAL(k@2)
```

We place a, b, k@1, and x in the root node_modules without incident.

Then, we evaluate y, and did not add `k@2` to its peerSet, because it
is a peerOptional.  Since it does not have any apparent peers to
conflict, it is _also_ placed at the root level.

Then, we look to the invalid edges coming out of `y`, and find `k@2` is
invalid, because it resolves to `k@1`, and there is no place to put it,
because `y` is already in the root level, where the conflict exists, and
we ERESOLVE.

The solution is to include peerOptional edges when creating the peerSet,
but still omit missing peerOptional deps when looking for invalid edges
needing further resolution.

Fix: https://github.com/npm/cli/issues/2265

(based on #208)