### PR TITLE
use the idealtree target path if it exists to make sure relpaths are from the correct root

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -491,7 +491,8 @@ module.exports = cls => class IdealTreeBuilder extends cls {
     /* istanbul ignore else - should also be covered by realpath failure */
     if (filepath) {
       const { name } = spec
-      spec = npa(`file:${relpath(this.path, filepath)}`, this.path)
+      const tree = this.idealTree.target || this.idealTree
+      spec = npa(`file:${relpath(tree.path, filepath)}`, tree.path)
       spec.name = name
     }
     return spec

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -1,4 +1,4 @@
-const {basename, resolve} = require('path')
+const {basename, resolve, relative} = require('path')
 const t = require('tap')
 const Arborist = require('../..')
 const fixtures = resolve(__dirname, '../fixtures')
@@ -1234,6 +1234,32 @@ t.test('workspaces', t => {
   })
 
   t.end()
+})
+
+t.test('adding tarball to global prefix that is a symlink at a different path depth', async t => {
+  const fixt = t.testdir({
+    'real-root': {},
+    'another-path': {
+      'global-root': t.fixture('symlink', '../real-root'),
+    },
+  })
+  const path = resolve(fixt, 'another-path/global-root')
+  const arb = new Arborist({
+    path,
+    global: true,
+    ...OPT,
+  })
+
+  const tarballpath = resolve(__dirname, '../fixtures/registry-mocks/content/mkdirp/-/mkdirp-1.0.2.tgz')
+  const tree = await arb.buildIdealTree({
+    path,
+    global: true,
+    add: [
+      // this will be a relative path to the tarball above
+      relative(process.cwd(), tarballpath),
+    ],
+  })
+  t.matchSnapshot(printTree(tree))
 })
 
 t.test('add symlink that points to a symlink', t => {


### PR DESCRIPTION
currently, at least in windows, if you attempt to globally install a tarball into a symlinked global prefix the relpath generated here is relative to the original path (i.e. `C:\\Program Files\\nodejs`) rather than the realpath (i.e. `C:\\Users\\username\\AppData\\Roaming\\nvm\\v14.15.5`) which when we try to reify later fails. this change makes sure we use the path that we're going to reify against to generate the relative path, making it valid.

i'll work out a test for this later, just wanted to get the change somewhere reviewable