### PR TITLE
Prevent ERESOLVEs caused by loose root dep specs

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -863,7 +863,7 @@ This is a one-time fix-up, please be patient...
 
   // loads a node from an edge, and then loads its peer deps (and their
   // peer deps, on down the line) into a virtual root parent.
-  [_nodeFromEdge] (edge, parent_) {
+  async [_nodeFromEdge] (edge, parent_, secondEdge = null) {
     // create a virtual root node with the same deps as the node that
     // is requesting this one, so that we can get all the peer deps in
     // a context where they're likely to be resolvable.
@@ -871,22 +871,43 @@ This is a one-time fix-up, please be patient...
     const realParent = edge.peer ? edge.from.resolveParent : edge.from
 
     const spec = npa.resolve(edge.name, edge.spec, edge.from.path)
-    return this[_nodeFromSpec](edge.name, spec, parent, edge)
-      .then(node => {
-        // handle otherwise unresolvable dependency nesting loops by
-        // creating a symbolic link
-        // a1 -> b1 -> a2 -> b2 -> a1 -> ...
-        // instead of nesting forever, when the loop occurs, create
-        // a symbolic link to the earlier instance
-        for (let p = edge.from.resolveParent; p; p = p.resolveParent) {
-          if (p.matches(node) && !p.isTop)
-            return new Link({ parent: realParent, target: p })
-        }
-        // keep track of the thing that caused this node to be included.
-        const src = parent.sourceReference
-        this[_peerSetSource].set(node, src)
-        return this[_loadPeerSet](node)
-      })
+    const first = await this[_nodeFromSpec](edge.name, spec, parent, edge)
+
+    // we might have a case where the parent has a peer dependency on
+    // `foo@*` which resolves to v2, but another dep in the set has a
+    // peerDependency on `foo@1`.  In that case, if we force it to be v2,
+    // we're unnecessarily triggering an ERESOLVE.
+    // If we have a second edge to worry about, and it's not satisfied
+    // by the first node, try a second and see if that satisfies the
+    // original edge here.
+    const spec2 = secondEdge && npa.resolve(
+      edge.name,
+      secondEdge.spec,
+      secondEdge.from.path
+    )
+    const second = secondEdge && !secondEdge.valid
+      ? await this[_nodeFromSpec](edge.name, spec2, parent, secondEdge)
+      : null
+
+    // pick the second one if they're both happy with that, otherwise first
+    const node = second && edge.valid ? second : first
+    // ensure the one we want is the one that's placed
+    node.parent = parent
+
+    // handle otherwise unresolvable dependency nesting loops by
+    // creating a symbolic link
+    // a1 -> b1 -> a2 -> b2 -> a1 -> ...
+    // instead of nesting forever, when the loop occurs, create
+    // a symbolic link to the earlier instance
+    for (let p = edge.from.resolveParent; p; p = p.resolveParent) {
+      if (p.matches(node) && !p.isTop)
+        return new Link({ parent: realParent, target: p })
+    }
+
+    // keep track of the thing that caused this node to be included.
+    const src = parent.sourceReference
+    this[_peerSetSource].set(node, src)
+    return this[_loadPeerSet](node)
   }
 
   [_virtualRoot] (node, reuse = false) {
@@ -1052,12 +1073,15 @@ This is a one-time fix-up, please be patient...
           await this[_nodeFromEdge](edge, node.parent)
           continue
         } else {
-          // try to put the parent's preference, and make sure that satisfies.
-          // if so, we're good.
-          // if it does not, then we have a problem in strict mode, no problem
+          // if the parent's edge is very broad like >=1, and the edge in
+          // question is something like 1.x, then we want to get a 1.x, not
+          // a 2.x.  pass along the child edge as an advisory guideline.
+          // if the parent edge doesn't satisfy the child edge, and the
+          // child edge doesn't satisfy the parent edge, then we have
+          // a conflict.  this is always a problem in strict mode, never
           // in force mode, and a problem in non-strict mode if this isn't
-          // on behalf of the root node.  In all such cases, we warn at least.
-          await this[_nodeFromEdge](parentEdge, node.parent)
+          // on behalf of our project.  in all such cases, we warn at least.
+          await this[_nodeFromEdge](parentEdge, node.parent, edge)
 
           // hooray! that worked!
           if (edge.valid)
@@ -1066,8 +1090,9 @@ This is a one-time fix-up, please be patient...
           // allow it
           if (this[_force] || !isMine && !this[_strictPeerDeps])
             continue
-          else
-            this[_failPeerConflict](edge)
+
+          // problem
+          this[_failPeerConflict](edge)
         }
       }
 

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -2319,3 +2319,8 @@ t.test('detect conflicts in transitive peerOptional deps', t => {
     t.equal(peers.size, 0, 'omit peerOptional, not needed')
   })
 })
