### PR TITLE
More 'root is a link' cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ scripts/benchmark/*/
 /test/fixtures/selflink/node_modules/foo/node_modules/selflink
 /test/fixtures/symlinked-node-modules/example/node_modules
 /test/fixtures/symlinked-node-modules/linked-node-modules/bar
+/test/fixtures/testing-bundledeps-link
 /test/fixtures/testing-peer-deps-link
 /test/fixtures/workspace/node_modules/a
 /test/fixtures/workspace/node_modules/b

--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -314,10 +314,11 @@ module.exports = cls => class IdealTreeBuilder extends cls {
       .then(async root => {
         if (!this[_updateAll] && !this[_global] && !root.meta.loadedFromDisk) {
           await new this.constructor(this.options).loadActual({ root })
+          const tree = root.target || root
           // even though we didn't load it from a package-lock.json FILE,
           // we still loaded it "from disk", meaning we have to reset
           // dep flags before assuming that any mutations were reflected.
-          if (root.children.size)
+          if (tree.children.size)
             root.meta.loadedFromDisk = true
         }
         return root
@@ -632,7 +633,7 @@ This is a one-time fix-up, please be patient...
     this.addTracker('idealTree:inflate')
     const queue = []
     for (const node of inventory.values()) {
-      if (node.isRoot)
+      if (node.isProjectRoot)
         continue
 
       queue.push(async () => {
@@ -878,7 +879,7 @@ This is a one-time fix-up, please be patient...
         // instead of nesting forever, when the loop occurs, create
         // a symbolic link to the earlier instance
         for (let p = edge.from.resolveParent; p; p = p.resolveParent) {
-          if (p.matches(node) && !p.isRoot)
+          if (p.matches(node) && !p.isTop)
             return new Link({ parent: realParent, target: p })
         }
         // keep track of the thing that caused this node to be included.
@@ -913,7 +914,7 @@ This is a one-time fix-up, please be patient...
 
     // also skip over any nodes in the tree that failed to load, since those
     // will crash the install later on anyway.
-    const bd = node.isRoot ? null : node.package.bundleDependencies
+    const bd = node.isProjectRoot ? null : node.package.bundleDependencies
     const bundled = new Set(bd || [])
 
     return [...node.edgesOut.values()]
@@ -950,7 +951,7 @@ This is a one-time fix-up, please be patient...
           return true
 
         // If the user has explicitly asked to install this package, it's a problem.
-        if (node.isRoot && this[_explicitRequests].has(edge.name))
+        if (node.isProjectRoot && this[_explicitRequests].has(edge.name))
           return true
 
         // No problems!
@@ -1043,8 +1044,8 @@ This is a one-time fix-up, please be patient...
         continue
 
       const parentEdge = node.parent.edgesOut.get(edge.name)
-      const {isRoot, isWorkspace} = node.parent.sourceReference
-      const isMine = isRoot || isWorkspace
+      const {isProjectRoot, isWorkspace} = node.parent.sourceReference
+      const isMine = isProjectRoot || isWorkspace
       if (!edge.to) {
         if (!parentEdge) {
           // easy, just put the thing there
@@ -1129,7 +1130,7 @@ This is a one-time fix-up, please be patient...
     // top nodes should still get peer deps from their fsParent if possible,
     // and only install locally if there's no other option, eg for a link
     // outside of the project root, or for a conflicted dep.
-    const start = edge.peer && !node.isRoot ? node.resolveParent || node
+    const start = edge.peer && !node.isProjectRoot ? node.resolveParent || node
       : node
 
     let target
@@ -1379,8 +1380,8 @@ This is a one-time fix-up, please be patient...
     // depends on a, and it has a conflict, it's our problem.  So, the root
     // (or whatever is bringing in a) becomes the "effective source" for
     // the purposes of this calculation.
-    const { isRoot, isWorkspace } = isSource ? target : source || {}
-    const isMine = isRoot || isWorkspace
+    const { isProjectRoot, isWorkspace } = isSource ? target : source || {}
+    const isMine = isProjectRoot || isWorkspace
 
     // Useful testing thingie right here.
     // peerEntryEdge should *always* be a non-peer dependency, or a peer

--- a/lib/node.js
+++ b/lib/node.js
@@ -464,6 +464,10 @@ class Node {
     return this === this.root
   }
 
+  get isProjectRoot () {
+    return this === this.root || this === this.root.target
+  }
+
   set root (root) {
     // setting to null means this is the new root
     // should only ever be one step

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -354,6 +354,19 @@ t.test('bundle deps example 2', t => {
     }), 'remove bundled dependency a'))
 })
 
+t.test('bundle deps example 2, link', t => {
+  // bundled deps at the root level are NOT ignored when building ideal trees
+  const path = resolve(fixtures, 'testing-bundledeps-link')
+  return t.resolveMatchSnapshot(printIdeal(path), 'bundle deps testing')
+    .then(() => t.resolveMatchSnapshot(printIdeal(path, {
+      saveBundle: true,
+      add: ['@isaacs/testing-bundledeps-c'],
+    }), 'add new bundled dep c'))
+    .then(() => t.resolveMatchSnapshot(printIdeal(path, {
+      rm: ['@isaacs/testing-bundledeps-a'],
+    }), 'remove bundled dependency a'))
+})
+
 t.test('unresolvable peer deps', t => {
   const path = resolve(fixtures, 'testing-peer-deps-unresolvable')
 

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -133,6 +133,8 @@ const symlinks = {
   'workspaces-add-new-dep/node_modules/a': '../a',
 
   'workspaces-non-simplistic/node_modules/pkg-a': '../a',
+
+  'testing-bundledeps-link': './testing-bundledeps-2',
 }
 
 const cleanup = () => Object.keys(symlinks).forEach(s => {

--- a/test/node.js
+++ b/test/node.js
@@ -2135,3 +2135,15 @@ t.test('printable Node', t => {
   })
   t.end()
 })
+
+t.test('isProjectRoot shows if the node is the root link target', async t => {
+  const link = new Link({
+    path: '/link',
+    realpath: '/actual',
+  })
+  const n = new Node({ path: '/actual', root: link })
+  t.equal(n.isProjectRoot, true)
+  t.equal(link.isProjectRoot, true)
+  t.equal(link.isRoot, true)
+  t.equal(n.isRoot, false)
+})


### PR DESCRIPTION
There were a few places in buildIdealTree where we do different behavior
if a node is the root.  However, it should really be if the node is
either the root, *or* the node that a Link root targets.

Add Node.isProjectRoot to mean 'the root node, or the target of a root
link node'.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
