### PR TITLE
default audit severity=high, vulnerable_versions=*

### DIFF
--- a/lib/audit-report.js
+++ b/lib/audit-report.js
@@ -268,8 +268,8 @@ class AuditReport extends Map {
         id,
         url,
         title,
-        severity,
-        vulnerable_versions,
+        severity = 'high',
+        vulnerable_versions = '*',
         module_name: name,
       } = advisory
       bulk[name] = bulk[name] || []

--- a/test/audit-report.js
+++ b/test/audit-report.js
@@ -365,3 +365,40 @@ t.test('audit when bulk report doenst have anything in it', async t => {
   const { report } = await auditReport.run()
   t.strictSame(report, null)
 })
+
+t.test('default severity=high, vulnerable_versions=*', async t => {
+  const audit = {
+    actions: [],
+    advisories: {
+      755: {
+        findings: [
+          {
+            version: '1.2.3',
+            paths: [
+              'something',
+            ],
+          },
+        ],
+        id: 755,
+        title: 'no severity or vulnerable versions',
+        module_name: 'something',
+        overview: 'should default severity=high, vulnerable_versions=*',
+        recommendation: "don't use this thing",
+        url: 'https://npmjs.com/advisories/755',
+      },
+    },
+    muted: [],
+    metadata: {
+      vulnerabilities: {},
+      dependencies: 1,
+      devDependencies: 0,
+      optionalDependencies: 0,
+      totalDependencies: 1,
+    },
+    runId: 'just-some-unique-identifier',
+  }
+
+  const bulk = auditToBulk(audit)
+  t.match(bulk, { something: [{ severity: 'high', vulnerable_versions: '*' }] })
+  t.end()
+})


### PR DESCRIPTION
Fix: https://github.com/npm/cli/issues/1875
Related: https://github.com/npm/metavuln-calculator/pull/4

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