+
+t.test('do not fail if root peerDep looser than meta peerDep', async t => {
+  const path = resolve(fixtures, 'test-peer-looser-than-dev')
+  t.matchSnapshot(await printIdeal(path))
+})

--- a/test/fixtures/registry-mocks/content/isaacs/test-peer-looser-than-dev-a-peer-dep.json
+++ b/test/fixtures/registry-mocks/content/isaacs/test-peer-looser-than-dev-a-peer-dep.json
@@ -1,0 +1,86 @@
+{
+  "_id": "@isaacs/test-peer-looser-than-dev-a-peer-dep",
+  "_rev": "1-f8c9d96c9054e8f002f0a31084cc24c3",
+  "name": "@isaacs/test-peer-looser-than-dev-a-peer-dep",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/test-peer-looser-than-dev-a-peer-dep",
+      "version": "1.0.0",
+      "_id": "@isaacs/test-peer-looser-than-dev-a-peer-dep@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.4.2",
+      "dist": {
+        "integrity": "sha512-yNZerk7tDLQP+CxtyOhcomqTF0DkP/RLHcSxFsM0TleLL4udeLE55LFy9f1ZdpZO0OUdlVkm0FTC2eVghBWEYA==",
+        "shasum": "5784751026ee9f7be53ebc977abffe23841bc658",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-peer-looser-than-dev-a-peer-dep/-/test-peer-looser-than-dev-a-peer-dep-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 83,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIBxCRA9TVsSAnZWagAAoSQP/3LiViTjfjYzMUX8hHI6\ne31b8WHplmgOR3rAIKNCHwUjNOgXXYMErhvczrKz7Od9JsLLdmz5p2gk1BOK\nzgSbdQgaKZQgRGAA20ePqc09xgzE2tls7EojLLyZ6PRLNZ9W+CL2g1z/4kSf\ncseIvymEi1B9FmjF505BDuF6GXSUE6+teUelxWvdJa+WuiW6F4ifs7AcIVOy\ndKCzNkaNWjEJha2nRt710yrssISVcRlN+OsA3xofZrV7eCkxunlURMpHFfYD\nZeSjrcjfqaomncIq3ZhM61PuxJQpbDvnRk6YS5x/tnUfgpXz5c9J4qvQuqTO\n1u+KDHjhUQB9/O1VUNyn+GvLS0i2A3d9xu/0gV6S5c1gJlILKuelov8+0q7Z\ndWHXJdssKGGpZDhIb0wB2kuMOcT2KN51vB9Sl1zxjndN5Ky7Ok1QrHevLhCy\nb+ggCkJNNQMG0sPdaFFPTGBl5akfHiiFgFVMZJDvw+CE+DH8bd213TIfTMMl\nvD9Ui7ebj5GPX62lhTf62/3FJSVFU7LAlCnFKRAPbuNdw/yoMe3yph5YYfvX\nTCnxkwarkliZfFjj23tlbEVlVQdwHfEv5TKfSxpuj8dl4pBsnE7r1M/TkpxU\nlLrzT6yiXDfOr5cCSTqD9l5TvVnWNrOs8Kbw8N/tXiTKY9l25W+zL6BC+BLz\nq1wJ\r\n=JyEm\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/test-peer-looser-than-dev-a-peer-dep_1.0.0_1611694192993_0.9499561253842561"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@isaacs/test-peer-looser-than-dev-a-peer-dep",
+      "version": "2.0.0",
+      "_id": "@isaacs/test-peer-looser-than-dev-a-peer-dep@2.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.4.2",
+      "dist": {
+        "integrity": "sha512-I4+mZBpY2S9ALgxRPLWNabc0YCtFByYAN8r8h7GuFgXjBmU4Y83vSi9KgppPgkcGSA2qXiuJAi/rQixS5Sobqw==",
+        "shasum": "d1c21fd6a55a7a2feef91759910456730ddf229e",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-peer-looser-than-dev-a-peer-dep/-/test-peer-looser-than-dev-a-peer-dep-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 83,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIB1CRA9TVsSAnZWagAANA4QAJqTn2AfLT3xTLmfuShs\nhHq3U1Odjc+V8ZgCkgJTMyU60IOA1sHuP3gAWdgV0kzbIGDk+LwL7yY1RtmH\n6HucLr6tKVnv7zZA01skNFQdHHcYgyOURy6e4CLIj49rcnHHkGGoczrzlgu9\ndVKFbTxkIVkl7rN4fQ31cRRQj9wsZ8cZTkoe9vGz5D/JJOzR6e29CFJHv9U7\niMc/30Qh6CFjU935B+X5I4yVvvdzgeqTb8JvHNP4ZetyYyLX+8Atw1VhqHtn\n13CnVHiNRbTVuPfvIR5kRFFpRohiZgreQP4B7GeClFVomeXp8QMZmtf594hr\nEoD/BTJJyWZpyPGh0NzEiX3HQ7wfTpXSxfjPP9cMwnbu8KQW3kL98rUD0oov\n2+Nmr1O3+4fyXlpM1dAWd6FY0M5jRsnx+hvrGwWcRu5UNUFYskCT4ecr+h3q\nApfwXVafVtN3YfTVPjJoxhdb51M4zRjSm31iAzTSb0a+Xdr1Io+qV7ayF74C\nKUllc8Pyqv7ncxmXJ8s3abWu7PQL7/8y/W6J7+4VZbOwMpj1tVm5yk3UA6Z1\nEKuoUQZOYN/g1z0s7vlN69csJMrzdJg1xnk+BqqKncjzLp3FigV/XKkIVcmg\nSsv6zc34r3BxBiqgqZPb9reW+qPZA+xcycXvfUXSdVh3ruhOUINCWYYYWiIW\nNEi/\r\n=ol1p\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/test-peer-looser-than-dev-a-peer-dep_2.0.0_1611694196571_0.8161177652360374"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-01-26T20:49:52.953Z",
+    "1.0.0": "2021-01-26T20:49:53.113Z",
+    "modified": "2021-01-26T20:49:58.968Z",
+    "2.0.0": "2021-01-26T20:49:56.712Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/test-peer-looser-than-dev-a-peer-dep.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/test-peer-looser-than-dev-a-peer-dep.min.json
@@ -1,0 +1,33 @@
+{
+  "name": "@isaacs/test-peer-looser-than-dev-a-peer-dep",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/test-peer-looser-than-dev-a-peer-dep",
+      "version": "1.0.0",
+      "dist": {
+        "integrity": "sha512-yNZerk7tDLQP+CxtyOhcomqTF0DkP/RLHcSxFsM0TleLL4udeLE55LFy9f1ZdpZO0OUdlVkm0FTC2eVghBWEYA==",
+        "shasum": "5784751026ee9f7be53ebc977abffe23841bc658",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-peer-looser-than-dev-a-peer-dep/-/test-peer-looser-than-dev-a-peer-dep-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 83,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIBxCRA9TVsSAnZWagAAoSQP/3LiViTjfjYzMUX8hHI6\ne31b8WHplmgOR3rAIKNCHwUjNOgXXYMErhvczrKz7Od9JsLLdmz5p2gk1BOK\nzgSbdQgaKZQgRGAA20ePqc09xgzE2tls7EojLLyZ6PRLNZ9W+CL2g1z/4kSf\ncseIvymEi1B9FmjF505BDuF6GXSUE6+teUelxWvdJa+WuiW6F4ifs7AcIVOy\ndKCzNkaNWjEJha2nRt710yrssISVcRlN+OsA3xofZrV7eCkxunlURMpHFfYD\nZeSjrcjfqaomncIq3ZhM61PuxJQpbDvnRk6YS5x/tnUfgpXz5c9J4qvQuqTO\n1u+KDHjhUQB9/O1VUNyn+GvLS0i2A3d9xu/0gV6S5c1gJlILKuelov8+0q7Z\ndWHXJdssKGGpZDhIb0wB2kuMOcT2KN51vB9Sl1zxjndN5Ky7Ok1QrHevLhCy\nb+ggCkJNNQMG0sPdaFFPTGBl5akfHiiFgFVMZJDvw+CE+DH8bd213TIfTMMl\nvD9Ui7ebj5GPX62lhTf62/3FJSVFU7LAlCnFKRAPbuNdw/yoMe3yph5YYfvX\nTCnxkwarkliZfFjj23tlbEVlVQdwHfEv5TKfSxpuj8dl4pBsnE7r1M/TkpxU\nlLrzT6yiXDfOr5cCSTqD9l5TvVnWNrOs8Kbw8N/tXiTKY9l25W+zL6BC+BLz\nq1wJ\r\n=JyEm\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "@isaacs/test-peer-looser-than-dev-a-peer-dep",
+      "version": "2.0.0",
+      "dist": {
+        "integrity": "sha512-I4+mZBpY2S9ALgxRPLWNabc0YCtFByYAN8r8h7GuFgXjBmU4Y83vSi9KgppPgkcGSA2qXiuJAi/rQixS5Sobqw==",
+        "shasum": "d1c21fd6a55a7a2feef91759910456730ddf229e",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-peer-looser-than-dev-a-peer-dep/-/test-peer-looser-than-dev-a-peer-dep-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 83,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIB1CRA9TVsSAnZWagAANA4QAJqTn2AfLT3xTLmfuShs\nhHq3U1Odjc+V8ZgCkgJTMyU60IOA1sHuP3gAWdgV0kzbIGDk+LwL7yY1RtmH\n6HucLr6tKVnv7zZA01skNFQdHHcYgyOURy6e4CLIj49rcnHHkGGoczrzlgu9\ndVKFbTxkIVkl7rN4fQ31cRRQj9wsZ8cZTkoe9vGz5D/JJOzR6e29CFJHv9U7\niMc/30Qh6CFjU935B+X5I4yVvvdzgeqTb8JvHNP4ZetyYyLX+8Atw1VhqHtn\n13CnVHiNRbTVuPfvIR5kRFFpRohiZgreQP4B7GeClFVomeXp8QMZmtf594hr\nEoD/BTJJyWZpyPGh0NzEiX3HQ7wfTpXSxfjPP9cMwnbu8KQW3kL98rUD0oov\n2+Nmr1O3+4fyXlpM1dAWd6FY0M5jRsnx+hvrGwWcRu5UNUFYskCT4ecr+h3q\nApfwXVafVtN3YfTVPjJoxhdb51M4zRjSm31iAzTSb0a+Xdr1Io+qV7ayF74C\nKUllc8Pyqv7ncxmXJ8s3abWu7PQL7/8y/W6J7+4VZbOwMpj1tVm5yk3UA6Z1\nEKuoUQZOYN/g1z0s7vlN69csJMrzdJg1xnk+BqqKncjzLp3FigV/XKkIVcmg\nSsv6zc34r3BxBiqgqZPb9reW+qPZA+xcycXvfUXSdVh3ruhOUINCWYYYWiIW\nNEi/\r\n=ol1p\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-01-26T20:49:58.968Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/test-peer-looser-than-dev-devdep.json
+++ b/test/fixtures/registry-mocks/content/isaacs/test-peer-looser-than-dev-devdep.json
@@ -1,0 +1,92 @@
+{
+  "_id": "@isaacs/test-peer-looser-than-dev-devdep",
+  "_rev": "1-ab2fb5fc8343b3b3c3de82580d8f9a26",
+  "name": "@isaacs/test-peer-looser-than-dev-devdep",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/test-peer-looser-than-dev-devdep",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/test-peer-looser-than-dev-peerdep": "1"
+      },
+      "_id": "@isaacs/test-peer-looser-than-dev-devdep@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.4.2",
+      "dist": {
+        "integrity": "sha512-EQEANLxxGxXW28OLhvTJZCFhOKtHJ0GPR37X816ZM9RivMcY/k0y9L2sJ69HK4J8tZqCQd15rR4rjZ7nRo3bVQ==",
+        "shasum": "6d09937fe9305dee1414e10ffbc0ba8cd3023710",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-peer-looser-than-dev-devdep/-/test-peer-looser-than-dev-devdep-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 161,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEH5/CRA9TVsSAnZWagAAqdcP/3tlYWTBQfISfmS08ejI\n3xIKMpxEFKRGFvAZO6fq9m0wX/bAACK0TUbUHLxY+MnXqjhS0dOIX/9b88SF\n64PvT9Jb0fnDSgGvXArpksjJgRFyiLF+Z1DzmeNmJOs0xglqm1ldN5nnPtzI\noGSRsQ0zFMKpUuMlKbsdrprA8YktGfCKDIr4xdksyvYiMy8KNmFNxgSsd0BE\n/dDc0SZ4bqREIImpZP4W3S5N3YtpnbpqokZFKtf42QaoPexkrHMCNZ/cpGQn\n4xrazrTlD74bER/zhwEyAMAvoHBpj3TFzrAOZ3NqI0eGrOo6aJL+q5IWezuf\nUlTINPenzh0jDDjg6Jsh4uLHeUrHS5rh1hfBTL3unoAbbEETQyBzTbMVssKA\n4iVpOSd9lVt2FPihW13CauORfK1kM7owYu5G4zpNZXEQqoE3+mAqBs46I9xG\nmZH22ZlzxeoghCok4G27Py7OHZyN59Im1KcD6NrkGZH73NXly+sl7vztlTkC\nKjLaRWVW0D5uPFEu44KHpz9qjJT3O2huxzPw4WyCdVJgt/WY4O+e9bZZ47SH\nb0mWkNNEd5MoSSaFavBy/GREkwure7VXnr6TQtraKAnz3IKkpeim+wCo1bkc\nV7d3RNCDMsgze6g4sXYAqQgll2O9t1ypckBb/QyEDRyVFEsfBCd0UO8d/Gbf\nK5M6\r\n=FVXg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/test-peer-looser-than-dev-devdep_1.0.0_1611693694784_0.717622176519509"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.1": {
+      "name": "@isaacs/test-peer-looser-than-dev-devdep",
+      "version": "1.0.1",
+      "peerDependencies": {
+        "@isaacs/test-peer-looser-than-dev-a-peer-dep": "1"
+      },
+      "_id": "@isaacs/test-peer-looser-than-dev-devdep@1.0.1",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.4.2",
+      "dist": {
+        "integrity": "sha512-fGK3qtEb5/max8Z/81dxBZAaw11n1UHGSJgdb5XDKT9iWeV9SLZI5tMwUu+A9kQanD4bMEC5mD1CiC254j3AXg==",
+        "shasum": "0797c3ebc77eadb81903f502f0295b7fbfdc6766",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-peer-looser-than-dev-devdep/-/test-peer-looser-than-dev-devdep-1.0.1.tgz",
+        "fileCount": 1,
+        "unpackedSize": 164,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIBsCRA9TVsSAnZWagAAeBQQAIcTE1VIzSSxkWh/J5LN\nsAggm2+h10borZlUXVB3hqU4shGXPAhoeDWZMeTxOiw/1yIC9pePRo967+Ub\nr5cuK+l5+IZniejYiFVTIkmIaFNVuCAjFKA7i7lkWoPjfcv2subkZcMvU5AG\npc0neTJMn0Gt34gXmKSUAJTMbWGAebswuiCxbS+L0Z57rIEj3HffkZ7eVo4b\nnRwrn1ClBTg1gPTpQZ6bStRYIuvnTx7XEKt8p7gHML2I8tyFWuqJ7JKCjaLr\nCeIQMJdqaivrhDbEe1CJnRPbH3O6hsIxTw7ZGsmbBQ7mcn9GJHrvfs3rAbn+\npjrPJOwOXwV5yocDRM9MyyLRYmdkQ8dIalCdCQC2G0Ppx0GYdSXMpp66AAFM\n8XeCtkmE4CNuwJ19DGut+e+yESsbr0XChu2e5LYc9FT3SaameWuICiQkyg2O\nAHN3hHO1CeR3MMr/NTLG75vEFJ35m8dLQ+U/fLihNFpliOpUC6TMch/YAS9D\noxho2JOeUeMkgIDeg+rdxbeQ8+3W8AtMkjxnvf033ydZ3kxwfF+YUwwF/P5m\nA47P9AnBnh8hW1Pypj8Pjqg0Fkhz3DG07Veo7ZNRM2NP9su0x+kUNlakdIH8\nAonYtpxd/fGhoUaoI95V9AFiDr6AsNf4gqJIsLtBjJ7HARrDVMCXyGLH90Ii\nGu11\r\n=IyvD\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/test-peer-looser-than-dev-devdep_1.0.1_1611694188404_0.746542945795017"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-01-26T20:41:34.723Z",
+    "1.0.0": "2021-01-26T20:41:34.902Z",
+    "modified": "2021-01-26T20:49:51.981Z",
+    "1.0.1": "2021-01-26T20:49:48.526Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/test-peer-looser-than-dev-devdep.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/test-peer-looser-than-dev-devdep.min.json
@@ -1,0 +1,39 @@
+{
+  "name": "@isaacs/test-peer-looser-than-dev-devdep",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/test-peer-looser-than-dev-devdep",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/test-peer-looser-than-dev-peerdep": "1"
+      },
+      "dist": {
+        "integrity": "sha512-EQEANLxxGxXW28OLhvTJZCFhOKtHJ0GPR37X816ZM9RivMcY/k0y9L2sJ69HK4J8tZqCQd15rR4rjZ7nRo3bVQ==",
+        "shasum": "6d09937fe9305dee1414e10ffbc0ba8cd3023710",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-peer-looser-than-dev-devdep/-/test-peer-looser-than-dev-devdep-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 161,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEH5/CRA9TVsSAnZWagAAqdcP/3tlYWTBQfISfmS08ejI\n3xIKMpxEFKRGFvAZO6fq9m0wX/bAACK0TUbUHLxY+MnXqjhS0dOIX/9b88SF\n64PvT9Jb0fnDSgGvXArpksjJgRFyiLF+Z1DzmeNmJOs0xglqm1ldN5nnPtzI\noGSRsQ0zFMKpUuMlKbsdrprA8YktGfCKDIr4xdksyvYiMy8KNmFNxgSsd0BE\n/dDc0SZ4bqREIImpZP4W3S5N3YtpnbpqokZFKtf42QaoPexkrHMCNZ/cpGQn\n4xrazrTlD74bER/zhwEyAMAvoHBpj3TFzrAOZ3NqI0eGrOo6aJL+q5IWezuf\nUlTINPenzh0jDDjg6Jsh4uLHeUrHS5rh1hfBTL3unoAbbEETQyBzTbMVssKA\n4iVpOSd9lVt2FPihW13CauORfK1kM7owYu5G4zpNZXEQqoE3+mAqBs46I9xG\nmZH22ZlzxeoghCok4G27Py7OHZyN59Im1KcD6NrkGZH73NXly+sl7vztlTkC\nKjLaRWVW0D5uPFEu44KHpz9qjJT3O2huxzPw4WyCdVJgt/WY4O+e9bZZ47SH\nb0mWkNNEd5MoSSaFavBy/GREkwure7VXnr6TQtraKAnz3IKkpeim+wCo1bkc\nV7d3RNCDMsgze6g4sXYAqQgll2O9t1ypckBb/QyEDRyVFEsfBCd0UO8d/Gbf\nK5M6\r\n=FVXg\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.0.1": {
+      "name": "@isaacs/test-peer-looser-than-dev-devdep",
+      "version": "1.0.1",
+      "peerDependencies": {
+        "@isaacs/test-peer-looser-than-dev-a-peer-dep": "1"
+      },
+      "dist": {
+        "integrity": "sha512-fGK3qtEb5/max8Z/81dxBZAaw11n1UHGSJgdb5XDKT9iWeV9SLZI5tMwUu+A9kQanD4bMEC5mD1CiC254j3AXg==",
+        "shasum": "0797c3ebc77eadb81903f502f0295b7fbfdc6766",
+        "tarball": "https://registry.npmjs.org/@isaacs/test-peer-looser-than-dev-devdep/-/test-peer-looser-than-dev-devdep-1.0.1.tgz",
+        "fileCount": 1,
+        "unpackedSize": 164,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgEIBsCRA9TVsSAnZWagAAeBQQAIcTE1VIzSSxkWh/J5LN\nsAggm2+h10borZlUXVB3hqU4shGXPAhoeDWZMeTxOiw/1yIC9pePRo967+Ub\nr5cuK+l5+IZniejYiFVTIkmIaFNVuCAjFKA7i7lkWoPjfcv2subkZcMvU5AG\npc0neTJMn0Gt34gXmKSUAJTMbWGAebswuiCxbS+L0Z57rIEj3HffkZ7eVo4b\nnRwrn1ClBTg1gPTpQZ6bStRYIuvnTx7XEKt8p7gHML2I8tyFWuqJ7JKCjaLr\nCeIQMJdqaivrhDbEe1CJnRPbH3O6hsIxTw7ZGsmbBQ7mcn9GJHrvfs3rAbn+\npjrPJOwOXwV5yocDRM9MyyLRYmdkQ8dIalCdCQC2G0Ppx0GYdSXMpp66AAFM\n8XeCtkmE4CNuwJ19DGut+e+yESsbr0XChu2e5LYc9FT3SaameWuICiQkyg2O\nAHN3hHO1CeR3MMr/NTLG75vEFJ35m8dLQ+U/fLihNFpliOpUC6TMch/YAS9D\noxho2JOeUeMkgIDeg+rdxbeQ8+3W8AtMkjxnvf033ydZ3kxwfF+YUwwF/P5m\nA47P9AnBnh8hW1Pypj8Pjqg0Fkhz3DG07Veo7ZNRM2NP9su0x+kUNlakdIH8\nAonYtpxd/fGhoUaoI95V9AFiDr6AsNf4gqJIsLtBjJ7HARrDVMCXyGLH90Ii\nGu11\r\n=IyvD\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-01-26T20:49:51.981Z"
+}

--- a/test/fixtures/test-peer-looser-than-dev/a-peer-dep/1/package.json
+++ b/test/fixtures/test-peer-looser-than-dev/a-peer-dep/1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/test-peer-looser-than-dev-a-peer-dep",
+  "version": "1.0.0"
+}

--- a/test/fixtures/test-peer-looser-than-dev/a-peer-dep/2/package.json
+++ b/test/fixtures/test-peer-looser-than-dev/a-peer-dep/2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/test-peer-looser-than-dev-a-peer-dep",
+  "version": "2.0.0"
+}

--- a/test/fixtures/test-peer-looser-than-dev/devdep/package.json
+++ b/test/fixtures/test-peer-looser-than-dev/devdep/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/test-peer-looser-than-dev-devdep",
+  "version": "1.0.1",
+  "peerDependencies": {
+    "@isaacs/test-peer-looser-than-dev-a-peer-dep": "1"
+  }
+}

--- a/test/fixtures/test-peer-looser-than-dev/package.json
+++ b/test/fixtures/test-peer-looser-than-dev/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@isaacs/test-peer-looser-than-dev",
+  "description": "an example package to reproduce/fix an ERESOLVE case",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@isaacs/test-peer-looser-than-dev-devdep": "1"
+  },
+  "peerDependencies": {
+    "@isaacs/test-peer-looser-than-dev-a-peer-dep": ">=0"
+  }
+}


### PR DESCRIPTION
Given the following dep graph:

```
root -> a@*, b@2
b -> PEER(a@1)
```

when we load the peerSet for `b@2`, we pull in the parent's
spec for that dependency, `a@*`.  This may result in adding `a@2` to the
tree, which conflicts with b's peer dependency.  However, `a@1` would
have _also_ satisfied the root's dependency and _not_ caused a conflict.

When there is no version that can be found to satisfy both dependencies,
then we use the parent's dependency and warn/crash as we would have
previously.  However, with this commit, we are more aggressively
deduplicating the parent/child dependency collision to avoid ERESOLVEs
that are unnecessary.

This increased deduplication results in a lot of churn in the test
snapshot, because it typically means getting an earlier or more
restrictive version of a shared peer dependency.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
