### PR TITLE
Allow --force to override conflicted peerOptional

### DIFF
--- a/bin/ideal.js
+++ b/bin/ideal.js
@@ -1,58 +1,10 @@
 const Arborist = require('../')
 
+const { inspect } = require('util')
 const options = require('./lib/options.js')
 const print = require('./lib/print-tree.js')
 require('./lib/logging.js')
 require('./lib/timers.js')
-
-const c = require('chalk')
-
-const whichIsA = (name, dependents, indent = '  ') => {
-  if (!dependents || dependents.length === 0)
-    return ''
-  const str = `\nfor: ` +
-    dependents.map(dep => {
-      return dep.more ? `${dep.more} more (${dep.names.join(', ')})`
-        : `${dep.type} dependency ` +
-          `${c.bold(name)}@"${c.bold(dep.spec)}"` + `\nfrom:` +
-          (dep.from.location ? (dep.from.name
-            ? ` ${c.bold(dep.from.name)}@${c.bold(dep.from.version)} ` +
-              c.dim(`at ${dep.from.location}`)
-            : ' the root project')
-          : ` ${c.bold(dep.from.name)}@${c.bold(dep.from.version)}`) +
-          whichIsA(dep.from.name, dep.from.dependents, '  ')
-    }).join('\nand: ')
-
-  return str.split(/\n/).join(`\n${indent}`)
-}
-
-const explainEresolve = ({ dep, current, peerConflict, fixWithForce }) => {
-  return (!dep.whileInstalling ? '' : `While resolving: ` +
-  `${c.bold(dep.whileInstalling.name)}@${c.bold(dep.whileInstalling.version)}\n`) +
-
-  `Found: ` +
-    `${c.bold(current.name)}@${c.bold(current.version)} ` +
-    c.dim(`at ${current.location}`) +
-    `${whichIsA(current.name, current.dependents)}` +
-
-  `\n\nCould not add conflicting dependency: ` +
-    `${c.bold(dep.name)}@${c.bold(dep.version)} ` +
-    c.dim(`at ${dep.location}`) +
-   `${whichIsA(dep.name, dep.dependents)}\n` +
-
-  (!peerConflict ? '' :
-    `\nConflicting peer dependency: ` +
-      `${c.bold(peerConflict.name)}@${c.bold(peerConflict.version)} ` +
-      c.dim(`at ${peerConflict.location}`) +
-      `${whichIsA(peerConflict.name, peerConflict.dependents)}\n`
-  ) +
-
-  `\nFix the upstream dependency conflict, or
-run this command with  --legacy-peer-deps${
-  fixWithForce ? ' or --force' : ''}
-to accept an incorrect (and potentially broken) dependency resolution.
-`
-}
 
 const start = process.hrtime()
 new Arborist(options).buildIdealTree(options).then(tree => {
@@ -62,7 +14,7 @@ new Arborist(options).buildIdealTree(options).then(tree => {
   if (tree.meta && options.save)
     tree.meta.save()
 }).catch(er => {
-  console.error(er)
-  if (er.code === 'ERESOLVE')
-    console.error(explainEresolve(er))
+  const opt = { depth: Infinity, color: true }
+  console.error(er.code === 'ERESOLVE' ? inspect(er, opt) : er)
+  process.exitCode = 1
 })

--- a/bin/lib/logging.js
+++ b/bin/lib/logging.js
@@ -26,7 +26,7 @@ if (loglevel !== 'silent') {
       return
     const pref = `${process.pid} ${level} `
     if (level === 'warn' && args[0] === 'ERESOLVE')
-      args[2] = inspect(args[2], { depth: Infinity })
+      args[2] = inspect(args[2], { depth: 10 })
     const msg = pref + format(...args).trim().split('\n').join(`\n${pref}`)
     console.error(msg)
   })

--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -827,13 +827,18 @@ This is a one-time fix-up, please be patient...
       // +-- z@1
       // But if x and y are loaded in the same virtual root, then they will
       // be forced to agree on a version of z.
+      const required = edge.type === 'peerOptional' ? new Set()
+        : new Set([edge.from])
+      const parent = edge.peer ? virtualRoot : null
       const dep = vrDep && vrDep.satisfies(edge) ? vrDep
-        : await this[_nodeFromEdge](edge, edge.peer ? virtualRoot : null)
+        : await this[_nodeFromEdge](edge, parent, null, required)
+
       /* istanbul ignore next */
       debug(() => {
         if (!dep)
           throw new Error('no dep??')
       })
+
       tasks.push({edge, dep})
     }
 
@@ -870,7 +875,7 @@ This is a one-time fix-up, please be patient...
 
   // loads a node from an edge, and then loads its peer deps (and their
   // peer deps, on down the line) into a virtual root parent.
-  async [_nodeFromEdge] (edge, parent_, secondEdge = null) {
+  async [_nodeFromEdge] (edge, parent_, secondEdge, required) {
     // create a virtual root node with the same deps as the node that
     // is requesting this one, so that we can get all the peer deps in
     // a context where they're likely to be resolvable.
@@ -901,6 +906,11 @@ This is a one-time fix-up, please be patient...
     // ensure the one we want is the one that's placed
     node.parent = parent
 
+    if (required.has(edge.from) && edge.type !== 'peerOptional' ||
+        secondEdge && (
+          required.has(secondEdge.from) && secondEdge.type !== 'peerOptional'))
+      required.add(node)
+
     // handle otherwise unresolvable dependency nesting loops by
     // creating a symbolic link
     // a1 -> b1 -> a2 -> b2 -> a1 -> ...
@@ -914,7 +924,7 @@ This is a one-time fix-up, please be patient...
     // keep track of the thing that caused this node to be included.
     const src = parent.sourceReference
     this[_peerSetSource].set(node, src)
-    return this[_loadPeerSet](node)
+    return this[_loadPeerSet](node, required)
   }
 
   [_virtualRoot] (node, reuse = false) {
@@ -1059,7 +1069,7 @@ This is a one-time fix-up, please be patient...
   // gets placed first.  In non-strict mode, we behave strictly if the
   // virtual root is based on the root project, and allow non-peer parent
   // deps to override, but throw if no preference can be determined.
-  async [_loadPeerSet] (node) {
+  async [_loadPeerSet] (node, required) {
     const peerEdges = [...node.edgesOut.values()]
       // we typically only install non-optional peers, but we have to
       // factor them into the peerSet so that we can avoid conflicts
@@ -1074,10 +1084,12 @@ This is a one-time fix-up, please be patient...
       const parentEdge = node.parent.edgesOut.get(edge.name)
       const {isProjectRoot, isWorkspace} = node.parent.sourceReference
       const isMine = isProjectRoot || isWorkspace
+      const conflictOK = this[_force] || !isMine && !this[_strictPeerDeps]
+
       if (!edge.to) {
         if (!parentEdge) {
           // easy, just put the thing there
-          await this[_nodeFromEdge](edge, node.parent)
+          await this[_nodeFromEdge](edge, node.parent, null, required)
           continue
         } else {
           // if the parent's edge is very broad like >=1, and the edge in
@@ -1088,14 +1100,16 @@ This is a one-time fix-up, please be patient...
           // a conflict.  this is always a problem in strict mode, never
           // in force mode, and a problem in non-strict mode if this isn't
           // on behalf of our project.  in all such cases, we warn at least.
-          await this[_nodeFromEdge](parentEdge, node.parent, edge)
+          const dep = await this[_nodeFromEdge](parentEdge, node.parent, edge, required)
 
           // hooray! that worked!
           if (edge.valid)
             continue
 
-          // allow it
-          if (this[_force] || !isMine && !this[_strictPeerDeps])
+          // allow it.  either we're overriding, or it's not something
+          // that will be installed by default anyway, and we'll fail when
+          // we get to the point where we need to, if we need to.
+          if (conflictOK || !required.has(dep))
             continue
 
           // problem
@@ -1108,7 +1122,7 @@ This is a one-time fix-up, please be patient...
       // in non-strict mode if it's not our fault.  don't warn here, because
       // we are going to warn again when we place the deps, if we end up
       // overriding for something else.
-      if (this[_force] || !isMine && !this[_strictPeerDeps])
+      if (conflictOK)
         continue
 
       // ok, it's the root, or we're in unforced strict mode, so this is bad

--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -806,6 +806,7 @@ This is a one-time fix-up, please be patient...
       // a virtual root of whatever brought in THIS node.
       // so we VR the node itself if the edge is not a peer
       const source = edge.peer ? peerSource : node
+
       const virtualRoot = this[_virtualRoot](source, true)
       // reuse virtual root if we already have one, but don't
       // try to do the override ahead of time, since we MAY be able
@@ -827,8 +828,7 @@ This is a one-time fix-up, please be patient...
       // +-- z@1
       // But if x and y are loaded in the same virtual root, then they will
       // be forced to agree on a version of z.
-      const required = edge.type === 'peerOptional' ? new Set()
-        : new Set([edge.from])
+      const required = new Set([edge.from])
       const parent = edge.peer ? virtualRoot : null
       const dep = vrDep && vrDep.satisfies(edge) ? vrDep
         : await this[_nodeFromEdge](edge, parent, null, required)
@@ -1218,8 +1218,25 @@ This is a one-time fix-up, please be patient...
         break
     }
 
-    if (!target)
-      this[_failPeerConflict](edge)
+    // if we can't find a target, that means that the last placed checked
+    // (and all the places before it) had a copy already.  if we're in
+    // --force mode, then the user has explicitly said that they're ok
+    // with conflicts.  This can only occur in --force mode in the case
+    // when a node was added to the tree with a peerOptional dep that we
+    // ignored, and then later, that edge became invalid, and we fail to
+    // resolve it.  We will warn about it in a moment.
+    if (!target) {
+      if (this[_force]) {
+        // we know that there is a dep (not the root) which is the target
+        // of this edge, or else it wouldn't have been a conflict.
+        target = edge.to.resolveParent
+        canPlace = KEEP
+      } else
+        this[_failPeerConflict](edge)
+    } else {
+      // it worked, so we clearly have no peer conflicts at this point.
+      this[_peerConflict] = null
+    }
 
     this.log.silly(
       'placeDep',
@@ -1229,9 +1246,6 @@ This is a one-time fix-up, please be patient...
       `for: ${node.package._id || node.location}`,
       `want: ${edge.spec || '*'}`
     )
-
-    // it worked, so we clearly have no peer conflicts at this point.
-    this[_peerConflict] = null
 
     // Can only get KEEP here if the original edge was valid,
     // and we're checking for an update but it's already up to date.
@@ -1418,6 +1432,7 @@ This is a one-time fix-up, please be patient...
     })
     const entryEdge = peerEntryEdge || edge
     const source = this[_peerSetSource].get(dep)
+
     isSource = isSource || target === source
     // if we're overriding the source, then we care if the *target* is
     // ours, even if it wasn't actually the original source, since we

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -2480,3 +2480,17 @@ t.test('shrinkwrapped dev/optional deps should not clobber flags', t => {
 
   t.end()
 })
+
+t.test('do not ERESOLVE on peerOptionals that are ignored anyway', t => {
+  // this simulates three cases where a conflict occurs during the peerSet
+  // generation phase, but will not manifest in the tree building phase.
+  const base = resolve(fixtures, 'peer-optional-eresolve')
+  const cases = ['a', 'b', 'c']
+  t.plan(cases.length)
+  for (const c of cases) {
+    t.test(`case ${c}`, async t => {
+      const path = resolve(base, c)
+      t.matchSnapshot(await printIdeal(path))
+    })
+  }
+})

--- a/test/fixtures/conflicted-peer-optional-from-dev-dep/b/package.json
+++ b/test/fixtures/conflicted-peer-optional-from-dev-dep/b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@isaacs/conflicted-peer-optional-from-dev-dep-b",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/conflicted-peer-optional-from-dev-dep-peer": "2"
+  },
+  "peerDependenciesMeta": {
+    "@isaacs/conflicted-peer-optional-from-dev-dep-peer": {
+      "optional": true
+    }
+  }
+}

--- a/test/fixtures/conflicted-peer-optional-from-dev-dep/peer/1/package.json
+++ b/test/fixtures/conflicted-peer-optional-from-dev-dep/peer/1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/conflicted-peer-optional-from-dev-dep-peer",
+  "version": "1.0.0"
+}

