### PR TITLE
fix: package.json saving optional deps

### DIFF
--- a/lib/dep-spec.js
+++ b/lib/dep-spec.js
@@ -22,14 +22,20 @@ const updateDepSpec = (pkg, name, newSpec) => {
   return pkg
 }
 
+const shouldAddToDependencies = (pkg, type, key) =>
+  type !== 'dependencies'
+    // make sure the dependency is not already listed as an optional dep
+    || !Object.prototype.hasOwnProperty.call(pkg.optionalDependencies || {}, key)
+
 // sort alphabetically all types of deps for a given package
-const orderDeps = (pkg) => {
+const updateDeps = (pkg) => {
   for (const type of types) {
     if (pkg && pkg[type]) {
       pkg[type] = Object.keys(pkg[type])
         .sort((a, b) => a.localeCompare(b))
         .reduce((res, key) => {
-          res[key] = pkg[type][key]
+          if (shouldAddToDependencies(pkg, type, key))
+            res[key] = pkg[type][key]
           return res
         }, {})
     }
@@ -38,6 +44,6 @@ const orderDeps = (pkg) => {
 }
 
 module.exports = {
-  orderDeps,
+  updateDeps,
   updateDepSpec,
 }

--- a/lib/update-root-package-json.js
+++ b/lib/update-root-package-json.js
@@ -6,7 +6,7 @@ const {resolve} = require('path')
 
 const parseJSON = require('json-parse-even-better-errors')
 
-const { orderDeps } = require('./dep-spec.js')
+const { updateDeps } = require('./dep-spec.js')
 
 const depTypes = new Set([
   'dependencies',
@@ -21,7 +21,7 @@ async function updateRootPackageJson ({ tree }) {
     .then(data => parseJSON(data))
     .catch(() => null)
 
-  const depsData = orderDeps({
+  const depsData = updateDeps({
     ...tree.package,
   })
 

--- a/test/dep-spec.js
+++ b/test/dep-spec.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const { orderDeps, updateDepSpec } = require('../lib/dep-spec.js')
+const { updateDeps, updateDepSpec } = require('../lib/dep-spec.js')
 
 t.test('updates existing record if found', t => {
   t.strictSame(updateDepSpec({
@@ -38,7 +38,7 @@ t.test('adds to pkg.dependencies if not', t => {
 })
 
 t.test('reorder deps properly', (t) => {
-  t.strictSame(orderDeps({
+  t.strictSame(updateDeps({
     dependencies: { b: '1.0.0', a: '1.0.0', d: '1.0.0', c: '1.0.0' },
   }), {
     dependencies: { a: '1.0.0', b: '1.0.0', c: '1.0.0', d: '1.0.0' },
@@ -47,7 +47,24 @@ t.test('reorder deps properly', (t) => {
 })
 
 t.test('reorder deps with no values', (t) => {
-  t.strictSame(orderDeps({}), {})
-  t.strictSame(orderDeps(), undefined)
+  t.strictSame(updateDeps({}), {})
+  t.strictSame(updateDeps(), undefined)
+  t.end()
+})
+
+t.test('items in both dependencies and optional deps lists', (t) => {
+  t.strictSame(updateDeps({
+    dependencies: {
+      a: '1.0.0',
+    },
+    optionalDependencies: {
+      a: '1.0.0',
+    },
+  }), {
+    dependencies: {},
+    optionalDependencies: {
+      a: '1.0.0',
+    },
+  }, 'should removes item from deps if already listed in optional deps')
   t.end()
 })


### PR DESCRIPTION
Reify currently duplicates entries listed as `optionalDependencies` in the
users' `package.json` files. While it's working as expected this is
unexpected to a number of users and it also contradicts our own docs on
it:

    Entries in optionalDependencies will override entries of the same
    name in dependencies, so it's usually best to only put in one place.

This patches this UX problem by adding an extra check that will avoid
adding a dependency to the `package.json` `dependencies` object in case
that package is already listed under `optionalDependencies`.

Fixes: https://github.com/npm/cli/issues/2203
Fixes: https://github.com/npm/cli/issues/1886
Fixes: https://github.com/npm/cli/issues/724
