### PR TITLE
Install bins properly when global root is a link

### DIFF
--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -605,7 +605,7 @@ module.exports = cls => class Reifier extends cls {
       tree: this.diff,
       visit: diff => {
         const node = diff.ideal
-        if (node && !node.isRoot && node.package.bundleDependencies &&
+        if (node && !node.isProjectRoot && node.package.bundleDependencies &&
             node.package.bundleDependencies.length) {
           maxBundleDepth = Math.max(maxBundleDepth, node.depth)
           if (!bundlesByDepth.has(node.depth))
@@ -811,7 +811,7 @@ module.exports = cls => class Reifier extends cls {
     dfwalk({
       tree: this.diff,
       leave: diff => {
-        if (!diff.ideal.isRoot)
+        if (!diff.ideal.isProjectRoot)
           nodes.push(diff.ideal)
       },
       // process adds before changes, ignore removals

--- a/lib/node.js
+++ b/lib/node.js
@@ -247,7 +247,7 @@ class Node {
 
   // true for packages installed directly in the global node_modules folder
   get globalTop () {
-    return this.global && this.parent.isRoot
+    return this.global && this.parent.isProjectRoot
   }
 
   get workspaces () {
@@ -294,8 +294,11 @@ class Node {
     const { name = '', version = '' } = this.package
     // root package will prefer package name over folder name,
     // and never be called an alias.
-    const myname = this.isRoot ? name || this.name : this.name
-    const alias = !this.isRoot && name && myname !== name ? `npm:${name}@` : ''
+    const { isProjectRoot } = this
+    const myname = isProjectRoot ? name || this.name
+      : this.name
+    const alias = !isProjectRoot && name && myname !== name ? `npm:${name}@`
+      : ''
     return `${myname}@${alias}${version}`
   }
 
@@ -339,14 +342,14 @@ class Node {
   }
 
   [_explain] (edge, seen) {
-    if (this.isRoot && !this.sourceReference) {
+    if (this.isProjectRoot && !this.sourceReference) {
       return {
         location: this.path,
       }
     }
 
     const why = {
-      name: this.isRoot ? this.package.name : this.name,
+      name: this.isProjectRoot ? this.package.name : this.name,
       version: this.package.version,
     }
     if (this.errors.length || !this.package.name || !this.package.version) {
@@ -384,7 +387,7 @@ class Node {
       // and are not keeping it held in this spot anyway.
       const edges = []
       for (const edge of this.edgesIn) {
-        if (!edge.valid && !edge.from.isRoot)
+        if (!edge.valid && !edge.from.isProjectRoot)
           continue
 
         edges.push(edge)
@@ -453,7 +456,7 @@ class Node {
   }
 
   get isWorkspace () {
-    if (this.isRoot)
+    if (this.isProjectRoot)
       return false
     const { root } = this
     const { type, to } = root.edgesOut.get(this.package.name) || {}
@@ -904,8 +907,8 @@ class Node {
     if (this.isLink)
       return node.isLink && this.target.matches(node.target)
 
-    // if they're two root nodes, they're different if the paths differ
-    if (this.isRoot && node.isRoot)
+    // if they're two project root nodes, they're different if the paths differ
+    if (this.isProjectRoot && node.isProjectRoot)
       return this.path === node.path
 
     // if the integrity matches, then they're the same.

--- a/test/node.js
+++ b/test/node.js
@@ -2163,3 +2163,21 @@ t.test('virtual references to root node has devDep edges', async t => {
   })
   t.equal(virtualRoot.edgesOut.get('a').type, 'dev')
 })
+
+t.test('globaTop set for children of global link root target', async t => {
+  const root = new Link({
+    path: '/usr/local/lib',
+    realpath: '/data/lib',
+    global: true,
+  })
+  root.target = new Node({
+    path: '/data/lib',
+    global: true,
+    root,
+  })
+  const gtop = new Node({
+    parent: root.target,
+    pkg: { name: 'foo', version: '1.2.3' },
+  })
+  t.equal(gtop.globalTop, true)
+})


### PR DESCRIPTION
Install bins properly when global root is a link

Also fixes up a few other places where we were checking isRoot and
should have been checking isProjectRoot.

Fix: https://github.com/nodejs/build/issues/2525