### PR TITLE
fix: deps of linked deps in package-lock

### DIFF
--- a/lib/calc-dep-flags.js
+++ b/lib/calc-dep-flags.js
@@ -11,7 +11,7 @@ const calcDepFlags = (tree, resetRoot = true) => {
     tree,
     visit: node => calcDepFlagsStep(node),
     filter: node => node,
-    getChildren: node => [...node.edgesOut.values()].map(edge => edge.to),
+    getChildren: (node, tree) => [...tree.edgesOut.values()].map(edge => edge.to),
   })
   return ret
 }

--- a/tap-snapshots/test-arborist-load-actual.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-load-actual.js-TAP.test.js
@@ -863,7 +863,6 @@ ArboristLink {
         "location": "node_modules/@scope/y",
         "name": "@scope/y",
         "path": "root/node_modules/@scope/y",
-        "peer": true,
         "version": "1.2.3",
       },
       "foo" => ArboristNode {
@@ -2646,7 +2645,6 @@ ArboristLink {
         "location": "node_modules/@scope/y",
         "name": "@scope/y",
         "path": "root/node_modules/@scope/y",
-        "peer": true,
         "version": "1.2.3",
       },
       "foo" => ArboristNode {

--- a/tap-snapshots/test-shrinkwrap.js-TAP.test.js
+++ b/tap-snapshots/test-shrinkwrap.js-TAP.test.js
@@ -1445,7 +1445,6 @@ Object {
       "version": "1.2.3",
     },
     "@scope/y": Object {
-      "peer": true,
       "requires": Object {
         "foo": "99.x",
       },
@@ -1533,7 +1532,6 @@ Object {
       "dependencies": Object {
         "foo": "99.x",
       },
-      "peer": true,
       "version": "1.2.3",
     },
     "../../root/node_modules/foo": Object {
@@ -2523,7 +2521,6 @@ Object {
       "version": "1.2.3",
     },
     "@scope/y": Object {
-      "peer": true,
       "requires": Object {
         "foo": "99.x",
       },
@@ -2611,7 +2608,6 @@ Object {
       "dependencies": Object {
         "foo": "99.x",
       },
-      "peer": true,
       "version": "1.2.3",
     },
     "../root/node_modules/foo": Object {

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -174,6 +174,11 @@ t.test('bad shrinkwrap file', t => {
   return t.resolveMatchSnapshot(printIdeal(path), 'bad shrinkwrap')
 })
 
+t.test('a direct link dep has a dep with optional dependencies', t => {
+  const path = resolve(fixtures, 'link-dep-has-dep-with-optional-dep')
+  return t.resolveMatchSnapshot(printIdeal(path), 'should not mark children of the optional dep as extraneous')
+})
+
 t.test('cyclical peer deps', t => {
   const paths = [
     resolve(fixtures, 'peer-dep-cycle'),

--- a/test/fixtures/link-dep-has-dep-with-optional-dep/a/package.json
+++ b/test/fixtures/link-dep-has-dep-with-optional-dep/a/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "a",
+  "version": "1.0.0",
+  "dependencies": {
+    "rimraf": "2.2.4"
+  }
+}

--- a/test/fixtures/link-dep-has-dep-with-optional-dep/package.json
+++ b/test/fixtures/link-dep-has-dep-with-optional-dep/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "link-dep-has-dep-with-optional-dep",
+  "version": "1.0.0",
+  "dependencies": {
+    "a": "./a"
+  }
+}


### PR DESCRIPTION
When having optional dependencies of a dependency of
a top-level link dependency, e.g:

    root -> LINK(a)
    a -> (b)
    b -> OPTIONAL(c)

    * c marked as extraneous

Any optional dependency (and all its nested nodes) were marked
as extraneous in package-lock due to `calcDepFlags` missing
properly following the target of Link nodes.

This changeset fixes it by properly following the result of the
`treeverse.visit` method that will have already followed any
link targets at that point.

Fixes: https://github.com/npm/cli/issues/2505

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