--- a/test/fixtures/conflicted-peer-optional-from-dev-dep/peer/2/package.json
+++ b/test/fixtures/conflicted-peer-optional-from-dev-dep/peer/2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/conflicted-peer-optional-from-dev-dep-peer",
+  "version": "2.0.0"
+}

--- a/test/fixtures/peer-optional-eresolve/README.md
+++ b/test/fixtures/peer-optional-eresolve/README.md
@@ -1,0 +1,5 @@
+# peer optional failures
+
+Cases which incorrectly caused `ERESOLVE` warnings.
+
+[npm/arborist#223](https://github.com/npm/arborist/issues/223)

--- a/test/fixtures/peer-optional-eresolve/a/README.md
+++ b/test/fixtures/peer-optional-eresolve/a/README.md
@@ -1,0 +1,9 @@
+# peer optional failure A
+
+```
+root -> (x, y@1)
+x -> PEEROPTIONAL(z)
+z -> PEER(y@2)
+```
+
+[npm/arborist#223](https://github.com/npm/arborist/issues/223)

--- a/test/fixtures/peer-optional-eresolve/a/package.json
+++ b/test/fixtures/peer-optional-eresolve/a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-a",
+  "version": "1.0.0",
+  "dependencies": {
+    "@isaacs/testing-peer-optional-conflict-a-x": "1",
+    "@isaacs/testing-peer-optional-conflict-a-y": "1"
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/a/x/package.json
+++ b/test/fixtures/peer-optional-eresolve/a/x/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-a-x",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-optional-conflict-a-z": "1"
+  },
+  "peerDependenciesMeta": {
+    "@isaacs/testing-peer-optional-conflict-a-z": {
+      "optional": true
+    }
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/a/y/1/package.json
+++ b/test/fixtures/peer-optional-eresolve/a/y/1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-a-y",
+  "version": "1.0.0"
+}

--- a/test/fixtures/peer-optional-eresolve/a/y/2/package.json
+++ b/test/fixtures/peer-optional-eresolve/a/y/2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-a-y",
+  "version": "2.0.0"
+}

--- a/test/fixtures/peer-optional-eresolve/a/z/package.json
+++ b/test/fixtures/peer-optional-eresolve/a/z/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-a-z",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-optional-conflict-a-y": "2"
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/b/README.md
+++ b/test/fixtures/peer-optional-eresolve/b/README.md
@@ -1,0 +1,8 @@
+# peer optional failure b
+
+```
+root -> (x) PEEROPTIONAL(y@1)
+x -> PEEROPTIONAL(y@2)
+```
+
+[npm/arborist#223](https://github.com/npm/arborist/issues/223)

--- a/test/fixtures/peer-optional-eresolve/b/package.json
+++ b/test/fixtures/peer-optional-eresolve/b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-b",
+  "version": "1.0.0",
+  "dependencies": {
+    "@isaacs/testing-peer-optional-conflict-b-x": "1"
+  },
+  "peerDependencies": {
+    "@isaacs/testing-peer-optional-conflict-b-y": "1"
+  },
+  "peerDependenciesMeta": {
+    "@isaacs/testing-peer-optional-conflict-b-y": {
+      "optional": true
+    }
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/b/x/package.json
+++ b/test/fixtures/peer-optional-eresolve/b/x/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-b-x",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-optional-conflict-b-y": "2"
+  },
+  "peerDependenciesMeta": {
+    "@isaacs/testing-peer-optional-conflict-b-y": {
+      "optional": true
+    }
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/b/y/1/package.json
+++ b/test/fixtures/peer-optional-eresolve/b/y/1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-b-y",
+  "version": "1.0.0"
+}

--- a/test/fixtures/peer-optional-eresolve/b/y/2/package.json
+++ b/test/fixtures/peer-optional-eresolve/b/y/2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-b-y",
+  "version": "2.0.0"
+}

--- a/test/fixtures/peer-optional-eresolve/c/README.md
+++ b/test/fixtures/peer-optional-eresolve/c/README.md
@@ -1,0 +1,9 @@
+# peer optional failure c
+
+```
+root -> (x) PEEROPTIONAL(y@1)
+x -> PEER(z)
+z -> PEEROPTIONAL(y@2)
+```
+
+[npm/arborist#223](https://github.com/npm/arborist/issues/223)

--- a/test/fixtures/peer-optional-eresolve/c/package.json
+++ b/test/fixtures/peer-optional-eresolve/c/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-c",
+  "version": "1.0.0",
+  "dependencies": {
+    "@isaacs/testing-peer-optional-conflict-c-x": "1"
+  },
+  "peerDependencies": {
+    "@isaacs/testing-peer-optional-conflict-c-y": "1"
+  },
+  "peerDependenciesMeta": {
+    "@isaacs/testing-peer-optional-conflict-c-y": {
+      "optional": true
+    }
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/c/x/package.json
+++ b/test/fixtures/peer-optional-eresolve/c/x/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-c-x",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-optional-conflict-c-z": "1.0.0"
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/c/y/1/package.json
+++ b/test/fixtures/peer-optional-eresolve/c/y/1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-c-y",
+  "version": "1.0.0"
+}

--- a/test/fixtures/peer-optional-eresolve/c/y/2/package.json
+++ b/test/fixtures/peer-optional-eresolve/c/y/2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-c-y",
+  "version": "2.0.0"
+}

--- a/test/fixtures/peer-optional-eresolve/c/z/package.json
+++ b/test/fixtures/peer-optional-eresolve/c/z/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-c-z",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-optional-conflict-c-y": "2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@isaacs/testing-peer-optional-conflict-c-y": {
+      "optional": true
+    }
+  }
+}

