### PR TITLE
fix: package.json saving optional deps

### DIFF
--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -907,7 +907,7 @@ module.exports = cls => class Reifier extends cls {
 
     return Promise.all([
       this[_saveLockFile](saveOpt),
-      updateRootPackageJson({ tree: this.idealTree }),
+      updateRootPackageJson(this.idealTree),
     ]).then(() => process.emit('timeEnd', 'reify:save'))
   }
 

--- a/lib/update-root-package-json.js
+++ b/lib/update-root-package-json.js
@@ -15,7 +15,7 @@ const depTypes = new Set([
   'peerDependencies',
 ])
 
-async function updateRootPackageJson ({ tree }) {
+const updateRootPackageJson = async tree => {
   const filename = resolve(tree.path, 'package.json')
   const originalContent = await readFile(filename, 'utf8')
     .then(data => parseJSON(data))
@@ -24,6 +24,16 @@ async function updateRootPackageJson ({ tree }) {
   const depsData = orderDeps({
     ...tree.package,
   })
+
+  // optionalDependencies don't need to be repeated in two places
+  if (depsData.dependencies) {
+    if (depsData.optionalDependencies) {
+      for (const name of Object.keys(depsData.optionalDependencies))
+        delete depsData.dependencies[name]
+    }
+    if (Object.keys(depsData.dependencies).length === 0)
+      delete depsData.dependencies
+  }
 
   // if there's no package.json, just use internal pkg info as source of truth
   const packageJsonContent = originalContent || depsData

--- a/test/update-root-package-json.js
+++ b/test/update-root-package-json.js
@@ -7,14 +7,12 @@ const updateRootPackageJson = require('../lib/update-root-package-json.js')
 t.test('missing package.json', async t => {
   const path = t.testdir({})
   await updateRootPackageJson({
-    tree: {
-      path: path,
-      package: {
-        name: 'missing-package-json-test',
-        version: '1.0.0',
-        dependencies: {
-          abbrev: '^1.0.0',
-        },
+    path: path,
+    package: {
+      name: 'missing-package-json-test',
+      version: '1.0.0',
+      dependencies: {
+        abbrev: '^1.0.0',
       },
     },
   })
@@ -44,13 +42,11 @@ t.test('existing package.json', async t => {
     }),
   })
   await updateRootPackageJson({
-    tree: {
-      path: path,
-      package: {
-        name: 'missing-package-json-test',
-        version: '1.0.0',
-        dependencies: {},
-      },
+    path: path,
+    package: {
+      name: 'missing-package-json-test',
+      version: '1.0.0',
+      dependencies: {},
     },
   })
   t.match(
@@ -60,7 +56,46 @@ t.test('existing package.json', async t => {
       version: '1.0.0',
       bin: './file.js',
       funding: 'http://example.com',
+      dependencies: undefined,
+    },
+    'should write new package.json with tree data'
+  )
+})
+
+t.test('existing package.json with optionalDependencies', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'existing-package-json-optional-test',
+      version: '1.0.0',
+      bin: './file.js',
+      funding: 'http://example.com',
       dependencies: {},
+    }),
+  })
+  await updateRootPackageJson({
+    path: path,
+    package: {
+      name: 'missing-package-json-optional-test',
+      version: '1.0.0',
+      dependencies: {
+        abbrev: '^1.0.0',
+      },
+      optionalDependencies: {
+        abbrev: '^1.0.0',
+      },
+    },
+  })
+  t.match(
+    require(resolve(path, 'package.json')),
+    {
+      name: 'existing-package-json-optional-test',
+      version: '1.0.0',
+      bin: './file.js',
+      funding: 'http://example.com',
+      dependencies: undefined,
+      optionalDependencies: {
+        abbrev: '^1.0.0',
+      },
     },
     'should write new package.json with tree data'
   )
@@ -74,14 +109,12 @@ t.test('custom formatting', async t => {
     }),
   })
   await updateRootPackageJson({
-    tree: {
-      path: path,
-      package: {
-        name: 'custom-formatting-test',
-        version: '1.0.0',
-        [Symbol.for('indent')]: 4,
-        [Symbol.for('newline')]: '',
-      },
+    path: path,
+    package: {
+      name: 'custom-formatting-test',
+      version: '1.0.0',
+      [Symbol.for('indent')]: 4,
+      [Symbol.for('newline')]: '',
     },
   })
   t.match(


### PR DESCRIPTION
Reify currently duplicates entries listed as optionalDependencies in the
users' package.json files. While it's working as expected this is
unexpected to a number of users and it also contradicts our own docs on
it:

    Entries in optionalDependencies will override entries of the same
    name in dependencies, so it's usually best to only put in one place.

This patches this UX problem by adding an extra check that will avoid
adding a dependency to the package.json `dependencies` object in case
that package is already listed under `optionalDependencies`.

Fixes: https://github.com/npm/cli/issues/2203
Fixes: https://github.com/npm/cli/issues/1886
Fixes: https://github.com/npm/cli/issues/724

EDIT(isaacs): Moved this into updateRootPackageJson in pairing session

Alternative approach for https://github.com/npm/arborist/pull/219

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
