### PR TITLE
Properly track dev edges on virtual root nodes

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -733,7 +733,9 @@ class Node {
     // Linked targets that are disconnected from the tree are tops,
     // but don't have a 'path' field, only a 'realpath', because we
     // don't know their canonical location. We don't need their devDeps.
-    if (this.isTop && this.path && !this.sourceReference)
+    const { isTop, path, sourceReference } = this
+    const { isTop: srcTop, path: srcPath } = sourceReference || {}
+    if (isTop && path && (!sourceReference || srcTop && srcPath))
       this[_loadDepType](this.package.devDependencies, 'dev')
 
     const pd = this.package.peerDependencies

--- a/test/node.js
+++ b/test/node.js
@@ -2147,3 +2147,19 @@ t.test('isProjectRoot shows if the node is the root link target', async t => {
   t.equal(link.isRoot, true)
   t.equal(n.isRoot, false)
 })
+
+t.test('virtual references to root node has devDep edges', async t => {
+  const root = new Node({
+    path: '/some/project/path',
+    pkg: {
+      devDependencies: {
+        a: '1',
+      },
+    },
+  })
+  const virtualRoot = new Node({
+    path: '/virtual-root',
+    sourceReference: root,
+  })
+  t.equal(virtualRoot.edgesOut.get('a').type, 'dev')
+})


### PR DESCRIPTION
If the virtualRoot node has a sourceReference, and that sourceReference
node would get its devDep edges loaded, then the virtualRoot node should
as well.

This caused a very useless ERESOLVE error, which could not be properly
forced away, when installing in a project that had conflicting peer deps
in its dev tree.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
