### PR TITLE
fix(install): make sure to reload explicitRequests

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -1148,6 +1148,7 @@ This is a one-time fix-up, please be patient...
   [_placeDep] (dep, node, edge, peerEntryEdge = null, peerPath = []) {
     if (edge.to &&
         !edge.error &&
+        !this[_explicitRequests].has(edge.name) &&
         !this[_updateNames].includes(edge.name) &&
         !this[_isVulnerable](edge.to))
       return []

--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -416,7 +416,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
       await this[_add](options)
 
     // triggers a refresh of all edgesOut
-    if (options.add && options.add.length || options.rm && options.rm.length)
+    if (options.add && options.add.length || options.rm && options.rm.length || this[_global])
       tree.package = tree.package
     process.emit('timeEnd', 'idealTree:userRequests')
   }

--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -233,7 +233,7 @@ module.exports = cls => class Reifier extends cls {
     const actualOpt = this[_global] ? {
       ignoreMissing: true,
       global: true,
-      filter: (node, kid) => !node.isRoot && node !== node.root.target
+      filter: (node, kid) => this[_explicitRequests].size === 0 || !node.isProjectRoot
         ? true
         : (node.edgesOut.has(kid) || this[_explicitRequests].has(kid)),
     } : { ignoreMissing: true }

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -2324,3 +2324,22 @@ t.test('do not fail if root peerDep looser than meta peerDep', async t => {
   const path = resolve(fixtures, 'test-peer-looser-than-dev')
   t.matchSnapshot(await printIdeal(path))
 })
+
+t.test('adding existing dep with updateable version in package.json', async t => {
+  const path = t.testdir({
+    node_modules: {
+      lodash: {
+        'package.json': JSON.stringify({
+          version: '3.9.1'
+        })
+      }
+    },
+    'package.json': JSON.stringify({
+      devDependencies: {
+        lodash: '^3.9.1'
+      },
+    })
+  })
+
+  t.matchSnapshot(await printIdeal(path, { add: ['lodash'] }))
+})


### PR DESCRIPTION
When we are placing our deps, if our edge dep was explicitly requested,
we want to re-place it instead of leaving whatever was there before.

This will mean doing something like `npm install foo` will install the
latest version of `foo` that your tree currently allows, instead of
doing nothing if any version already existed


## References
Closes https://github.com/npm/cli/issues/2243