--- a/test/fixtures/registry-mocks/content/isaacs/conflicted-peer-optional-from-dev-dep-b.json
+++ b/test/fixtures/registry-mocks/content/isaacs/conflicted-peer-optional-from-dev-dep-b.json
@@ -1,0 +1,61 @@
+{
+  "_id": "@isaacs/conflicted-peer-optional-from-dev-dep-b",
+  "name": "@isaacs/conflicted-peer-optional-from-dev-dep-b",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/conflicted-peer-optional-from-dev-dep-b",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/conflicted-peer-optional-from-dev-dep-peer": "2"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/conflicted-peer-optional-from-dev-dep-peer": {
+          "optional": true
+        }
+      },
+      "_id": "@isaacs/conflicted-peer-optional-from-dev-dep-b@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.3",
+      "dist": {
+        "integrity": "sha512-2rStqBkn1QSXBjweS4lHUPH9jt4ToFqkw2nUbWA4fZBxOaYS1nkS/ST70xRlQxRW+3UdTFGc+5xk187sHlMT/A==",
+        "shasum": "63f188dba7ec8a3e23b09540230ba8014ee760d2",
+        "tarball": "https://registry.npmjs.org/@isaacs/conflicted-peer-optional-from-dev-dep-b/-/conflicted-peer-optional-from-dev-dep-b-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 299,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgJI1ACRA9TVsSAnZWagAAbrMP+QHkDuGH+7Upc7vgCNGn\nh/BJ9oweduRP3C8DW4xviYVqUVYJdRtfN9NjA8DOA6RroecCaRONhiMPybz3\nD53u7QfKMAowj9z5KckriR8/RJ6v9EbFZWA3re/c3O6lNR8sZ0fPlw3VeOgq\nxuofI21+n3SQNDlD2N/fK8YRGkqgx4QI90IF0gb5q1k56cFP7DAqAHnRaxk9\nZ60SA8iv/lYu60+bGrnozv4H1qn6VM9m2hm/284H+HkGMOCBXSLpPLu6N1oJ\nNBy0rrp+5nhHHizWxEtTeI7xMds59p9IjMXMHSyVjnKakPYqLXeyda/dceCM\naqx5KFVyiJV+fcnqJgjgjbOLnE4+Xaz3PcSrYOfThSPgAvQBeOWk9vh0Wmuf\nMHpoONZt7NSI3ZBEbJuELpaFRO94bqaZgLqJIxDd8CiYmnbBQnOTWdzWFmCU\nQxFkwkOdQFE2oGkRRocRuWK2oD+aNegW48/tR2ckIp8apKOz9xGyL7suWmdO\n6RjCoq+9LFQJLb4q3J+ebRKD4GP0vXWHbNr/pEEPdgJI3X3q0s3jn5ig2gvU\nLj/oEkXoiPgeOvqX2n53tRtWen8Zw/hRtk06tMBUPzdg5LbGON24F7aklIrU\nCdMZwtbk/LwKXU+8bJlhTl63YB8+qoYKC7WnCqxcTvFyxZobT7FPTnGSO0wE\nHGT/\r\n=wnoR\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/conflicted-peer-optional-from-dev-dep-b_1.0.0_1613008191679_0.24514239505031288"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-11T01:49:51.620Z",
+    "1.0.0": "2021-02-11T01:49:51.832Z",
+    "modified": "2021-02-11T01:49:54.757Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/conflicted-peer-optional-from-dev-dep-b.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/conflicted-peer-optional-from-dev-dep-b.min.json
@@ -1,0 +1,29 @@
+{
+  "name": "@isaacs/conflicted-peer-optional-from-dev-dep-b",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/conflicted-peer-optional-from-dev-dep-b",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/conflicted-peer-optional-from-dev-dep-peer": "2"
+      },
+      "dist": {
+        "integrity": "sha512-2rStqBkn1QSXBjweS4lHUPH9jt4ToFqkw2nUbWA4fZBxOaYS1nkS/ST70xRlQxRW+3UdTFGc+5xk187sHlMT/A==",
+        "shasum": "63f188dba7ec8a3e23b09540230ba8014ee760d2",
+        "tarball": "https://registry.npmjs.org/@isaacs/conflicted-peer-optional-from-dev-dep-b/-/conflicted-peer-optional-from-dev-dep-b-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 299,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgJI1ACRA9TVsSAnZWagAAbrMP+QHkDuGH+7Upc7vgCNGn\nh/BJ9oweduRP3C8DW4xviYVqUVYJdRtfN9NjA8DOA6RroecCaRONhiMPybz3\nD53u7QfKMAowj9z5KckriR8/RJ6v9EbFZWA3re/c3O6lNR8sZ0fPlw3VeOgq\nxuofI21+n3SQNDlD2N/fK8YRGkqgx4QI90IF0gb5q1k56cFP7DAqAHnRaxk9\nZ60SA8iv/lYu60+bGrnozv4H1qn6VM9m2hm/284H+HkGMOCBXSLpPLu6N1oJ\nNBy0rrp+5nhHHizWxEtTeI7xMds59p9IjMXMHSyVjnKakPYqLXeyda/dceCM\naqx5KFVyiJV+fcnqJgjgjbOLnE4+Xaz3PcSrYOfThSPgAvQBeOWk9vh0Wmuf\nMHpoONZt7NSI3ZBEbJuELpaFRO94bqaZgLqJIxDd8CiYmnbBQnOTWdzWFmCU\nQxFkwkOdQFE2oGkRRocRuWK2oD+aNegW48/tR2ckIp8apKOz9xGyL7suWmdO\n6RjCoq+9LFQJLb4q3J+ebRKD4GP0vXWHbNr/pEEPdgJI3X3q0s3jn5ig2gvU\nLj/oEkXoiPgeOvqX2n53tRtWen8Zw/hRtk06tMBUPzdg5LbGON24F7aklIrU\nCdMZwtbk/LwKXU+8bJlhTl63YB8+qoYKC7WnCqxcTvFyxZobT7FPTnGSO0wE\nHGT/\r\n=wnoR\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/conflicted-peer-optional-from-dev-dep-peer": {
+          "optional": true
+        }
+      }
+    }
+  },
+  "modified": "2021-02-11T01:49:54.757Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/conflicted-peer-optional-from-dev-dep-peer.json
+++ b/test/fixtures/registry-mocks/content/isaacs/conflicted-peer-optional-from-dev-dep-peer.json
@@ -1,0 +1,86 @@
+{
+  "_id": "@isaacs/conflicted-peer-optional-from-dev-dep-peer",
+  "_rev": "1-1a8e917429566dc7ed1fb9b8fd70bb6f",
+  "name": "@isaacs/conflicted-peer-optional-from-dev-dep-peer",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/conflicted-peer-optional-from-dev-dep-peer",
+      "version": "1.0.0",
+      "_id": "@isaacs/conflicted-peer-optional-from-dev-dep-peer@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.3",
+      "dist": {
+        "integrity": "sha512-aigW1kh3zkxch1C45Fkl4Xzb5pScrV3NoXefGffNArG+S/etd2vmrPXm4G6SFwwPgIcmlygsVgp4TkrAqGjqvg==",
+        "shasum": "2aae82d451c3683c60779fdf10d437d5425fd363",
+        "tarball": "https://registry.npmjs.org/@isaacs/conflicted-peer-optional-from-dev-dep-peer/-/conflicted-peer-optional-from-dev-dep-peer-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 89,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgJI1ECRA9TVsSAnZWagAAecUP/jgRv7bsxpJEQPHhDxEc\n0zcya5koI2VYrgVWbE9kmO0sXg8lyQCMJKLq29gjXsN1O9jiaYsgi0xVsB/G\nWfL8/MyqFGP+WRlnGsWes63WNHa9IKOVnFDbzkwhDjLId4ZFKUuDQ6N3ZJTQ\nqy/jeXrdz2tdT0Y4rfjdTGBnNJWZyf78A3ESjDmf5K0g7hhEtdU1B1bLfOOb\nY7uS8ab7lR5SsW65vn7aoaL8kxQC9Q4a7KNb/PpvxchIUMrAyVQAx85tK9ct\nPuE7Sd6x0JyHV/y5gjeJqzwjA7FqgRS6stdu1287YXqy7RKDvdbHdXM4TAqY\nlUbB+Kp7dMzoQM+OwP9NEny+axBilAYLHIHTgF995YveBodWUr/4o+ZA7RQp\ncUdjz6hJCNvQHpPNHVfTxvn2tHa/Gd9Rk7Lk52MhLcREDnKvL6lktgZ/cJOy\nOW2pBeoOEEhPQWzVTp2ugYNHeFDVqqUP647qZ1nu8qfhzrCo38WR6enGJpgs\n0NJtxwtxLkTOU7j7mnd0D8SPZIK3NI9ackKb6RhJ6mzURwPjTsmMrxWpCIoV\n+aMNt9ugfYOx3wi4z5tHxjkjS3lFvFJCWdR9N3Et8qWMoTeDZFLkQKihrxdT\na9YG58zvQyRLvtE3OrN2lCZw36ftSWVDCKCIM8VqGn4s64KE8LzRph3mW5EI\nkd2m\r\n=Q9LN\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/conflicted-peer-optional-from-dev-dep-peer_1.0.0_1613008195871_0.9488799085098012"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@isaacs/conflicted-peer-optional-from-dev-dep-peer",
+      "version": "2.0.0",
+      "_id": "@isaacs/conflicted-peer-optional-from-dev-dep-peer@2.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.3",
+      "dist": {
+        "integrity": "sha512-N/Bg11JKWel/PTOVDt89oQ3fw569d4h5bLkElozWaFkJ9qH7m05VY1L1Kfjik8sB+Bi8HnBS4JkP8F8VC1QHsw==",
+        "shasum": "cf64ce16c0cfe78c3c7b97c38a00d459b88d89a3",
+        "tarball": "https://registry.npmjs.org/@isaacs/conflicted-peer-optional-from-dev-dep-peer/-/conflicted-peer-optional-from-dev-dep-peer-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 89,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgJI1HCRA9TVsSAnZWagAAi94P/3sAxX8bVi5N+F+ZFY3W\nz9berGe2gT6Nt0vT6DHlMuIVqoW8EyrH+ZzB7hY1Ez/ws1D8doR/au17dMyQ\nSP0+gZHi3Jb1PAHdOlhh9mq8uc7GHKxoHRBvK9P763TPXwbLE0Rhb/2jqpP2\nLultq3+xM1GpmIKxPAf5bZ2v1StmfgKFww/FV+5UgAyumnz+lFlhDOoj3NoK\nGAFdBmiEnVnJ0lhMesv4iNBa+KYItR4y7EmLIHDaLfvumqT14tOSavhnSvRt\nTS7TL+UcKuru8fR2ZWrkms+zA6kjOF1nYzZDOq/zJ2LNJa9H7idoOyXQHPNR\nXieOWjq0AnfS8X23ogRBwKkf1wyfSnZe2VVXB7fF/T+l2WBEXI+b1jEb+oGE\n5ix1EGZJBwi0jYimUmaBVgjgNGy8+d365i22ymvM7P++HDi4w4Kk+LtG+gK8\nqFuloNfHBFvNFw5/wvmnVhQxx3bRGSwWLwhP2sgquH+BcXa+C+W0MAa3WF+A\n1hQmP6T/rfdPo8CKmuHrPVHrFslrZC81zLwWynb0ea6zLvHdwx+f+9oENcrp\n4WirMDZPwQvDlsIvQiRPbPinADomAkdDpmOfUn1O9N4o3E3ckgldbyzL9vOb\nPR4bO04F9eNo9jXx2pqeBLKB/V+0BhLz1a/uoi+Pk1s7wJq7IJ7iPw60vzld\nNOEm\r\n=vQNY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/conflicted-peer-optional-from-dev-dep-peer_2.0.0_1613008199324_0.776370650758518"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-11T01:49:55.832Z",
+    "1.0.0": "2021-02-11T01:49:55.989Z",
+    "modified": "2021-02-11T01:50:01.651Z",
+    "2.0.0": "2021-02-11T01:49:59.462Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/conflicted-peer-optional-from-dev-dep-peer.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/conflicted-peer-optional-from-dev-dep-peer.min.json
@@ -1,0 +1,33 @@
+{
+  "name": "@isaacs/conflicted-peer-optional-from-dev-dep-peer",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/conflicted-peer-optional-from-dev-dep-peer",
+      "version": "1.0.0",
+      "dist": {
+        "integrity": "sha512-aigW1kh3zkxch1C45Fkl4Xzb5pScrV3NoXefGffNArG+S/etd2vmrPXm4G6SFwwPgIcmlygsVgp4TkrAqGjqvg==",
+        "shasum": "2aae82d451c3683c60779fdf10d437d5425fd363",
+        "tarball": "https://registry.npmjs.org/@isaacs/conflicted-peer-optional-from-dev-dep-peer/-/conflicted-peer-optional-from-dev-dep-peer-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 89,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgJI1ECRA9TVsSAnZWagAAecUP/jgRv7bsxpJEQPHhDxEc\n0zcya5koI2VYrgVWbE9kmO0sXg8lyQCMJKLq29gjXsN1O9jiaYsgi0xVsB/G\nWfL8/MyqFGP+WRlnGsWes63WNHa9IKOVnFDbzkwhDjLId4ZFKUuDQ6N3ZJTQ\nqy/jeXrdz2tdT0Y4rfjdTGBnNJWZyf78A3ESjDmf5K0g7hhEtdU1B1bLfOOb\nY7uS8ab7lR5SsW65vn7aoaL8kxQC9Q4a7KNb/PpvxchIUMrAyVQAx85tK9ct\nPuE7Sd6x0JyHV/y5gjeJqzwjA7FqgRS6stdu1287YXqy7RKDvdbHdXM4TAqY\nlUbB+Kp7dMzoQM+OwP9NEny+axBilAYLHIHTgF995YveBodWUr/4o+ZA7RQp\ncUdjz6hJCNvQHpPNHVfTxvn2tHa/Gd9Rk7Lk52MhLcREDnKvL6lktgZ/cJOy\nOW2pBeoOEEhPQWzVTp2ugYNHeFDVqqUP647qZ1nu8qfhzrCo38WR6enGJpgs\n0NJtxwtxLkTOU7j7mnd0D8SPZIK3NI9ackKb6RhJ6mzURwPjTsmMrxWpCIoV\n+aMNt9ugfYOx3wi4z5tHxjkjS3lFvFJCWdR9N3Et8qWMoTeDZFLkQKihrxdT\na9YG58zvQyRLvtE3OrN2lCZw36ftSWVDCKCIM8VqGn4s64KE8LzRph3mW5EI\nkd2m\r\n=Q9LN\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "@isaacs/conflicted-peer-optional-from-dev-dep-peer",
+      "version": "2.0.0",
+      "dist": {
+        "integrity": "sha512-N/Bg11JKWel/PTOVDt89oQ3fw569d4h5bLkElozWaFkJ9qH7m05VY1L1Kfjik8sB+Bi8HnBS4JkP8F8VC1QHsw==",
+        "shasum": "cf64ce16c0cfe78c3c7b97c38a00d459b88d89a3",
+        "tarball": "https://registry.npmjs.org/@isaacs/conflicted-peer-optional-from-dev-dep-peer/-/conflicted-peer-optional-from-dev-dep-peer-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 89,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgJI1HCRA9TVsSAnZWagAAi94P/3sAxX8bVi5N+F+ZFY3W\nz9berGe2gT6Nt0vT6DHlMuIVqoW8EyrH+ZzB7hY1Ez/ws1D8doR/au17dMyQ\nSP0+gZHi3Jb1PAHdOlhh9mq8uc7GHKxoHRBvK9P763TPXwbLE0Rhb/2jqpP2\nLultq3+xM1GpmIKxPAf5bZ2v1StmfgKFww/FV+5UgAyumnz+lFlhDOoj3NoK\nGAFdBmiEnVnJ0lhMesv4iNBa+KYItR4y7EmLIHDaLfvumqT14tOSavhnSvRt\nTS7TL+UcKuru8fR2ZWrkms+zA6kjOF1nYzZDOq/zJ2LNJa9H7idoOyXQHPNR\nXieOWjq0AnfS8X23ogRBwKkf1wyfSnZe2VVXB7fF/T+l2WBEXI+b1jEb+oGE\n5ix1EGZJBwi0jYimUmaBVgjgNGy8+d365i22ymvM7P++HDi4w4Kk+LtG+gK8\nqFuloNfHBFvNFw5/wvmnVhQxx3bRGSwWLwhP2sgquH+BcXa+C+W0MAa3WF+A\n1hQmP6T/rfdPo8CKmuHrPVHrFslrZC81zLwWynb0ea6zLvHdwx+f+9oENcrp\n4WirMDZPwQvDlsIvQiRPbPinADomAkdDpmOfUn1O9N4o3E3ckgldbyzL9vOb\nPR4bO04F9eNo9jXx2pqeBLKB/V+0BhLz1a/uoi+Pk1s7wJq7IJ7iPw60vzld\nNOEm\r\n=vQNY\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-02-11T01:50:01.651Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-a-x.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-a-x.json
@@ -1,0 +1,61 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-a-x",
+  "name": "@isaacs/testing-peer-optional-conflict-a-x",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-a-x",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-a-z": "1"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/testing-peer-optional-conflict-a-z": {
+          "optional": true
+        }
+      },
+      "_id": "@isaacs/testing-peer-optional-conflict-a-x@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.3",
+      "dist": {
+        "integrity": "sha512-GYIjOCQ5BFWl0caylWvjYOLrs0JZq0SkAY0WhNegXPXehob14/DjVD3LxwUWIKzgbhfr345ig46H0jFEmdV66Q==",
+        "shasum": "180429a1c399a06d13fb89d432ab4d944e185c0f",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-a-x/-/testing-peer-optional-conflict-a-x-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 278,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYQCRA9TVsSAnZWagAA+zAP/3gaZXWUMVIa38I7432G\nZ1kkLgmmAD/xe73r6JImY2Zo+TD1i0AJX62dyvPn4IO7CaJk+aIF+qt9Uuki\nIT/URVTzglLl2f3eo8purQBBKrcssJaHJAab5CdybEJ207MTqaUAInOkx57w\nERk2Wx0HkbJQ/yaE8Bu5U+DuX84fYAx2igk3/gjuPaXYZHW43x5sOuzpltCG\nwoaNxAh32v8Z3iYh32kPB1iW/5+FRYbnvxgRFZazkNgHQ5pcws/H0to//JJI\nDd3p9Vz69SnnNvjREZjdX+qGa9dVb2SR+bR+bJiNqcc/OC4Foz755lkDEC6+\nGS/Us5H2+CTq7JG6PkTkWuO4khos3MUIE18duaHupYHVhkVXW4QwoHIAQRty\nOGotmR3x8QxS3K2pzhKRxuJP9QMo2SHVRgLztQYK7DZaYEml0xzTVRF4G99p\nnDdZR46/9uHN5aAC6iFxZv/v2GUIYlIxISfAAYz33sS8i///vqeiUFG1/d/o\nfdloO9lSswWxq/qJ7UmfLaQba/C5GssMeT8JKE18Fzwzsy5RiVhDsoilF4+w\nrVIbk0CFfrZUANjdHzWIltEKOpBpDv0NOepl7k656eluWjNLCZ3FiK8Drahb\nSUASWIQUo6GY4KPceFh70R556sQMbPifBsFuj1Bjgnh6QTffnETfmjMloCbk\nOFnm\r\n=GZw5\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-a-x_1.0.0_1612916239858_0.23000580254330338"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-10T00:17:19.796Z",
+    "1.0.0": "2021-02-10T00:17:19.969Z",
+    "modified": "2021-02-10T00:17:22.717Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-a-x.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-a-x.min.json
@@ -1,0 +1,29 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-a-x",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-a-x",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-a-z": "1"
+      },
+      "dist": {
+        "integrity": "sha512-GYIjOCQ5BFWl0caylWvjYOLrs0JZq0SkAY0WhNegXPXehob14/DjVD3LxwUWIKzgbhfr345ig46H0jFEmdV66Q==",
+        "shasum": "180429a1c399a06d13fb89d432ab4d944e185c0f",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-a-x/-/testing-peer-optional-conflict-a-x-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 278,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYQCRA9TVsSAnZWagAA+zAP/3gaZXWUMVIa38I7432G\nZ1kkLgmmAD/xe73r6JImY2Zo+TD1i0AJX62dyvPn4IO7CaJk+aIF+qt9Uuki\nIT/URVTzglLl2f3eo8purQBBKrcssJaHJAab5CdybEJ207MTqaUAInOkx57w\nERk2Wx0HkbJQ/yaE8Bu5U+DuX84fYAx2igk3/gjuPaXYZHW43x5sOuzpltCG\nwoaNxAh32v8Z3iYh32kPB1iW/5+FRYbnvxgRFZazkNgHQ5pcws/H0to//JJI\nDd3p9Vz69SnnNvjREZjdX+qGa9dVb2SR+bR+bJiNqcc/OC4Foz755lkDEC6+\nGS/Us5H2+CTq7JG6PkTkWuO4khos3MUIE18duaHupYHVhkVXW4QwoHIAQRty\nOGotmR3x8QxS3K2pzhKRxuJP9QMo2SHVRgLztQYK7DZaYEml0xzTVRF4G99p\nnDdZR46/9uHN5aAC6iFxZv/v2GUIYlIxISfAAYz33sS8i///vqeiUFG1/d/o\nfdloO9lSswWxq/qJ7UmfLaQba/C5GssMeT8JKE18Fzwzsy5RiVhDsoilF4+w\nrVIbk0CFfrZUANjdHzWIltEKOpBpDv0NOepl7k656eluWjNLCZ3FiK8Drahb\nSUASWIQUo6GY4KPceFh70R556sQMbPifBsFuj1Bjgnh6QTffnETfmjMloCbk\nOFnm\r\n=GZw5\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/testing-peer-optional-conflict-a-z": {
+          "optional": true
+        }
+      }
+    }
+  },
+  "modified": "2021-02-10T00:17:22.717Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-a-y.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-a-y.json
@@ -1,0 +1,86 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-a-y",
+  "_rev": "1-17db572f96e0023895da3fd869062a88",
+  "name": "@isaacs/testing-peer-optional-conflict-a-y",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-a-y",
+      "version": "1.0.0",
+      "_id": "@isaacs/testing-peer-optional-conflict-a-y@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.3",
+      "dist": {
+        "integrity": "sha512-v8/s8BZTLE28MF+s+Mh9IgGsnM68xkZm1Gy3GjXwEoMmUKmhZdVq+s4AgyE5zvMjKwNXStLzfLlI0fm5mbmUUw==",
+        "shasum": "d1f6f1c95396263891d7a1158b8be9ae7f44e3f0",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-a-y/-/testing-peer-optional-conflict-a-y-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYUCRA9TVsSAnZWagAAbIgQAIQEFNjXKq6CPg75FEBs\nmmw70efdiFgy+EXOyDhp22ES6gyupbNjjYT2g8cGdtkIpgUiI3HRUFv0hKqA\nsAdqDgbsbZIREMdNcaCux9TBw0yXKQc/Bvv2F0R/j5imJbceuU77LzC1H8rQ\nnnVDO9PxRYcHVnr8/Hezv6Go9dZmM6D4TISXpdG9xoVULwWuYProea56kdNY\npt915qEL8H4l39uLAZmP3dL0riQS2hTdE//1x2G7mmSpm/yt3w2y82Y2S4/N\nPV+dFWCxo9rDb37aT9n+tv76kWSihBTLK93HLFJnSUT1f5uTMMlGJgjJX0L5\nAdfxvYG+yY/9VC98cYvOHz4lUs4P3sAq444YLESoh5CUxudMsyy7RPkk9e21\nY+i7EerEpIQsgKrLvBZENe2gknAqPwmrfp9bwhwIHvKA9ZfuoRGHm9do55Uz\nWEFqDxq1nb8yIdE5xaqpReZrR/oY0Jt0Krzbo/yTqtKvWAxUf2wURxIlLuKb\ntBSCnWTDwGnMH/mYRRf5Jy8hZK0+ip9l0sHUYmYBbWJfCmDk6g6LdUMvnAyp\nZV1zJdIR5m05IxEwjcDvUER7nPrVjRw3lWb9PCi1qjCygj7Mp/0b2tgdgwx5\n0m3MreZXe57USWNIsEqyu1G2JW82TfVaO2LanS+QXjNbWhqkSR8DZ0Igo+kN\nkQms\r\n=yjiE\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-a-y_1.0.0_1612916243650_0.4011117562042925"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-a-y",
+      "version": "2.0.0",
+      "_id": "@isaacs/testing-peer-optional-conflict-a-y@2.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.3",
+      "dist": {
+        "integrity": "sha512-5T3FvqDzt+FsWm/+j2l08gLX5yfCWhS6v2RUOQRASPhJ99K1NSdJaY8dQWIARcWNVTL0yTJg2TJ8/8LqXL+CPA==",
+        "shasum": "ef6d8b932ae6ff6c7b40dd2ae7532a1edf0d156c",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-a-y/-/testing-peer-optional-conflict-a-y-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYXCRA9TVsSAnZWagAAw5QP/RjNdA6zzIWaD9N6Nimm\n9wJmlP5WgTL2hwCTerh/aAgy/TiZH/cm8BTgepdCvL+NXbP6sNlIcH3kr8MF\nRmfWf3DwWGpDyZpb+n4n517l2C3s+ujhwqZ+KEZfIB1cNjr4PgXF2xaa8yGz\nlooMg9FeY2nht0FilZ1FceErbMpcPN/9aB1Lx2d9yxm+0EJ9q7U1yOhP318+\nKvgLDU4Z8JS4liaYm3PNwHrxRqo2rFTSustLvaRY9c/jkjqvi57vU5qjuK5h\nMHQigiHpl/BZPUXON7KMx9Z6jlxLYOOZ1xKB4ZLHtkMGNT8GfgkqZUIcocfG\nyo0EtcmqvdyX5nS1h1RcZPakQf4TU9TG15qyDmAlznE+HI3dGBqafVQKYqrZ\nmIU2hAvT+rQCEuBNoztipx5XZ+gVvGg+8fFMAC7uDpHRhSL9diGjjvWNH0aH\nLLZF9sZutow17fJw881oTFutgcuG7CguJlIR60nldv6McAFS3ZeOE5gyntsE\na0LLY6/NK5qtYSXqfSMlNykECIzipjAcJ+7X3hoUXzbIKOK5ickno70DTybW\nGJq2iU9/f/OF5t753V8d6CL1T9P57pu8CS0qSHzn+VevptABrGEdsNp7FH5w\nHI567IHgrw24xFHJU4Vbyt+GmXEitk54nG+IvgYw35kxPaQ0hs7Frcb3w9Pr\n/28I\r\n=SRHz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-a-y_2.0.0_1612916246720_0.5590377643511333"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-10T00:17:23.615Z",
+    "1.0.0": "2021-02-10T00:17:23.758Z",
+    "modified": "2021-02-10T00:17:29.293Z",
+    "2.0.0": "2021-02-10T00:17:26.882Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-a-y.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-a-y.min.json
@@ -1,0 +1,33 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-a-y",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-a-y",
+      "version": "1.0.0",
+      "dist": {
+        "integrity": "sha512-v8/s8BZTLE28MF+s+Mh9IgGsnM68xkZm1Gy3GjXwEoMmUKmhZdVq+s4AgyE5zvMjKwNXStLzfLlI0fm5mbmUUw==",
+        "shasum": "d1f6f1c95396263891d7a1158b8be9ae7f44e3f0",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-a-y/-/testing-peer-optional-conflict-a-y-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYUCRA9TVsSAnZWagAAbIgQAIQEFNjXKq6CPg75FEBs\nmmw70efdiFgy+EXOyDhp22ES6gyupbNjjYT2g8cGdtkIpgUiI3HRUFv0hKqA\nsAdqDgbsbZIREMdNcaCux9TBw0yXKQc/Bvv2F0R/j5imJbceuU77LzC1H8rQ\nnnVDO9PxRYcHVnr8/Hezv6Go9dZmM6D4TISXpdG9xoVULwWuYProea56kdNY\npt915qEL8H4l39uLAZmP3dL0riQS2hTdE//1x2G7mmSpm/yt3w2y82Y2S4/N\nPV+dFWCxo9rDb37aT9n+tv76kWSihBTLK93HLFJnSUT1f5uTMMlGJgjJX0L5\nAdfxvYG+yY/9VC98cYvOHz4lUs4P3sAq444YLESoh5CUxudMsyy7RPkk9e21\nY+i7EerEpIQsgKrLvBZENe2gknAqPwmrfp9bwhwIHvKA9ZfuoRGHm9do55Uz\nWEFqDxq1nb8yIdE5xaqpReZrR/oY0Jt0Krzbo/yTqtKvWAxUf2wURxIlLuKb\ntBSCnWTDwGnMH/mYRRf5Jy8hZK0+ip9l0sHUYmYBbWJfCmDk6g6LdUMvnAyp\nZV1zJdIR5m05IxEwjcDvUER7nPrVjRw3lWb9PCi1qjCygj7Mp/0b2tgdgwx5\n0m3MreZXe57USWNIsEqyu1G2JW82TfVaO2LanS+QXjNbWhqkSR8DZ0Igo+kN\nkQms\r\n=yjiE\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-a-y",
+      "version": "2.0.0",
+      "dist": {
+        "integrity": "sha512-5T3FvqDzt+FsWm/+j2l08gLX5yfCWhS6v2RUOQRASPhJ99K1NSdJaY8dQWIARcWNVTL0yTJg2TJ8/8LqXL+CPA==",
+        "shasum": "ef6d8b932ae6ff6c7b40dd2ae7532a1edf0d156c",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-a-y/-/testing-peer-optional-conflict-a-y-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYXCRA9TVsSAnZWagAAw5QP/RjNdA6zzIWaD9N6Nimm\n9wJmlP5WgTL2hwCTerh/aAgy/TiZH/cm8BTgepdCvL+NXbP6sNlIcH3kr8MF\nRmfWf3DwWGpDyZpb+n4n517l2C3s+ujhwqZ+KEZfIB1cNjr4PgXF2xaa8yGz\nlooMg9FeY2nht0FilZ1FceErbMpcPN/9aB1Lx2d9yxm+0EJ9q7U1yOhP318+\nKvgLDU4Z8JS4liaYm3PNwHrxRqo2rFTSustLvaRY9c/jkjqvi57vU5qjuK5h\nMHQigiHpl/BZPUXON7KMx9Z6jlxLYOOZ1xKB4ZLHtkMGNT8GfgkqZUIcocfG\nyo0EtcmqvdyX5nS1h1RcZPakQf4TU9TG15qyDmAlznE+HI3dGBqafVQKYqrZ\nmIU2hAvT+rQCEuBNoztipx5XZ+gVvGg+8fFMAC7uDpHRhSL9diGjjvWNH0aH\nLLZF9sZutow17fJw881oTFutgcuG7CguJlIR60nldv6McAFS3ZeOE5gyntsE\na0LLY6/NK5qtYSXqfSMlNykECIzipjAcJ+7X3hoUXzbIKOK5ickno70DTybW\nGJq2iU9/f/OF5t753V8d6CL1T9P57pu8CS0qSHzn+VevptABrGEdsNp7FH5w\nHI567IHgrw24xFHJU4Vbyt+GmXEitk54nG+IvgYw35kxPaQ0hs7Frcb3w9Pr\n/28I\r\n=SRHz\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-02-10T00:17:29.293Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-a-z.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-a-z.json
@@ -1,0 +1,56 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-a-z",
+  "name": "@isaacs/testing-peer-optional-conflict-a-z",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-a-z",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-a-y": "2"
+      },
+      "_id": "@isaacs/testing-peer-optional-conflict-a-z@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.3",
+      "dist": {
+        "integrity": "sha512-/0JuUS4gMtsbRPDPaskOCUaSYmm6vunbU5A51y7YLyb6Agnwr8j8h2jHLMSxkSHZZLgZs6fRpQDSQeu5umAq1w==",
+        "shasum": "1fcad6706e52048b74e98642c9526d691897879f",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-a-z/-/testing-peer-optional-conflict-a-z-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 164,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYaCRA9TVsSAnZWagAAKfAP/2yWA9yPMb2WVBouSd90\nM62QrKivhOzWehteT6BnfN4tSD1sB+WNDdXL4sUIb8+33GFE2gvmk/fA2m38\nIuR4kdXIjfrt2+SfnSYxPcJAeigHyF8xjBpWFBkDWhBcV7/UKjnozvzBE1Yh\n+Z6m8WEG58guxc96i/ayK/l8OSBVFm+oGNVHCCCo4YPKwREvPZaEMpgLJd+S\n4XRvEaPm1K8DfYSH83RxZaGxuV8WHPfFxc42xWEOMTJ2Tqmg/y4fnts7w/BI\nCtcTK5s92UNqfgcp04KQbBr3k+zKEy9MHWhHcBlGlntpfAVQ8b4phPWqST9K\nJjl6rTD6Mb/L5oFZEehb5xQ+4MRU6eGJiMzSMQ2kNyAkhp6LIyO1bmifaYKB\ns47gkYIBiJGoxFMmeFhHgti6jl1+6IpNV9TUP9/sZjy2IrKlB7e/KkVaRsk1\n+l70ZJVZJiT4NyINLxG0d5dZrs8roPmGPEF6FFEYZBsat3jwgQVCDffG0kVb\nCNgyy38gibNpqxO6Nxiz1ypzp1qtX6Pu5nZCjPo8vmrBcTFK5zd6U4yHegW7\nARIF7dFssCWCqUR7y6u5aThYj6bFNX2r0dHuygqp32DS7xEsNmbIjDt3YkKB\nzaoIzlxQ1GHayxUxK6j5aSx5js5TuPrxxcsR+zAOCJpoLmt/G5XYKV3iyr0t\na+0S\r\n=DP7f\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-a-z_1.0.0_1612916250343_0.5616989215394574"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-10T00:17:30.308Z",
+    "1.0.0": "2021-02-10T00:17:30.451Z",
+    "modified": "2021-02-10T00:17:33.150Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-a-z.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-a-z.min.json
@@ -1,0 +1,24 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-a-z",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-a-z",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-a-y": "2"
+      },
+      "dist": {
+        "integrity": "sha512-/0JuUS4gMtsbRPDPaskOCUaSYmm6vunbU5A51y7YLyb6Agnwr8j8h2jHLMSxkSHZZLgZs6fRpQDSQeu5umAq1w==",
+        "shasum": "1fcad6706e52048b74e98642c9526d691897879f",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-a-z/-/testing-peer-optional-conflict-a-z-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 164,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYaCRA9TVsSAnZWagAAKfAP/2yWA9yPMb2WVBouSd90\nM62QrKivhOzWehteT6BnfN4tSD1sB+WNDdXL4sUIb8+33GFE2gvmk/fA2m38\nIuR4kdXIjfrt2+SfnSYxPcJAeigHyF8xjBpWFBkDWhBcV7/UKjnozvzBE1Yh\n+Z6m8WEG58guxc96i/ayK/l8OSBVFm+oGNVHCCCo4YPKwREvPZaEMpgLJd+S\n4XRvEaPm1K8DfYSH83RxZaGxuV8WHPfFxc42xWEOMTJ2Tqmg/y4fnts7w/BI\nCtcTK5s92UNqfgcp04KQbBr3k+zKEy9MHWhHcBlGlntpfAVQ8b4phPWqST9K\nJjl6rTD6Mb/L5oFZEehb5xQ+4MRU6eGJiMzSMQ2kNyAkhp6LIyO1bmifaYKB\ns47gkYIBiJGoxFMmeFhHgti6jl1+6IpNV9TUP9/sZjy2IrKlB7e/KkVaRsk1\n+l70ZJVZJiT4NyINLxG0d5dZrs8roPmGPEF6FFEYZBsat3jwgQVCDffG0kVb\nCNgyy38gibNpqxO6Nxiz1ypzp1qtX6Pu5nZCjPo8vmrBcTFK5zd6U4yHegW7\nARIF7dFssCWCqUR7y6u5aThYj6bFNX2r0dHuygqp32DS7xEsNmbIjDt3YkKB\nzaoIzlxQ1GHayxUxK6j5aSx5js5TuPrxxcsR+zAOCJpoLmt/G5XYKV3iyr0t\na+0S\r\n=DP7f\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-02-10T00:17:33.150Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-b-x.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-b-x.json
@@ -1,0 +1,61 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-b-x",
+  "name": "@isaacs/testing-peer-optional-conflict-b-x",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-b-x",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-b-y": "2"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/testing-peer-optional-conflict-b-y": {
+          "optional": true
+        }
+      },
+      "_id": "@isaacs/testing-peer-optional-conflict-b-x@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.3",
+      "dist": {
+        "integrity": "sha512-19feHJAqq5HG2RrN2zHXiPXujXqHgJuGyZaKFolghgYKyncZYRpBwxboSDgMp8SxyrGx9EF74x6yarrVXRo9hw==",
+        "shasum": "d055ce82184b766154c5ce3523c06d430a7575ea",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-b-x/-/testing-peer-optional-conflict-b-x-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 278,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYjCRA9TVsSAnZWagAAJsYQAI6TiTI+kYscTluu8wvs\nKND0Wv+Zo3QU3cIbX55igi47+K+mnCWZzH6/jwhvWb3fvCMlzzvqeUEgLJ1q\nRGodgk1fZzbafhHUTq1U5cunMiHlGGBHypvgZRJzmMqKW89qwDIX7ZFc+V/s\nR0Mk8Cg6rpwVA25656FEVt8FXgMS2hQgTNFAESp3l8e3umInJN867en/qGNO\nRLPYv3bfNFG/JfOyW9Kae5LLIQjgKIJdYEvY5O0JE+QUOayX6SgEKY0/7ytE\nF7uUEKqKBVgctEFP+LXIqZ9mkdqN5jLieRm8G3ZvV0MInMJt8G91K4Dz42TG\nJzIOdVj3HT1Hcqi5JWIo716J77mjddsTEgQdoC2/qTweq/H2B09OgQuaCyvB\n4U79TnDMUZ7capq/biivX/5/GWuAU5ky5M2Eo71hWfTw14IX/hPTmx7Csx+D\nhscAgp0vUP9cqe3MZGyMkGCQTDmdzVsc6zvE5Bgr++B6ljDhwP95yiUr+4QU\nfYhP3JVeEG3VY7xjepOidsJW6nG7pMomdVDCyRqgajfdr39lMzxKozB5Zt05\nbMDnOg1ua4XI3sBnBUuypm/Id9KAMyWMnd0Oi47J4Uz1jfnvbdWr/EEHCBUT\nNg0QadkqMTWGdIPNkH3NlxSVv31cgXwqMOinxYxRpN5er7ogdRBUMPTKel2g\ngQS1\r\n=ab2e\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-b-x_1.0.0_1612916259095_0.530917127127337"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-10T00:17:39.025Z",
+    "1.0.0": "2021-02-10T00:17:39.328Z",
+    "modified": "2021-02-10T00:17:41.644Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-b-x.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-b-x.min.json
@@ -1,0 +1,29 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-b-x",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-b-x",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-b-y": "2"
+      },
+      "dist": {
+        "integrity": "sha512-19feHJAqq5HG2RrN2zHXiPXujXqHgJuGyZaKFolghgYKyncZYRpBwxboSDgMp8SxyrGx9EF74x6yarrVXRo9hw==",
+        "shasum": "d055ce82184b766154c5ce3523c06d430a7575ea",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-b-x/-/testing-peer-optional-conflict-b-x-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 278,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYjCRA9TVsSAnZWagAAJsYQAI6TiTI+kYscTluu8wvs\nKND0Wv+Zo3QU3cIbX55igi47+K+mnCWZzH6/jwhvWb3fvCMlzzvqeUEgLJ1q\nRGodgk1fZzbafhHUTq1U5cunMiHlGGBHypvgZRJzmMqKW89qwDIX7ZFc+V/s\nR0Mk8Cg6rpwVA25656FEVt8FXgMS2hQgTNFAESp3l8e3umInJN867en/qGNO\nRLPYv3bfNFG/JfOyW9Kae5LLIQjgKIJdYEvY5O0JE+QUOayX6SgEKY0/7ytE\nF7uUEKqKBVgctEFP+LXIqZ9mkdqN5jLieRm8G3ZvV0MInMJt8G91K4Dz42TG\nJzIOdVj3HT1Hcqi5JWIo716J77mjddsTEgQdoC2/qTweq/H2B09OgQuaCyvB\n4U79TnDMUZ7capq/biivX/5/GWuAU5ky5M2Eo71hWfTw14IX/hPTmx7Csx+D\nhscAgp0vUP9cqe3MZGyMkGCQTDmdzVsc6zvE5Bgr++B6ljDhwP95yiUr+4QU\nfYhP3JVeEG3VY7xjepOidsJW6nG7pMomdVDCyRqgajfdr39lMzxKozB5Zt05\nbMDnOg1ua4XI3sBnBUuypm/Id9KAMyWMnd0Oi47J4Uz1jfnvbdWr/EEHCBUT\nNg0QadkqMTWGdIPNkH3NlxSVv31cgXwqMOinxYxRpN5er7ogdRBUMPTKel2g\ngQS1\r\n=ab2e\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/testing-peer-optional-conflict-b-y": {
+          "optional": true
+        }
+      }
+    }
+  },
+  "modified": "2021-02-10T00:17:41.644Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-b-y.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-b-y.json
@@ -1,0 +1,86 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-b-y",
+  "_rev": "1-af3dfb943dcfd546c15731b715eebcd8",
+  "name": "@isaacs/testing-peer-optional-conflict-b-y",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-b-y",
+      "version": "1.0.0",
+      "_id": "@isaacs/testing-peer-optional-conflict-b-y@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.3",
+      "dist": {
+        "integrity": "sha512-fAKWNYcuMMAnkf41XXxcQnU1CAcpVbPErSPZHOoOrEJcBy1OqCV5YGQfnQzvOJUwdo5p0MOJ+pNGRdi5r/ugyw==",
+        "shasum": "e1108b08be80b39ce7ce232e555cde37dd22078f",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-b-y/-/testing-peer-optional-conflict-b-y-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYmCRA9TVsSAnZWagAAv00P+QFF4wpqx+Bvy/isugOv\nIF4XzvTG0muOO7E6thU2qWOQPTS3eHy8ypFwAW7yvJd6AM7WAMR9wueVw4oj\neVoifRypz7vzIn78gaJVqG2MDCUkCiZzO/UVydME5BiBMjYyWhqX97OYjoIv\nDD9ELmsabHl9JZzxbfxbBuQd19d5/MVYljtHcDhzAX/ouDICosW2ALHpWIGC\nezRPN9awNTcU/ZcNWd7miP15xz88PQ0SjfWObbUERxu/xHMbEGxznbWbbQ2I\nzYy47VnTNbRmBoznGajDgzlVIK6BQu0r6svqjnGSXrajuP8TEUzxRPV50C/c\n38HMqft7okdEO8lhIUkzXyOhfd+MMgrQiy42G8JnyfkQFxTT28IIbXn56WXf\n0WuNl74U/bNGKn0HEklmFAvtfK9/mKrzcmJi9nsDyOMzKxKsvdAZ51EpBUqP\nfke+tylG4DfDKSTpjkye+yE7FNRWh9mMYyvRovavNfiC+Ovy3eqFzDGHgYKa\nL44nOU8yDj3JwGhVXt+reZjClW1SKbfMAFcfdkgA4c8R3YPHi9zk8FRJozjf\nKqYPV9Z6dYaJ8rTh21KqPkRWjXsu7KbAhYWJBxRt7ZCMdkqVKh+Wdy4urCwG\nLHjcEAiRyfoMVjSEgnIXpUoboi0Ix1BRK64fcLBbvK+gbg0/dxtguLfRIWmO\nQqMZ\r\n=9Jkl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-b-y_1.0.0_1612916262505_0.39808746038198706"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-b-y",
+      "version": "2.0.0",
+      "_id": "@isaacs/testing-peer-optional-conflict-b-y@2.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.3",
+      "dist": {
+        "integrity": "sha512-85pQWyE3xVc7wt3z8wTWGNSaUQ83UAF4oloEi7UcNUfXqa5HPMPbmBg4pwoF6X4GdufTCzmwRyEvF9Ru3hShVg==",
+        "shasum": "84e0de3590f98c29497b7ecdc3b3cc5023bdeb6b",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-b-y/-/testing-peer-optional-conflict-b-y-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYqCRA9TVsSAnZWagAAdnAP/2N2bkWPAudF2fr+Yrnf\nNZ0AzPYlM4zibBnPJsaT8tPB05/nTbWkBNybXLMEnuj2j1f7aovv7DSX8SDO\nNg2UXP9dPfnspm9Tl/DOTZ09pdr+bZbM13huxY5stVxpGCHLDI3jXQCx37IF\n+kxiMIsbIyhgALqekQz8rl9xfzB/AYeZuf012i4bXYVJ95oNFUEBOXe9gwn2\nRIWgcEQovKZWT06Lfyezoinyz0bFyUW8U0jX8SbaoFgrAKGPRQoOJGPC3Ipm\nlAOkax4yR6VlZfgFR2r+iYWMokrzYKJS7+74nH8cTXqdVGaF6RqJbWD0lgTN\nCeQaxpDHwOT8Ew3SwAtHTEsVEInUTwi14FKyz5TxJRmfjPzXVX3X+PH66kRH\nXyoFmtFoCY3Uqj7H6fS6MxudKEMqLWxejzAj7VwuKoTG7t7E2XPSaHM0Doxg\nsEvSVf4Ak96fTmH2lTL+IgvG2fqmtnrIsxv2ayaezDou3F1uY9vMFmG9j11g\n6p+aHQjNJqVZ20PUyWli34rX7AaY823aa9fFg9LcgJJWkJAMqORH4jCtiYzA\nkt1mkypYed8Y1XwG81PKGLzmZjwh8tH9jzI95ZuKv8Jjbm6sPuEhadcGC9IX\nbwInuo+pPgOWvuUuJlAHKz5P/MXGA9tad8L/04JI4GKsK4CKp8z/I13mUVGg\nz5O2\r\n=+0FH\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-b-y_2.0.0_1612916266360_0.8002700128752667"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-10T00:17:42.467Z",
+    "1.0.0": "2021-02-10T00:17:42.680Z",
+    "modified": "2021-02-10T00:17:48.758Z",
+    "2.0.0": "2021-02-10T00:17:46.488Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-b-y.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-b-y.min.json
@@ -1,0 +1,33 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-b-y",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-b-y",
+      "version": "1.0.0",
+      "dist": {
+        "integrity": "sha512-fAKWNYcuMMAnkf41XXxcQnU1CAcpVbPErSPZHOoOrEJcBy1OqCV5YGQfnQzvOJUwdo5p0MOJ+pNGRdi5r/ugyw==",
+        "shasum": "e1108b08be80b39ce7ce232e555cde37dd22078f",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-b-y/-/testing-peer-optional-conflict-b-y-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYmCRA9TVsSAnZWagAAv00P+QFF4wpqx+Bvy/isugOv\nIF4XzvTG0muOO7E6thU2qWOQPTS3eHy8ypFwAW7yvJd6AM7WAMR9wueVw4oj\neVoifRypz7vzIn78gaJVqG2MDCUkCiZzO/UVydME5BiBMjYyWhqX97OYjoIv\nDD9ELmsabHl9JZzxbfxbBuQd19d5/MVYljtHcDhzAX/ouDICosW2ALHpWIGC\nezRPN9awNTcU/ZcNWd7miP15xz88PQ0SjfWObbUERxu/xHMbEGxznbWbbQ2I\nzYy47VnTNbRmBoznGajDgzlVIK6BQu0r6svqjnGSXrajuP8TEUzxRPV50C/c\n38HMqft7okdEO8lhIUkzXyOhfd+MMgrQiy42G8JnyfkQFxTT28IIbXn56WXf\n0WuNl74U/bNGKn0HEklmFAvtfK9/mKrzcmJi9nsDyOMzKxKsvdAZ51EpBUqP\nfke+tylG4DfDKSTpjkye+yE7FNRWh9mMYyvRovavNfiC+Ovy3eqFzDGHgYKa\nL44nOU8yDj3JwGhVXt+reZjClW1SKbfMAFcfdkgA4c8R3YPHi9zk8FRJozjf\nKqYPV9Z6dYaJ8rTh21KqPkRWjXsu7KbAhYWJBxRt7ZCMdkqVKh+Wdy4urCwG\nLHjcEAiRyfoMVjSEgnIXpUoboi0Ix1BRK64fcLBbvK+gbg0/dxtguLfRIWmO\nQqMZ\r\n=9Jkl\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-b-y",
+      "version": "2.0.0",
+      "dist": {
+        "integrity": "sha512-85pQWyE3xVc7wt3z8wTWGNSaUQ83UAF4oloEi7UcNUfXqa5HPMPbmBg4pwoF6X4GdufTCzmwRyEvF9Ru3hShVg==",
+        "shasum": "84e0de3590f98c29497b7ecdc3b3cc5023bdeb6b",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-b-y/-/testing-peer-optional-conflict-b-y-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYqCRA9TVsSAnZWagAAdnAP/2N2bkWPAudF2fr+Yrnf\nNZ0AzPYlM4zibBnPJsaT8tPB05/nTbWkBNybXLMEnuj2j1f7aovv7DSX8SDO\nNg2UXP9dPfnspm9Tl/DOTZ09pdr+bZbM13huxY5stVxpGCHLDI3jXQCx37IF\n+kxiMIsbIyhgALqekQz8rl9xfzB/AYeZuf012i4bXYVJ95oNFUEBOXe9gwn2\nRIWgcEQovKZWT06Lfyezoinyz0bFyUW8U0jX8SbaoFgrAKGPRQoOJGPC3Ipm\nlAOkax4yR6VlZfgFR2r+iYWMokrzYKJS7+74nH8cTXqdVGaF6RqJbWD0lgTN\nCeQaxpDHwOT8Ew3SwAtHTEsVEInUTwi14FKyz5TxJRmfjPzXVX3X+PH66kRH\nXyoFmtFoCY3Uqj7H6fS6MxudKEMqLWxejzAj7VwuKoTG7t7E2XPSaHM0Doxg\nsEvSVf4Ak96fTmH2lTL+IgvG2fqmtnrIsxv2ayaezDou3F1uY9vMFmG9j11g\n6p+aHQjNJqVZ20PUyWli34rX7AaY823aa9fFg9LcgJJWkJAMqORH4jCtiYzA\nkt1mkypYed8Y1XwG81PKGLzmZjwh8tH9jzI95ZuKv8Jjbm6sPuEhadcGC9IX\nbwInuo+pPgOWvuUuJlAHKz5P/MXGA9tad8L/04JI4GKsK4CKp8z/I13mUVGg\nz5O2\r\n=+0FH\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-02-10T00:17:48.758Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-c-x.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-c-x.json
@@ -1,0 +1,56 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-c-x",
+  "name": "@isaacs/testing-peer-optional-conflict-c-x",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-c-x",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-c-z": "1.0.0"
+      },
+      "_id": "@isaacs/testing-peer-optional-conflict-c-x@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.3",
+      "dist": {
+        "integrity": "sha512-wvByt0plqaMZBxfIgbqUSc/RRnfk83Zn5I/OpuV/NrZ89Bo0mqao22CSM3I1v72czur4B91tC/vTZyzLYl1Anw==",
+        "shasum": "070cdc9584afcdc3946078ec65bf56e2a0bf544c",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-c-x/-/testing-peer-optional-conflict-c-x-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 168,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYuCRA9TVsSAnZWagAA2iMP/j37QOhtWCj1vS27rhED\nx5f0SQtrgmskXUIFJEKbLuR+iifzGbSHTpLVsyRK/MtPBw+qtjMWQJomNAtv\nePW6VLR4hOPoSKotWQOBq3sXmdgw8bDI3+dV+6Uyn8ci+oW6YCCcI7aqfndD\ns4uxdVAnSOnFYg6S23Hd/mm1cjSTzdu0I6kv+2FonS8PbAT0tFOnYEYP/lMt\nMFUEI5vSM/zMl9UX4BoxH4AKVXJXLItKgxL+aMSuvZimNiQD1MNllLeZxqOm\nBlyjn7mCHIqenAi2Bn1vfFLpBnC4zTF3MFFr2KliXzr4l13bSw3aGtS43Ic0\nrdCs7YZr63wJf4nU/ojTYV8USblVovqQfhHLTfRLFrW/VwvAn3Yn9NqhPW+g\narSNKGlN5SveqLEMSic9apZ1p/BqD/CWAXNI9/B6bB6ROZYn1c1Dwja1UaXh\nE8eBo+qfyk8qbB4ZCNw7BwGxpqrVYDeHJA32qzRQE7hwBkwOgxiCJrfelMv3\nmk2MVM4kfe0L9+ErBsnEQ1Q1uZIreyDjax+RoIzwPx3jTlThJLz8ooV5wbd0\nHsixbqm8FFJwsNJBY16wwDZriPoEEOYwg42SIOz1M2XlSF5TocHmrl9KFxJ2\nZRRV8Wq883w/Xmj/5tC+LlxgEKLiEmozLd7ghZl3wf29VNwuo479FIG/b+fg\nKFWP\r\n=LxlY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-c-x_1.0.0_1612916270285_0.9235254750009496"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-10T00:17:50.247Z",
+    "1.0.0": "2021-02-10T00:17:50.464Z",
+    "modified": "2021-02-10T00:17:52.668Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-c-x.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-c-x.min.json
@@ -1,0 +1,24 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-c-x",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-c-x",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-c-z": "1.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-wvByt0plqaMZBxfIgbqUSc/RRnfk83Zn5I/OpuV/NrZ89Bo0mqao22CSM3I1v72czur4B91tC/vTZyzLYl1Anw==",
+        "shasum": "070cdc9584afcdc3946078ec65bf56e2a0bf544c",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-c-x/-/testing-peer-optional-conflict-c-x-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 168,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyYuCRA9TVsSAnZWagAA2iMP/j37QOhtWCj1vS27rhED\nx5f0SQtrgmskXUIFJEKbLuR+iifzGbSHTpLVsyRK/MtPBw+qtjMWQJomNAtv\nePW6VLR4hOPoSKotWQOBq3sXmdgw8bDI3+dV+6Uyn8ci+oW6YCCcI7aqfndD\ns4uxdVAnSOnFYg6S23Hd/mm1cjSTzdu0I6kv+2FonS8PbAT0tFOnYEYP/lMt\nMFUEI5vSM/zMl9UX4BoxH4AKVXJXLItKgxL+aMSuvZimNiQD1MNllLeZxqOm\nBlyjn7mCHIqenAi2Bn1vfFLpBnC4zTF3MFFr2KliXzr4l13bSw3aGtS43Ic0\nrdCs7YZr63wJf4nU/ojTYV8USblVovqQfhHLTfRLFrW/VwvAn3Yn9NqhPW+g\narSNKGlN5SveqLEMSic9apZ1p/BqD/CWAXNI9/B6bB6ROZYn1c1Dwja1UaXh\nE8eBo+qfyk8qbB4ZCNw7BwGxpqrVYDeHJA32qzRQE7hwBkwOgxiCJrfelMv3\nmk2MVM4kfe0L9+ErBsnEQ1Q1uZIreyDjax+RoIzwPx3jTlThJLz8ooV5wbd0\nHsixbqm8FFJwsNJBY16wwDZriPoEEOYwg42SIOz1M2XlSF5TocHmrl9KFxJ2\nZRRV8Wq883w/Xmj/5tC+LlxgEKLiEmozLd7ghZl3wf29VNwuo479FIG/b+fg\nKFWP\r\n=LxlY\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-02-10T00:17:52.668Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-c-y.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-c-y.json
@@ -1,0 +1,86 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-c-y",
+  "_rev": "1-aa0acac94cda0dd2fb5a5135961862b8",
+  "name": "@isaacs/testing-peer-optional-conflict-c-y",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-c-y",
+      "version": "1.0.0",
+      "_id": "@isaacs/testing-peer-optional-conflict-c-y@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.3",
+      "dist": {
+        "integrity": "sha512-gfDjXMk+fUhUl335SnAGBmfJs9TN4rjcUedMKnKjpFSc6w0AYoAy0bSoSio7rz0QofDjYbw52iVz+xcIl0zs9w==",
+        "shasum": "9a76e64cdb8c61e6a66a4b9e9e0e3332a51cb081",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-c-y/-/testing-peer-optional-conflict-c-y-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyZTCRA9TVsSAnZWagAAujgP/22GDej2MGKhZ6xlFgui\nNcpTCR2DZmM8uZsSZVDkp7vvVQC/MOELZQOZUhOuSvl+U+itdCv8AnrEO/1+\nxbdc7rJVTH/6jvYo06IGrNg8K0pJH8kjoYaBMbNzJHCBO8YfdPq0OHOENR+j\nc5uGmaVqDgnBxuX2Wsm7LWEJNNRVsAav6Jj4M7cIejPqMMoyRMQ+mmGmSDeg\n84huK+0gnINpgt+LTrhk1+a4fjxz7gPsWJmoVhygFlnAR2eweKXgZwHXQHbI\nwcCtWNl+vScMkraqjTXqLpcSnBJoCSFUYZyrXxVVPy+HyEuHQ4Gz08auQVi3\n4THw0CLWcdxQ3JJEh3/JYtHC+VK2uYs30dySIe9jW8DKNottPIHO6WUQfsSC\n8fjYATqejhL1FYBeBra322h7mVSbzV7+ufyVyCapoH4XggsCUlqZrnU2HbhH\ndXCoiyvP9efQsnlJKK13eGbhy8Wd/flhYduZTtunUrjvceW+EmLXf6UWd+Fq\nmxSRqCxPibUI1FbM6b/eZnd6V3dVGjoKNOy35dbqOp0XcKD/PDV4d8df6aFf\nMHnFYkLTvJigOy7ixTFRbUIW//DigUER9kS19QHggFjtwIGvC1l6CHQja26U\nGFpRgNIOwdZaNEvJfV5xluLBemI6gtqOS3pBUWm0zcYOCK//uWDGPERHOVn4\nxup9\r\n=MVau\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-c-y_1.0.0_1612916306979_0.7998148752697067"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-c-y",
+      "version": "2.0.0",
+      "_id": "@isaacs/testing-peer-optional-conflict-c-y@2.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.3",
+      "dist": {
+        "integrity": "sha512-uYpth20b7tWSGl8iUWRYPbMGdbw/tFb9E8JwHw+Q8mozFSpASxobmEbCf+MtY9iR2da8lA53BaShG8o/ymxYig==",
+        "shasum": "01cdc988b8ff500dfbf44f62480835182b12a99c",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-c-y/-/testing-peer-optional-conflict-c-y-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIybVCRA9TVsSAnZWagAAB/4P/j/LPu62sDVMhacY0SKI\nfyHVkyK5RIzocox66Q40HibZ6B8EHJjAYcggVnQ2Gp+6d3+lwQulVnGtQ18c\nJemWuaR+XddEd13JNBjaRRhifNNEbIB0vWARaQ55sT3mMly/CF1etXmpQCI2\nWb5dm8IzxGgMMcpuzKrFqLI+JP+ewthjCAuBhmuNazVKvTxArKEZzhHRcST2\nLEVZAnwDg6h7lW1k13GoZ22CizzZVZ0tLUss8+WlFkUK04IEFKI7owHRLKPV\nUnJbbL/Vl1hHSwPD9KSDbgsAq+BwGoZHzPDGEE5uKdtyKYLZBSQuaf9iQAfQ\n4a9l299f7k+tzfxlU3bQ301JFojFSUs1WNUYk0xPtJABfElkrjpnwkCTrCsY\n3L1WXfG9rTjW1cMBX9KuiWa9kPIbSIGVfETXKQDhpc04S+3v6SnUaVk+zNeO\nxcybdS06y6JYn+7v3nUIQMJVc3KK7gfazu8Nj3QT+U84QO9YZoMQ5EN9BH4L\nCDd+H4u6LRFYC0YlCz/7rUY94qvNl9tnP4p1gu9MXS6LmhcPXGbPOwSU4oRy\nNRCL1pjqczuyQ5N2O2Tg83IaKJxJPFpiNN+xgw4OcMzRfgs1HP9eaFJ7nPJo\nKO0/bi6hRRBJWm6g1vc5IiSLCNu6OfEMeIobdFTMahwKpatVh1CfzLmT1XIm\nEmeh\r\n=Pk01\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-c-y_2.0.0_1612916436634_0.5880168227884359"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-10T00:18:26.910Z",
+    "1.0.0": "2021-02-10T00:18:27.091Z",
+    "modified": "2021-02-10T00:20:42.272Z",
+    "2.0.0": "2021-02-10T00:20:36.760Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-c-y.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-c-y.min.json
@@ -1,0 +1,33 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-c-y",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-c-y",
+      "version": "1.0.0",
+      "dist": {
+        "integrity": "sha512-gfDjXMk+fUhUl335SnAGBmfJs9TN4rjcUedMKnKjpFSc6w0AYoAy0bSoSio7rz0QofDjYbw52iVz+xcIl0zs9w==",
+        "shasum": "9a76e64cdb8c61e6a66a4b9e9e0e3332a51cb081",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-c-y/-/testing-peer-optional-conflict-c-y-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyZTCRA9TVsSAnZWagAAujgP/22GDej2MGKhZ6xlFgui\nNcpTCR2DZmM8uZsSZVDkp7vvVQC/MOELZQOZUhOuSvl+U+itdCv8AnrEO/1+\nxbdc7rJVTH/6jvYo06IGrNg8K0pJH8kjoYaBMbNzJHCBO8YfdPq0OHOENR+j\nc5uGmaVqDgnBxuX2Wsm7LWEJNNRVsAav6Jj4M7cIejPqMMoyRMQ+mmGmSDeg\n84huK+0gnINpgt+LTrhk1+a4fjxz7gPsWJmoVhygFlnAR2eweKXgZwHXQHbI\nwcCtWNl+vScMkraqjTXqLpcSnBJoCSFUYZyrXxVVPy+HyEuHQ4Gz08auQVi3\n4THw0CLWcdxQ3JJEh3/JYtHC+VK2uYs30dySIe9jW8DKNottPIHO6WUQfsSC\n8fjYATqejhL1FYBeBra322h7mVSbzV7+ufyVyCapoH4XggsCUlqZrnU2HbhH\ndXCoiyvP9efQsnlJKK13eGbhy8Wd/flhYduZTtunUrjvceW+EmLXf6UWd+Fq\nmxSRqCxPibUI1FbM6b/eZnd6V3dVGjoKNOy35dbqOp0XcKD/PDV4d8df6aFf\nMHnFYkLTvJigOy7ixTFRbUIW//DigUER9kS19QHggFjtwIGvC1l6CHQja26U\nGFpRgNIOwdZaNEvJfV5xluLBemI6gtqOS3pBUWm0zcYOCK//uWDGPERHOVn4\nxup9\r\n=MVau\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-c-y",
+      "version": "2.0.0",
+      "dist": {
+        "integrity": "sha512-uYpth20b7tWSGl8iUWRYPbMGdbw/tFb9E8JwHw+Q8mozFSpASxobmEbCf+MtY9iR2da8lA53BaShG8o/ymxYig==",
+        "shasum": "01cdc988b8ff500dfbf44f62480835182b12a99c",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-c-y/-/testing-peer-optional-conflict-c-y-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIybVCRA9TVsSAnZWagAAB/4P/j/LPu62sDVMhacY0SKI\nfyHVkyK5RIzocox66Q40HibZ6B8EHJjAYcggVnQ2Gp+6d3+lwQulVnGtQ18c\nJemWuaR+XddEd13JNBjaRRhifNNEbIB0vWARaQ55sT3mMly/CF1etXmpQCI2\nWb5dm8IzxGgMMcpuzKrFqLI+JP+ewthjCAuBhmuNazVKvTxArKEZzhHRcST2\nLEVZAnwDg6h7lW1k13GoZ22CizzZVZ0tLUss8+WlFkUK04IEFKI7owHRLKPV\nUnJbbL/Vl1hHSwPD9KSDbgsAq+BwGoZHzPDGEE5uKdtyKYLZBSQuaf9iQAfQ\n4a9l299f7k+tzfxlU3bQ301JFojFSUs1WNUYk0xPtJABfElkrjpnwkCTrCsY\n3L1WXfG9rTjW1cMBX9KuiWa9kPIbSIGVfETXKQDhpc04S+3v6SnUaVk+zNeO\nxcybdS06y6JYn+7v3nUIQMJVc3KK7gfazu8Nj3QT+U84QO9YZoMQ5EN9BH4L\nCDd+H4u6LRFYC0YlCz/7rUY94qvNl9tnP4p1gu9MXS6LmhcPXGbPOwSU4oRy\nNRCL1pjqczuyQ5N2O2Tg83IaKJxJPFpiNN+xgw4OcMzRfgs1HP9eaFJ7nPJo\nKO0/bi6hRRBJWm6g1vc5IiSLCNu6OfEMeIobdFTMahwKpatVh1CfzLmT1XIm\nEmeh\r\n=Pk01\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-02-10T00:20:42.272Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-c-z.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-c-z.json
@@ -1,0 +1,61 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-c-z",
+  "name": "@isaacs/testing-peer-optional-conflict-c-z",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-c-z",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-c-y": "2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/testing-peer-optional-conflict-c-y": {
+          "optional": true
+        }
+      },
+      "_id": "@isaacs/testing-peer-optional-conflict-c-z@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.3",
+      "dist": {
+        "integrity": "sha512-pgnul6UIJ7QYIfchXrZ9WwYhqpXvPwote3j7emH7LZyDeXyUbSWPUYR6Cc0NlBZIfB20Ia3J6KcxdZBOG5y6zw==",
+        "shasum": "0c1307ef1bc89280ef66554af84fc3628e658fcf",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-c-z/-/testing-peer-optional-conflict-c-z-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 282,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyaMCRA9TVsSAnZWagAAZkQP/A+rOf8PZC6vkF75Cw0P\nEOFquUT7LBjRS050v2KFXTMkqnowTztywANv82g8XRGG8AtHDjK0zTpC3qaE\nnYxBV4RGOOMXNV3PjScXmlabF2q8kZi6PX+pBaO5a3WH772oS89YTjrpU0Fm\nma0RD5cvG888dsiw9D84JPUoMpViFVLv1IfLOTHmbfH7CE6EDSBqEJfFO7vu\nZ82KSmkw276tyOcpM8R2DsN0ZLtxCAbWCAPWh+gyK40ZImh99rfj6EKXSZYK\nWG1cGuatNLP7T3VCIO4IBEabcumorS/DHqdGEhi2McZqK8OCmzGq4GXtinpb\nLWLHBqOkDHpMH20tB6n11AaxIz2bLKWQPqUONVHjP550FUS8Mg3LK7E1H8n4\nvBx4E/1gB7J1fRLLNLBoqge+5rH68NWuy2hZBVOo9lfe9m5ObgaQse4ccLnO\n0l2YhdK8lUhB4wBkW2F2giMX4VKXzj4qo4ug2wcHJ08cz/JfqTu5uS4Y76YJ\nAbSxpF2xmpL5fIY2JusOZ0aGGV2pMlbMa/AIGmkv9lOBlbXR4Oe6qjU2SyYY\n4uM4DvCD/196+G8bkRjQWOE3stZVSuXAbFiAQLZmlVGYZDq0khHXF8W9YMeU\nHXYC6Oh9ecmZ7qERg6aMwfgZcog819eocGx3A/BTvVAEZTUGjJ++Mlz4bXkd\nzAYr\r\n=AkBd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-c-z_1.0.0_1612916361439_0.4826758108339586"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-10T00:19:21.398Z",
+    "1.0.0": "2021-02-10T00:19:21.618Z",
+    "modified": "2021-02-10T00:19:26.243Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-c-z.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-c-z.min.json
@@ -1,0 +1,29 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-c-z",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-c-z",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-c-y": "2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-pgnul6UIJ7QYIfchXrZ9WwYhqpXvPwote3j7emH7LZyDeXyUbSWPUYR6Cc0NlBZIfB20Ia3J6KcxdZBOG5y6zw==",
+        "shasum": "0c1307ef1bc89280ef66554af84fc3628e658fcf",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-c-z/-/testing-peer-optional-conflict-c-z-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 282,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgIyaMCRA9TVsSAnZWagAAZkQP/A+rOf8PZC6vkF75Cw0P\nEOFquUT7LBjRS050v2KFXTMkqnowTztywANv82g8XRGG8AtHDjK0zTpC3qaE\nnYxBV4RGOOMXNV3PjScXmlabF2q8kZi6PX+pBaO5a3WH772oS89YTjrpU0Fm\nma0RD5cvG888dsiw9D84JPUoMpViFVLv1IfLOTHmbfH7CE6EDSBqEJfFO7vu\nZ82KSmkw276tyOcpM8R2DsN0ZLtxCAbWCAPWh+gyK40ZImh99rfj6EKXSZYK\nWG1cGuatNLP7T3VCIO4IBEabcumorS/DHqdGEhi2McZqK8OCmzGq4GXtinpb\nLWLHBqOkDHpMH20tB6n11AaxIz2bLKWQPqUONVHjP550FUS8Mg3LK7E1H8n4\nvBx4E/1gB7J1fRLLNLBoqge+5rH68NWuy2hZBVOo9lfe9m5ObgaQse4ccLnO\n0l2YhdK8lUhB4wBkW2F2giMX4VKXzj4qo4ug2wcHJ08cz/JfqTu5uS4Y76YJ\nAbSxpF2xmpL5fIY2JusOZ0aGGV2pMlbMa/AIGmkv9lOBlbXR4Oe6qjU2SyYY\n4uM4DvCD/196+G8bkRjQWOE3stZVSuXAbFiAQLZmlVGYZDq0khHXF8W9YMeU\nHXYC6Oh9ecmZ7qERg6aMwfgZcog819eocGx3A/BTvVAEZTUGjJ++Mlz4bXkd\nzAYr\r\n=AkBd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/testing-peer-optional-conflict-c-y": {
+          "optional": true
+        }
+      }
+    }
+  },
+  "modified": "2021-02-10T00:19:26.243Z"
+}


### PR DESCRIPTION
Based on #227, land that first.

With a dependency graph like this:

```
root -> (a, b@1)
a -> PEEROPTIONAL(b@2)
```

We do not install the peerOptional dependency by default, so even though
`b@2` is included in the peerSet of `a`, it is not added to the tree.

Then, the `b@1` dependency is added to satisfy root's direct dependency
on it, causing the `a -> b@2` edge to become invalid.

We then try to resolve the `a -> b@2` edge, and find that we cannot
place it anywhere, causing an `ERESOLVE` error.

However, because `b@2` is no longer a part of a peerSet sourced on the
`root` node, we miss the chance to detect that it should be overridden,
resulting in an `ERESOLVE` failure even when `--force` is used.

This commit adds the check for `this[_force]` prior to crashing with
ERESOLVE, so that cases that avoid our earlier heuristics still accept
the invalid resolution when `--force` is in effect.

Fix: #226
Fix: https://github.com/npm/cli/issues/2504