### PR TITLE
fix: if there are children but the diff itself has an action, make sure to add it to leaves

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -105,7 +105,7 @@ const getChildren = diff => {
     diffNode(actual, ideal, children, unchanged, removed)
   }
 
-  if (diff.leaves && !children.length)
+  if (diff.leaves && !children.length || diff.action && diff.action !== 'REMOVE')
     diff.leaves.push(diff)
 
   return children

--- a/tap-snapshots/test-diff.js-TAP.test.js
+++ b/tap-snapshots/test-diff.js-TAP.test.js
@@ -19,6 +19,7 @@ Diff {
     "integrity": "sha512-aaa",
   },
   "leaves": Array [
+    "/path/to/root/node_modules/b",
     "/path/to/root/node_modules/b/node_modules/c",
     "/path/to/root/node_modules/b/node_modules/d/node_modules/e",
     "/path/to/root/node_modules/x/node_modules/y",
@@ -26,6 +27,7 @@ Diff {
     "/path/to/root/node_modules/bundler/node_modules/not-bundled",
     "/path/to/root/node_modules/should-have-bins",
     "/path/to/root/foo/node_modules/baz",
+    "/path/to/root/node_modules/i",
     "/path/to/root/node_modules/i/node_modules/j",
     "/path/to/root/foo/node_modules/boo",
   ],
@@ -91,6 +93,7 @@ Diff {
         "integrity": "sha512-BBB",
       },
       "leaves": Array [
+        "/path/to/root/node_modules/b",
         "/path/to/root/node_modules/b/node_modules/c",
         "/path/to/root/node_modules/b/node_modules/d/node_modules/e",
       ],
@@ -168,6 +171,7 @@ Diff {
         "integrity": "sha512-III",
       },
       "leaves": Array [
+        "/path/to/root/node_modules/i",
         "/path/to/root/node_modules/i/node_modules/j",
       ],
       "unchanged": Array [],


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
this problem is most easily highlighted with the dependency `aws-cdk` which for some reason when you `npm ci` after installing, never makes it to the leaves and so is never reified. we do reify its children, but not that node itself.

this change does pass the hands on test, and the changes to the diff look correct to me (and do seem to show the exact bug that i'm trying to fix)

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes https://github.com/npm/cli/issues/2251