### PR TITLE
Fix additional peerOptional conflict cases

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -1121,8 +1121,11 @@ This is a one-time fix-up, please be patient...
       // we don't like it.  always fail strictly, always allow forcibly or
       // in non-strict mode if it's not our fault.  don't warn here, because
       // we are going to warn again when we place the deps, if we end up
-      // overriding for something else.
-      if (conflictOK)
+      // overriding for something else.  If the thing that has this dep
+      // isn't also required, then there's a good chance we won't need it,
+      // so allow it for now and let it conflict if it turns out to actually
+      // be necessary for the installation.
+      if (conflictOK || !required.has(edge.from))
         continue
 
       // ok, it's the root, or we're in unforced strict mode, so this is bad

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -2509,7 +2509,7 @@ t.test('do not ERESOLVE on peerOptionals that are ignored anyway', t => {
   // this simulates three cases where a conflict occurs during the peerSet
   // generation phase, but will not manifest in the tree building phase.
   const base = resolve(fixtures, 'peer-optional-eresolve')
-  const cases = ['a', 'b', 'c']
+  const cases = ['a', 'b', 'c', 'd', 'e', 'f']
   t.plan(cases.length)
   for (const c of cases) {
     t.test(`case ${c}`, async t => {

--- a/test/fixtures/peer-optional-eresolve/d/README.md
+++ b/test/fixtures/peer-optional-eresolve/d/README.md
@@ -1,0 +1,17 @@
+# peer optional failure D
+
+```
+root -> (x, z@1)
+x -> PEEROPTIONAL(y)
+y -> PEER(z@2)
+```
+
+[npm/arborist#223](https://github.com/npm/arborist/issues/223)
+
+[npm/arborist#236](https://github.com/npm/arborist/issues/236)
+
+Subtly similar to case A, but note y and z swapped, so that they are
+resolved in the reverse order (because deps are alphabetically sorted for
+consistency).  This is relevant, because it ensures that there's no dep
+present in the peerSet until _after_ the conflict is encountered, and that
+code path was not being hit.

--- a/test/fixtures/peer-optional-eresolve/d/package.json
+++ b/test/fixtures/peer-optional-eresolve/d/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-d",
+  "version": "1.0.0",
+  "dependencies": {
+    "@isaacs/testing-peer-optional-conflict-d-x": "1",
+    "@isaacs/testing-peer-optional-conflict-d-z": "1"
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/d/x/package.json
+++ b/test/fixtures/peer-optional-eresolve/d/x/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-d-x",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-optional-conflict-d-y": "1"
+  },
+  "peerDependenciesMeta": {
+    "@isaacs/testing-peer-optional-conflict-d-y": {
+      "optional": true
+    }
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/d/y/package.json
+++ b/test/fixtures/peer-optional-eresolve/d/y/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-d-y",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-optional-conflict-d-z": "2"
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/d/z/1/package.json
+++ b/test/fixtures/peer-optional-eresolve/d/z/1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-d-z",
+  "version": "1.0.0"
+}

--- a/test/fixtures/peer-optional-eresolve/d/z/2/package.json
+++ b/test/fixtures/peer-optional-eresolve/d/z/2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-d-z",
+  "version": "2.0.0"
+}

--- a/test/fixtures/peer-optional-eresolve/e/README.md
+++ b/test/fixtures/peer-optional-eresolve/e/README.md
@@ -1,0 +1,13 @@
+# peer optional failure E
+
+```
+root -> (x, z@1)
+x -> PEEROPTIONAL(y) PEER(z@1)
+y -> PEER(z@2)
+```
+
+[npm/arborist#223](https://github.com/npm/arborist/issues/223)
+
+[npm/arborist#236](https://github.com/npm/arborist/issues/236)
+
+The same as case D, but with the addition of a `x->z` peerDep.

--- a/test/fixtures/peer-optional-eresolve/e/package.json
+++ b/test/fixtures/peer-optional-eresolve/e/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-e",
+  "version": "1.0.0",
+  "dependencies": {
+    "@isaacs/testing-peer-optional-conflict-e-x": "1",
+    "@isaacs/testing-peer-optional-conflict-e-z": "1"
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/e/x/package.json
+++ b/test/fixtures/peer-optional-eresolve/e/x/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-e-x",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-optional-conflict-e-y": "1",
+    "@isaacs/testing-peer-optional-conflict-e-z": "1"
+  },
+  "peerDependenciesMeta": {
+    "@isaacs/testing-peer-optional-conflict-e-y": {
+      "optional": true
+    }
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/e/y/package.json
+++ b/test/fixtures/peer-optional-eresolve/e/y/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-e-y",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-optional-conflict-e-z": "2"
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/e/z/1/package.json
+++ b/test/fixtures/peer-optional-eresolve/e/z/1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-e-z",
+  "version": "1.0.0"
+}

--- a/test/fixtures/peer-optional-eresolve/e/z/2/package.json
+++ b/test/fixtures/peer-optional-eresolve/e/z/2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-e-z",
+  "version": "2.0.0"
+}

--- a/test/fixtures/peer-optional-eresolve/f/README.md
+++ b/test/fixtures/peer-optional-eresolve/f/README.md
@@ -1,0 +1,14 @@
+# peer optional failure F
+
+```
+root -> (x, z@1)
+x -> PEEROPTIONAL(y) PEER(z@1) PEER(w@1)
+w -> PEER(z@1)
+y -> PEER(z@2)
+```
+
+[npm/arborist#223](https://github.com/npm/arborist/issues/223)
+
+[npm/arborist#236](https://github.com/npm/arborist/issues/236)
+
+The same as case E, but with the addition of a `x->w->z` peerDep chain.

--- a/test/fixtures/peer-optional-eresolve/f/package.json
+++ b/test/fixtures/peer-optional-eresolve/f/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-f",
+  "version": "1.0.0",
+  "dependencies": {
+    "@isaacs/testing-peer-optional-conflict-f-x": "1",
+    "@isaacs/testing-peer-optional-conflict-f-z": "1"
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/f/w/package.json
+++ b/test/fixtures/peer-optional-eresolve/f/w/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-f-w",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-optional-conflict-f-z": "1"
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/f/x/package.json
+++ b/test/fixtures/peer-optional-eresolve/f/x/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-f-x",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-optional-conflict-f-w": "1",
+    "@isaacs/testing-peer-optional-conflict-f-y": "1",
+    "@isaacs/testing-peer-optional-conflict-f-z": "1"
+  },
+  "peerDependenciesMeta": {
+    "@isaacs/testing-peer-optional-conflict-f-y": {
+      "optional": true
+    }
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/f/y/package.json
+++ b/test/fixtures/peer-optional-eresolve/f/y/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-f-y",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-optional-conflict-f-z": "2"
+  }
+}

--- a/test/fixtures/peer-optional-eresolve/f/z/1/package.json
+++ b/test/fixtures/peer-optional-eresolve/f/z/1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-f-z",
+  "version": "1.0.0"
+}

--- a/test/fixtures/peer-optional-eresolve/f/z/2/package.json
+++ b/test/fixtures/peer-optional-eresolve/f/z/2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-f-z",
+  "version": "2.0.0"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-d-x.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-d-x.json
@@ -1,0 +1,61 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-d-x",
+  "name": "@isaacs/testing-peer-optional-conflict-d-x",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-d-x",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-d-y": "1"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/testing-peer-optional-conflict-d-y": {
+          "optional": true
+        }
+      },
+      "_id": "@isaacs/testing-peer-optional-conflict-d-x@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.4",
+      "dist": {
+        "integrity": "sha512-8nj3SY7KJbdLLwN2dIwwrSiUld0yzsid7sOP1St6OmUi+roOdqaUfZI7FyWAGlverzCljYRY0iRjbYV3zA5kdw==",
+        "shasum": "6ab84cb07b956ea5c05650c5db0f475374c483d0",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-d-x/-/testing-peer-optional-conflict-d-x-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 278,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLYsICRA9TVsSAnZWagAAoAMQAIW4nZOUVZtTDat1Sr5m\n5Z/APwSkOQjlTNuGNsw/mouvIlLMMOlY+zI4/uFr/b8byAFLGh5/eUw5GmQR\noBugcrCF+FP+IxMe1Q5DkwH7UmnB/8JzxSZeeFW20UsZkjzTDd4d14M6zDyA\nar3t9qd0udT/WFDA+ikhbS/W0qmJC7ekf18+rwpLXP25uIucFCljh20vgt+u\nH/VzVq9rBiA87jjob27L0ReVQK/ZgwClMSuJwmrUYJMVKCKCWkrTLh5y7dG6\n+KM66oBNnHNy+V+Z47Y00684JijUQennWUvU5RhUzJTDuCca9AdtIJ5BkQqK\nvE5RTp3J8l+MELN832sH5ZacGfkRw/CE+8RjIY3nHyIFxDm/46JAl1nAQ4JM\n2cipIYOsIMEcppEOijWQZ0MOrRHW7iM5/jWFG2AHPiTbba4FXsuLxQ7NsJyY\ngPKAiFIqJWJn9NPboD0v68SmYQsbp+y0QjCuG53THgL7t7H99YX6iztn3cRj\n0MbM8YI/6RJ5TRHNq6bX2uyCSlq/NTFs45JDOUUwTzSa9q0ot2uJ+KYn/t6p\nb7hUIgKeh8CuOQx0lSJDiGMy4zRuwHh/WwdoW+RR0U1a5J3sNGWTFC/qUnLr\nTawfuoTVSFJ7XMSNfpE9kSpf69mkYWBsgWKrC/UQQtX8AQx66f1ki7oyAweF\nNc/D\r\n=9cbf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-d-x_1.0.0_1613597447215_0.8323317511576882"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-17T21:30:47.150Z",
+    "1.0.0": "2021-02-17T21:30:47.425Z",
+    "modified": "2021-02-17T21:30:49.975Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-d-x.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-d-x.min.json
@@ -1,0 +1,29 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-d-x",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-d-x",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-d-y": "1"
+      },
+      "dist": {
+        "integrity": "sha512-8nj3SY7KJbdLLwN2dIwwrSiUld0yzsid7sOP1St6OmUi+roOdqaUfZI7FyWAGlverzCljYRY0iRjbYV3zA5kdw==",
+        "shasum": "6ab84cb07b956ea5c05650c5db0f475374c483d0",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-d-x/-/testing-peer-optional-conflict-d-x-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 278,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLYsICRA9TVsSAnZWagAAoAMQAIW4nZOUVZtTDat1Sr5m\n5Z/APwSkOQjlTNuGNsw/mouvIlLMMOlY+zI4/uFr/b8byAFLGh5/eUw5GmQR\noBugcrCF+FP+IxMe1Q5DkwH7UmnB/8JzxSZeeFW20UsZkjzTDd4d14M6zDyA\nar3t9qd0udT/WFDA+ikhbS/W0qmJC7ekf18+rwpLXP25uIucFCljh20vgt+u\nH/VzVq9rBiA87jjob27L0ReVQK/ZgwClMSuJwmrUYJMVKCKCWkrTLh5y7dG6\n+KM66oBNnHNy+V+Z47Y00684JijUQennWUvU5RhUzJTDuCca9AdtIJ5BkQqK\nvE5RTp3J8l+MELN832sH5ZacGfkRw/CE+8RjIY3nHyIFxDm/46JAl1nAQ4JM\n2cipIYOsIMEcppEOijWQZ0MOrRHW7iM5/jWFG2AHPiTbba4FXsuLxQ7NsJyY\ngPKAiFIqJWJn9NPboD0v68SmYQsbp+y0QjCuG53THgL7t7H99YX6iztn3cRj\n0MbM8YI/6RJ5TRHNq6bX2uyCSlq/NTFs45JDOUUwTzSa9q0ot2uJ+KYn/t6p\nb7hUIgKeh8CuOQx0lSJDiGMy4zRuwHh/WwdoW+RR0U1a5J3sNGWTFC/qUnLr\nTawfuoTVSFJ7XMSNfpE9kSpf69mkYWBsgWKrC/UQQtX8AQx66f1ki7oyAweF\nNc/D\r\n=9cbf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/testing-peer-optional-conflict-d-y": {
+          "optional": true
+        }
+      }
+    }
+  },
+  "modified": "2021-02-17T21:30:49.975Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-d-y.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-d-y.json
@@ -1,0 +1,56 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-d-y",
+  "name": "@isaacs/testing-peer-optional-conflict-d-y",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-d-y",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-d-z": "2"
+      },
+      "_id": "@isaacs/testing-peer-optional-conflict-d-y@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.4",
+      "dist": {
+        "integrity": "sha512-EGhRdChbbzNyK+OadDhk50Zgg10yoO/wcIceEeTRPDJrvfRHYEGsPca5fEj2v29SGtvQ2cDLlvvg8EhqYJG7xg==",
+        "shasum": "f58f3118801105f36a27b9dca8e6c569b63835e4",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-d-y/-/testing-peer-optional-conflict-d-y-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 164,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLYsLCRA9TVsSAnZWagAAkUgQAJzu1rk17iM+XWirP6gq\nnMq9CRA1Yd7emErBHo5Mu8Nzmwkw5PUV4LxY3exw9yEl9yZlGq5e755PCxzG\ng+mJf/eLsN5CD0/XYUCKV5zbVY39jK2U3j3Jm3QrugPHi3dv9jXcl7bWHja1\n0TOAPmyGb38eDXu5inO10cE+1xESxS8jllPNIP48vmcGqZc8bi96+NfjD4RM\n+3Zw8Zi4tZ0aZtCFx++8yGn0i2UJ21TayYf/7BzCowSFB3f4khKCyEIojPb4\nKqmOzSi6lHnB9kgk1NWejgJTe9M+2yi1mNTcSrPKjZbWj8UPUJSFNTr2CnqD\nu6HuQZnk+Gc94ZSwQctUrIbtRYVfqr2kC4QdK481d3zGNBDzmR29bla51c2S\ntmiIzrzm/1h2L0h8pqo87ghCZ2HcRnAy5pkqFGz/aPSecyx91gPh/LlrxLCn\n/A/ts+kyzc9gLYeA6kf5A6TerJ2sjwLYAHaOXxsPari222OUJT9/Ayz7puLT\nNyjjcUsmcriijaTYz9hTd7BaVMbnZkXD7WbNar76QZSwe0/dc9UQ8/rxX72p\nUzQgIpbUfhATMmCHQlSBjobzLuNl2uIL4tgrYKWZ2gPwrNQv+f+SuLTwDKIZ\nZOjI6BC6VewtIJdoaA1Kp50x3aB+jqY9zHzfjnehEVTO+1VN7p/2a1YHMBTC\nKxP8\r\n=m67F\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-d-y_1.0.0_1613597450956_0.2865033799975065"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-17T21:30:50.918Z",
+    "1.0.0": "2021-02-17T21:30:51.070Z",
+    "modified": "2021-02-17T21:30:54.333Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-d-y.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-d-y.min.json
@@ -1,0 +1,24 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-d-y",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-d-y",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-d-z": "2"
+      },
+      "dist": {
+        "integrity": "sha512-EGhRdChbbzNyK+OadDhk50Zgg10yoO/wcIceEeTRPDJrvfRHYEGsPca5fEj2v29SGtvQ2cDLlvvg8EhqYJG7xg==",
+        "shasum": "f58f3118801105f36a27b9dca8e6c569b63835e4",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-d-y/-/testing-peer-optional-conflict-d-y-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 164,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLYsLCRA9TVsSAnZWagAAkUgQAJzu1rk17iM+XWirP6gq\nnMq9CRA1Yd7emErBHo5Mu8Nzmwkw5PUV4LxY3exw9yEl9yZlGq5e755PCxzG\ng+mJf/eLsN5CD0/XYUCKV5zbVY39jK2U3j3Jm3QrugPHi3dv9jXcl7bWHja1\n0TOAPmyGb38eDXu5inO10cE+1xESxS8jllPNIP48vmcGqZc8bi96+NfjD4RM\n+3Zw8Zi4tZ0aZtCFx++8yGn0i2UJ21TayYf/7BzCowSFB3f4khKCyEIojPb4\nKqmOzSi6lHnB9kgk1NWejgJTe9M+2yi1mNTcSrPKjZbWj8UPUJSFNTr2CnqD\nu6HuQZnk+Gc94ZSwQctUrIbtRYVfqr2kC4QdK481d3zGNBDzmR29bla51c2S\ntmiIzrzm/1h2L0h8pqo87ghCZ2HcRnAy5pkqFGz/aPSecyx91gPh/LlrxLCn\n/A/ts+kyzc9gLYeA6kf5A6TerJ2sjwLYAHaOXxsPari222OUJT9/Ayz7puLT\nNyjjcUsmcriijaTYz9hTd7BaVMbnZkXD7WbNar76QZSwe0/dc9UQ8/rxX72p\nUzQgIpbUfhATMmCHQlSBjobzLuNl2uIL4tgrYKWZ2gPwrNQv+f+SuLTwDKIZ\nZOjI6BC6VewtIJdoaA1Kp50x3aB+jqY9zHzfjnehEVTO+1VN7p/2a1YHMBTC\nKxP8\r\n=m67F\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-02-17T21:30:54.333Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-d-z.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-d-z.json
@@ -1,0 +1,86 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-d-z",
+  "_rev": "1-9b8f6b3d118cc1da90c2be49e2b102cb",
+  "name": "@isaacs/testing-peer-optional-conflict-d-z",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-d-z",
+      "version": "1.0.0",
+      "_id": "@isaacs/testing-peer-optional-conflict-d-z@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.4",
+      "dist": {
+        "integrity": "sha512-hELwsNHAN94tT4E1PTSYm3B8wemOd4qfNiNwlhXjr9XDPOUA91fk9vEoP47MvC9B8Cp5C4Ojp77Nmn6KOWqx8A==",
+        "shasum": "018a2ebcd9124ac0fad6edcfadc2d8d36083fd8e",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-d-z/-/testing-peer-optional-conflict-d-z-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLYsRCRA9TVsSAnZWagAArvYP/3a18QV8DSzYGrpgkV9G\nVubkoX1iAPE5yUTHBL8+8jJzmDW/tdHmdTymS2QVAYXnP40WsAR/DqlxOJ7H\niSYyazBEQaNMzK3bg/bqBjtNatwT3nEZHoq/vczUvEBqlDNTjrG43WePjutn\nhI1gJG9qp4pTxCwR8+Im1C2RrmuWyIhSr5zB/Xsx+sMcv95jQEl8M3Cvl/zc\neDTpxkNUieaxf4lt9o7aavtIsvEPyBPwkG6dnlQApxsCn/boEnGZ24nADUoY\nxL90VuQUjSagFOrl9QexaPTxGL3pugBfoJcI4kltwa3UBKGgdjLyJ/QhtgKz\nCTJ4RiCfdUpLNmmDAuyn/ZDrpxRxJ4qrVKqVt9FTzxil0AZRr0RVxth8Bp89\n+SJGJrkNbRoFaRpvlnSgW7zmh1QgT9Y4l8nQSP9njJHbcCV6TGUQ8/fHXxWW\nSbg4e8ZRAwj6XmUNZ7wXySu3Nw8UqzZ3Hxcqcv8aSee1W8oES7Q5ewjnutGz\nxZH9mLJFamGLn9sxJxuZ0PJB3/ct7VG8eAxcUANAwSbiHVF+AEXVYTRMU7sW\nvYGquAU166RSw9YwdLFD3OmZbRw4RQGHwYEcAu9FIFPgx9dAftORKJmLdvZ8\nR/SBLe5OpklA3r//I32920H90GGEsXVb61t+pXBCxLr5oNcUFwcIpX32ME5L\nWibf\r\n=l0jC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-d-z_1.0.0_1613597456507_0.9602939468842844"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-d-z",
+      "version": "2.0.0",
+      "_id": "@isaacs/testing-peer-optional-conflict-d-z@2.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.4",
+      "dist": {
+        "integrity": "sha512-2ccdx08En4W9Ad+FPDToy3UJ8p1XVW2wnuZROnQYe030xbKuvTmS32mWJ+fllkQ6a0FxU0bNhg/1SSXuAhMVUA==",
+        "shasum": "4ba1e3854a5c76ca0c3673da5482ecb4b29043ac",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-d-z/-/testing-peer-optional-conflict-d-z-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLYsUCRA9TVsSAnZWagAAtZQP/juE9+tHCkxeqhG44q4c\nH0wzyfw2CmnMQBDmpsdRLlbYME+j68wPgpOsrR+Oe+aX1eTLcryj7JcdZTwx\nSUX4Gbvq5M1lDXn7s+FlDC9e4CH4ul1wl6paMuPlA6O7fglX3AjiPuvZF2aG\nZ2WwFvtfjX1LuX5pMhS/VjyUYsh0cXi1Dhh7qgiO/k1alT/dvm/3oFL7PZiB\nHQrpHoLAQgA0JH8MUsSnGnGSdAbp0KhqnuRrIQP9b4U06aX/1JDFVvF+XD88\nGn+SU+3XaLwU17PANjI5BgkwBlyqzbm8Hw7cLCDOlhsTQMRzSDsTlUOtx0X8\nMBM8uhRHnlJQG4wxJTESwCKxUWh+SFeTBSRDbE21uAX/RviqqMyYfDQuSqsY\n9NbuS8Tm8AoBY82AGIP084+RnnJLqMZvCCGOsaBagv2Rz11rAkl7lqYwQEcm\n5PuCBRLKk79pGkVG0Mpklcc7+pYk9lfVPIOAQGf9TWCL7cMterREbXofjc3C\nUuqlAupHIlZiw7kzq8luM4Q0WUSiZtdw5+SOaDANAj/IOmF2pzElIuMEj37O\n7G+j2/nUvlp4SR9NI9O3vTpaj1Gz3HujTaoYyPvUcWd4FGDOZnl3ACyinAQ5\n+AGWqLO2Cwyb7L3FJKvM2/kJyX6CDVbwHCYnPR31WYp3pIhbu/fFUpgETJF0\nYgEs\r\n=7LsS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-d-z_2.0.0_1613597459853_0.8458630849734323"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-17T21:30:56.465Z",
+    "1.0.0": "2021-02-17T21:30:56.828Z",
+    "modified": "2021-02-17T21:31:02.265Z",
+    "2.0.0": "2021-02-17T21:30:59.971Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-d-z.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-d-z.min.json
@@ -1,0 +1,33 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-d-z",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-d-z",
+      "version": "1.0.0",
+      "dist": {
+        "integrity": "sha512-hELwsNHAN94tT4E1PTSYm3B8wemOd4qfNiNwlhXjr9XDPOUA91fk9vEoP47MvC9B8Cp5C4Ojp77Nmn6KOWqx8A==",
+        "shasum": "018a2ebcd9124ac0fad6edcfadc2d8d36083fd8e",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-d-z/-/testing-peer-optional-conflict-d-z-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLYsRCRA9TVsSAnZWagAArvYP/3a18QV8DSzYGrpgkV9G\nVubkoX1iAPE5yUTHBL8+8jJzmDW/tdHmdTymS2QVAYXnP40WsAR/DqlxOJ7H\niSYyazBEQaNMzK3bg/bqBjtNatwT3nEZHoq/vczUvEBqlDNTjrG43WePjutn\nhI1gJG9qp4pTxCwR8+Im1C2RrmuWyIhSr5zB/Xsx+sMcv95jQEl8M3Cvl/zc\neDTpxkNUieaxf4lt9o7aavtIsvEPyBPwkG6dnlQApxsCn/boEnGZ24nADUoY\nxL90VuQUjSagFOrl9QexaPTxGL3pugBfoJcI4kltwa3UBKGgdjLyJ/QhtgKz\nCTJ4RiCfdUpLNmmDAuyn/ZDrpxRxJ4qrVKqVt9FTzxil0AZRr0RVxth8Bp89\n+SJGJrkNbRoFaRpvlnSgW7zmh1QgT9Y4l8nQSP9njJHbcCV6TGUQ8/fHXxWW\nSbg4e8ZRAwj6XmUNZ7wXySu3Nw8UqzZ3Hxcqcv8aSee1W8oES7Q5ewjnutGz\nxZH9mLJFamGLn9sxJxuZ0PJB3/ct7VG8eAxcUANAwSbiHVF+AEXVYTRMU7sW\nvYGquAU166RSw9YwdLFD3OmZbRw4RQGHwYEcAu9FIFPgx9dAftORKJmLdvZ8\nR/SBLe5OpklA3r//I32920H90GGEsXVb61t+pXBCxLr5oNcUFwcIpX32ME5L\nWibf\r\n=l0jC\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-d-z",
+      "version": "2.0.0",
+      "dist": {
+        "integrity": "sha512-2ccdx08En4W9Ad+FPDToy3UJ8p1XVW2wnuZROnQYe030xbKuvTmS32mWJ+fllkQ6a0FxU0bNhg/1SSXuAhMVUA==",
+        "shasum": "4ba1e3854a5c76ca0c3673da5482ecb4b29043ac",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-d-z/-/testing-peer-optional-conflict-d-z-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLYsUCRA9TVsSAnZWagAAtZQP/juE9+tHCkxeqhG44q4c\nH0wzyfw2CmnMQBDmpsdRLlbYME+j68wPgpOsrR+Oe+aX1eTLcryj7JcdZTwx\nSUX4Gbvq5M1lDXn7s+FlDC9e4CH4ul1wl6paMuPlA6O7fglX3AjiPuvZF2aG\nZ2WwFvtfjX1LuX5pMhS/VjyUYsh0cXi1Dhh7qgiO/k1alT/dvm/3oFL7PZiB\nHQrpHoLAQgA0JH8MUsSnGnGSdAbp0KhqnuRrIQP9b4U06aX/1JDFVvF+XD88\nGn+SU+3XaLwU17PANjI5BgkwBlyqzbm8Hw7cLCDOlhsTQMRzSDsTlUOtx0X8\nMBM8uhRHnlJQG4wxJTESwCKxUWh+SFeTBSRDbE21uAX/RviqqMyYfDQuSqsY\n9NbuS8Tm8AoBY82AGIP084+RnnJLqMZvCCGOsaBagv2Rz11rAkl7lqYwQEcm\n5PuCBRLKk79pGkVG0Mpklcc7+pYk9lfVPIOAQGf9TWCL7cMterREbXofjc3C\nUuqlAupHIlZiw7kzq8luM4Q0WUSiZtdw5+SOaDANAj/IOmF2pzElIuMEj37O\n7G+j2/nUvlp4SR9NI9O3vTpaj1Gz3HujTaoYyPvUcWd4FGDOZnl3ACyinAQ5\n+AGWqLO2Cwyb7L3FJKvM2/kJyX6CDVbwHCYnPR31WYp3pIhbu/fFUpgETJF0\nYgEs\r\n=7LsS\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-02-17T21:31:02.265Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-e-x.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-e-x.json
@@ -1,0 +1,62 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-e-x",
+  "name": "@isaacs/testing-peer-optional-conflict-e-x",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-e-x",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-e-y": "1",
+        "@isaacs/testing-peer-optional-conflict-e-z": "1"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/testing-peer-optional-conflict-e-y": {
+          "optional": true
+        }
+      },
+      "_id": "@isaacs/testing-peer-optional-conflict-e-x@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.4",
+      "dist": {
+        "integrity": "sha512-6RLUPctc0FHaWNdJVPeoOnGsOrpH3IjBgd8wcuaqGPhEh3nI90LK3r7q9vEdSsmXLHprGwn5UpqMKunVW8yvjA==",
+        "shasum": "99288f3e7ac85b65178c2e9302cd96cbfe29b0ae",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-e-x/-/testing-peer-optional-conflict-e-x-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 333,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLY9eCRA9TVsSAnZWagAAi54P/AxH1OPhBGukgcWUBJwh\nI5E8aWb27CwY0/lxTY1A+Mw920JPc7e0kcIrPb/446TWk7Mt6oxry971n6R+\ns1vAm/S2UOyI08iBiGqVlo5+NGCiSDW87wJnwhEqg8Blw8cJmIej0y4I6Ov3\nmIx3VcdB/DoUjKOZ8xz6ynqm4yOWFEGSKZb2jnr2QHHob8psWWrUOkADAehd\nzi4Bm97nN1FyMk3ys+UQMp9VGWvlTHzE8OQ5YPUEb5F1AW4v7YkBkTPkD0YC\nSfv2Hzw4jvfC7NkVzTTiYRpxB+e9u0o0SipL6F0nAssZqlVK7ZRXbX2FMels\ncgmQKHtedKXpXnACqXI+g0XF+SOER6AdRMFkXDovOIztuH7vKNcMOYFuAoyu\nAgu/IR7UNuZiREMceCA61TNXNn0ARbvFQUtc1yT089OGoEIEsS2TgYfKuRIp\nft1k53dSTOfiv1fsIE6tZUGMCM1uyUS7ZfOwnkpV2K6JZ2zgWgo+ThbIPB+9\nG3Z4NE4XPhmfLB9ooqHbIcmWpK7PFAK0AbJl19wYZ6zc6TdgVHujE3P3JHmv\nykx/hQmiH1VC1L9IGuieFAPl0QleyuF075y/fNb1gmzTlN2dhF3M2Pi1eham\n9BQWnPYKBZ6/B+MRh8bH0Dw0zK5iLJ8f56BCZGKZm9M3E6pbWNGFfFlsvBQv\n+oo3\r\n=WMBf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-e-x_1.0.0_1613598558120_0.7096423493816826"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-17T21:49:18.079Z",
+    "1.0.0": "2021-02-17T21:49:18.225Z",
+    "modified": "2021-02-17T21:49:22.116Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-e-x.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-e-x.min.json
@@ -1,0 +1,30 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-e-x",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-e-x",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-e-y": "1",
+        "@isaacs/testing-peer-optional-conflict-e-z": "1"
+      },
+      "dist": {
+        "integrity": "sha512-6RLUPctc0FHaWNdJVPeoOnGsOrpH3IjBgd8wcuaqGPhEh3nI90LK3r7q9vEdSsmXLHprGwn5UpqMKunVW8yvjA==",
+        "shasum": "99288f3e7ac85b65178c2e9302cd96cbfe29b0ae",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-e-x/-/testing-peer-optional-conflict-e-x-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 333,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLY9eCRA9TVsSAnZWagAAi54P/AxH1OPhBGukgcWUBJwh\nI5E8aWb27CwY0/lxTY1A+Mw920JPc7e0kcIrPb/446TWk7Mt6oxry971n6R+\ns1vAm/S2UOyI08iBiGqVlo5+NGCiSDW87wJnwhEqg8Blw8cJmIej0y4I6Ov3\nmIx3VcdB/DoUjKOZ8xz6ynqm4yOWFEGSKZb2jnr2QHHob8psWWrUOkADAehd\nzi4Bm97nN1FyMk3ys+UQMp9VGWvlTHzE8OQ5YPUEb5F1AW4v7YkBkTPkD0YC\nSfv2Hzw4jvfC7NkVzTTiYRpxB+e9u0o0SipL6F0nAssZqlVK7ZRXbX2FMels\ncgmQKHtedKXpXnACqXI+g0XF+SOER6AdRMFkXDovOIztuH7vKNcMOYFuAoyu\nAgu/IR7UNuZiREMceCA61TNXNn0ARbvFQUtc1yT089OGoEIEsS2TgYfKuRIp\nft1k53dSTOfiv1fsIE6tZUGMCM1uyUS7ZfOwnkpV2K6JZ2zgWgo+ThbIPB+9\nG3Z4NE4XPhmfLB9ooqHbIcmWpK7PFAK0AbJl19wYZ6zc6TdgVHujE3P3JHmv\nykx/hQmiH1VC1L9IGuieFAPl0QleyuF075y/fNb1gmzTlN2dhF3M2Pi1eham\n9BQWnPYKBZ6/B+MRh8bH0Dw0zK5iLJ8f56BCZGKZm9M3E6pbWNGFfFlsvBQv\n+oo3\r\n=WMBf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/testing-peer-optional-conflict-e-y": {
+          "optional": true
+        }
+      }
+    }
+  },
+  "modified": "2021-02-17T21:49:22.116Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-e-y.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-e-y.json
@@ -1,0 +1,56 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-e-y",
+  "name": "@isaacs/testing-peer-optional-conflict-e-y",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-e-y",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-e-z": "2"
+      },
+      "_id": "@isaacs/testing-peer-optional-conflict-e-y@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.4",
+      "dist": {
+        "integrity": "sha512-R+ScmMwhEXtfL3jKHZeWVMuU994y7ke1ebnrzGi1gb2pjYLB0mk5N2M8PtjKZXH97W6C+0DiiW+zxFfDVN+nHA==",
+        "shasum": "604f9becb9f77fa71fd9acd32c5b3135dd76acfe",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-e-y/-/testing-peer-optional-conflict-e-y-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 164,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLY9jCRA9TVsSAnZWagAAbngQAJJz7dj7kf6TtHdC7hTY\nP6elqoP8Vr0T0SHPNt20NYx0H21Es1+tu4QGRV7FLyopBMgUOkWk1QNQq4cI\nn0JHzCwQG6Q/CElWRh4Bt3wXRqG4pgyLMPbuepO+7j3Y7VnMZelmSNuXh/oM\nsLBodL5yv8GmFVWIKafFTZ7aBSJZkqiybb1ANSaHuJTwiTm2I8VgsunwHhuk\n6MS/Fd3zg84HlGCNl2XDb4CYN6Vx5UfUvtLWh7Sgwo5R6rOfjRcK6dFiCAOo\nGz8E9tYh+oK+UeY6fawB3ny3FBn1eSmeP7El/2ZvbD6vDTv8eUQOqfr7afMZ\nvHa5MCmTWviucHyU/HSrshshriaXE3molnugssvCeeTeJPiw5VV0IXYVAhrM\njkJHS0f1NpQXFl/NKjQegRryJ9EvwyLFJjOj78iHlmIG6lvVaDS3qUta6L1g\nglC44HrjV2GqIrWiGNycRrnIx74LUiuvW9IAiEM43bJ9PRhTFthySzSTXSOL\nbNhWNKs7PE5ULPp6mvSX7D868CCGc/8wuUq3WoqDGSbVKbdnWEOdB4uWT52Z\nc2F1vkFjR25QCJmTijhbXa0iDbYuwuF5J/OVKCkFcuD6JSQlIxovMadYp6W1\nrsNypdh0ktzNQKeN458Dfxoy3hkGoDVZ4CermsWc+ZKngBAfw4czpFfIBP68\niqOO\r\n=Rz2F\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-e-y_1.0.0_1613598562997_0.8349095335085308"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-17T21:49:22.960Z",
+    "1.0.0": "2021-02-17T21:49:23.131Z",
+    "modified": "2021-02-17T21:49:25.402Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-e-y.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-e-y.min.json
@@ -1,0 +1,24 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-e-y",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-e-y",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-e-z": "2"
+      },
+      "dist": {
+        "integrity": "sha512-R+ScmMwhEXtfL3jKHZeWVMuU994y7ke1ebnrzGi1gb2pjYLB0mk5N2M8PtjKZXH97W6C+0DiiW+zxFfDVN+nHA==",
+        "shasum": "604f9becb9f77fa71fd9acd32c5b3135dd76acfe",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-e-y/-/testing-peer-optional-conflict-e-y-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 164,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLY9jCRA9TVsSAnZWagAAbngQAJJz7dj7kf6TtHdC7hTY\nP6elqoP8Vr0T0SHPNt20NYx0H21Es1+tu4QGRV7FLyopBMgUOkWk1QNQq4cI\nn0JHzCwQG6Q/CElWRh4Bt3wXRqG4pgyLMPbuepO+7j3Y7VnMZelmSNuXh/oM\nsLBodL5yv8GmFVWIKafFTZ7aBSJZkqiybb1ANSaHuJTwiTm2I8VgsunwHhuk\n6MS/Fd3zg84HlGCNl2XDb4CYN6Vx5UfUvtLWh7Sgwo5R6rOfjRcK6dFiCAOo\nGz8E9tYh+oK+UeY6fawB3ny3FBn1eSmeP7El/2ZvbD6vDTv8eUQOqfr7afMZ\nvHa5MCmTWviucHyU/HSrshshriaXE3molnugssvCeeTeJPiw5VV0IXYVAhrM\njkJHS0f1NpQXFl/NKjQegRryJ9EvwyLFJjOj78iHlmIG6lvVaDS3qUta6L1g\nglC44HrjV2GqIrWiGNycRrnIx74LUiuvW9IAiEM43bJ9PRhTFthySzSTXSOL\nbNhWNKs7PE5ULPp6mvSX7D868CCGc/8wuUq3WoqDGSbVKbdnWEOdB4uWT52Z\nc2F1vkFjR25QCJmTijhbXa0iDbYuwuF5J/OVKCkFcuD6JSQlIxovMadYp6W1\nrsNypdh0ktzNQKeN458Dfxoy3hkGoDVZ4CermsWc+ZKngBAfw4czpFfIBP68\niqOO\r\n=Rz2F\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-02-17T21:49:25.402Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-e-z.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-e-z.json
@@ -1,0 +1,86 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-e-z",
+  "_rev": "1-d51e6604fbdd48c3f37a9cc854690274",
+  "name": "@isaacs/testing-peer-optional-conflict-e-z",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-e-z",
+      "version": "1.0.0",
+      "_id": "@isaacs/testing-peer-optional-conflict-e-z@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.4",
+      "dist": {
+        "integrity": "sha512-K6CLmb2tlz+q3JBhIq4KrBO1jcpescWaYb8bEQ0PJyL4AodYh5TMgS5EWy43s/Z8Nig00/L5yrffI99C/NRXTA==",
+        "shasum": "474df8e53e985a5945ce357d30f2c99102e13658",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-e-z/-/testing-peer-optional-conflict-e-z-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLY9mCRA9TVsSAnZWagAAbHgP/0kXqjT1UkGXiz7D8YtT\nrEwZHp6lz10vA3Vw416zm0pp01mNZuaDlP8wJUbTgJ95MYTNxr9iAtza2A/R\n322ylzJ02RX4DDUXTT7TxAB8vODymnqfqvA/q0+wNtKiXMKOsyWbSQMnKIaf\n8nrtvAA/guiqalAuZsEvsL60OTg7dhmEggCmrWiDWm4PmGHWY4/e/Nx+bpES\nFtsxlO+x0bkfw0o18vBu+eWcJvTqyeQET+OFAyALgjbMu9/CDiIxvTKL7Mgj\nZv9MfFkCUSXq56Ngdupi6WSRh4aJ9HthlzQjKW415v0O8NFjQ9pX2Hxd0SOj\nS78nG+qmnS3adVZhyS5BAD38s7madTk2IDProzANGJnzOQbsh/A6LGok7l5e\nHt364QaLyAoJO7l0w8DcE01xxQ1QwQF/mN6HKDz2nCGTznEsHTFOWdSlQBXs\nDzj0ikLH2VVlHjwDOPRK5onICkGcSaXRJCxpNyUUDo1Siy41hYHr/RdDcX8u\nu4pvmvTD/xLeRoXVIGICX0RwYV3sqx9syYJaSh5L5UWJa4lglC91i7uvM4VY\nQCbrP5wI5KG9pWQNZmk0mRe5l2cjl06PdvV2hxVxdR/ZN6EHbrTp53V37XGe\nbhZBKQ3aK9Ejdr7CzRm47KCXQlbIEogXssbVb1oIF8bwuAUUjWi31wG4t8ah\neLsC\r\n=lRjY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-e-z_1.0.0_1613598566463_0.050827202010111705"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-e-z",
+      "version": "2.0.0",
+      "_id": "@isaacs/testing-peer-optional-conflict-e-z@2.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.4",
+      "dist": {
+        "integrity": "sha512-00PcfalC7Ik35VUwqufEFIGbXbGqgVoekZcsTwhDlmm3AgzqiUgdhgDNiXKMmF93KocxPaoAhihAuiDG+V6mmw==",
+        "shasum": "8d2cad5cf04540db4e2e33a27860ef65313d8a9c",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-e-z/-/testing-peer-optional-conflict-e-z-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLY9rCRA9TVsSAnZWagAAxb0P/jgY44WCv3uJ04tNJ0HC\nFx52mJKbcOl5QnNMT6YcVlxkMYjTf+PtESUBwewT0UP4nbi/4rPi60BtdRV1\nzx4O9Tv9c+Q+dNYKFFXKWbFT8YeWoJKY20aHGsGlyCtt6jbuET0DOpbn/hrG\nK1krHl3kk+AQz+pvmQT7sc4WmYaI9Uqn7JcsUTOjV3smqc9QKCnVMsx13iOA\nMZSyKnJNhSqf2ewacRgpws6+Eu30CHL1O6s6U+ojZ46SCIizbr+1H6gF/4Ev\nU79kMAbBY03jlycPDK7xbf7OxVc6MtyJDYZZjbZNIQD/wTbAgx+pR5204ik4\nAkf2z0hODTdLN0gMo/YheB5WquAW5cRU/QpuqRzv1PwyCKIXV419q5PNS6SL\nwfEKnBmR7SYTEuISXKQ8wZ5PxvHCihN2UStTaGczIuGSyRRKz/ZNcEVBxZoS\nZkCVcP9n5DOo3QU9FDq/BZ05n6//QFWxc3M1EKDjJrSl15dSqOsxLbU9wYzY\nv/IzRFvWUPxqPmrq0II6op8Xyf7rqvsO959YI5m19FoUxXkrYo2iv4N6WE+K\nTmtsg/kjSImF2jlwGl711AxqdB3zpl9R6bCeDTr2eAbtrNdIrjQ3+4yY+KCM\nwT1PGPmBhjJOl8vG96hP4TmJ9ZsuQXVL1AbLdpe2abViA8Z7U3l2dFD24qPz\n0xrP\r\n=cVVq\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-e-z_2.0.0_1613598571632_0.3721525091164768"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-17T21:49:26.398Z",
+    "1.0.0": "2021-02-17T21:49:26.629Z",
+    "modified": "2021-02-17T21:49:33.912Z",
+    "2.0.0": "2021-02-17T21:49:31.732Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-e-z.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-e-z.min.json
@@ -1,0 +1,33 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-e-z",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-e-z",
+      "version": "1.0.0",
+      "dist": {
+        "integrity": "sha512-K6CLmb2tlz+q3JBhIq4KrBO1jcpescWaYb8bEQ0PJyL4AodYh5TMgS5EWy43s/Z8Nig00/L5yrffI99C/NRXTA==",
+        "shasum": "474df8e53e985a5945ce357d30f2c99102e13658",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-e-z/-/testing-peer-optional-conflict-e-z-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLY9mCRA9TVsSAnZWagAAbHgP/0kXqjT1UkGXiz7D8YtT\nrEwZHp6lz10vA3Vw416zm0pp01mNZuaDlP8wJUbTgJ95MYTNxr9iAtza2A/R\n322ylzJ02RX4DDUXTT7TxAB8vODymnqfqvA/q0+wNtKiXMKOsyWbSQMnKIaf\n8nrtvAA/guiqalAuZsEvsL60OTg7dhmEggCmrWiDWm4PmGHWY4/e/Nx+bpES\nFtsxlO+x0bkfw0o18vBu+eWcJvTqyeQET+OFAyALgjbMu9/CDiIxvTKL7Mgj\nZv9MfFkCUSXq56Ngdupi6WSRh4aJ9HthlzQjKW415v0O8NFjQ9pX2Hxd0SOj\nS78nG+qmnS3adVZhyS5BAD38s7madTk2IDProzANGJnzOQbsh/A6LGok7l5e\nHt364QaLyAoJO7l0w8DcE01xxQ1QwQF/mN6HKDz2nCGTznEsHTFOWdSlQBXs\nDzj0ikLH2VVlHjwDOPRK5onICkGcSaXRJCxpNyUUDo1Siy41hYHr/RdDcX8u\nu4pvmvTD/xLeRoXVIGICX0RwYV3sqx9syYJaSh5L5UWJa4lglC91i7uvM4VY\nQCbrP5wI5KG9pWQNZmk0mRe5l2cjl06PdvV2hxVxdR/ZN6EHbrTp53V37XGe\nbhZBKQ3aK9Ejdr7CzRm47KCXQlbIEogXssbVb1oIF8bwuAUUjWi31wG4t8ah\neLsC\r\n=lRjY\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-e-z",
+      "version": "2.0.0",
+      "dist": {
+        "integrity": "sha512-00PcfalC7Ik35VUwqufEFIGbXbGqgVoekZcsTwhDlmm3AgzqiUgdhgDNiXKMmF93KocxPaoAhihAuiDG+V6mmw==",
+        "shasum": "8d2cad5cf04540db4e2e33a27860ef65313d8a9c",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-e-z/-/testing-peer-optional-conflict-e-z-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLY9rCRA9TVsSAnZWagAAxb0P/jgY44WCv3uJ04tNJ0HC\nFx52mJKbcOl5QnNMT6YcVlxkMYjTf+PtESUBwewT0UP4nbi/4rPi60BtdRV1\nzx4O9Tv9c+Q+dNYKFFXKWbFT8YeWoJKY20aHGsGlyCtt6jbuET0DOpbn/hrG\nK1krHl3kk+AQz+pvmQT7sc4WmYaI9Uqn7JcsUTOjV3smqc9QKCnVMsx13iOA\nMZSyKnJNhSqf2ewacRgpws6+Eu30CHL1O6s6U+ojZ46SCIizbr+1H6gF/4Ev\nU79kMAbBY03jlycPDK7xbf7OxVc6MtyJDYZZjbZNIQD/wTbAgx+pR5204ik4\nAkf2z0hODTdLN0gMo/YheB5WquAW5cRU/QpuqRzv1PwyCKIXV419q5PNS6SL\nwfEKnBmR7SYTEuISXKQ8wZ5PxvHCihN2UStTaGczIuGSyRRKz/ZNcEVBxZoS\nZkCVcP9n5DOo3QU9FDq/BZ05n6//QFWxc3M1EKDjJrSl15dSqOsxLbU9wYzY\nv/IzRFvWUPxqPmrq0II6op8Xyf7rqvsO959YI5m19FoUxXkrYo2iv4N6WE+K\nTmtsg/kjSImF2jlwGl711AxqdB3zpl9R6bCeDTr2eAbtrNdIrjQ3+4yY+KCM\nwT1PGPmBhjJOl8vG96hP4TmJ9ZsuQXVL1AbLdpe2abViA8Z7U3l2dFD24qPz\n0xrP\r\n=cVVq\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-02-17T21:49:33.912Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-w.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-w.json
@@ -1,0 +1,56 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-f-w",
+  "name": "@isaacs/testing-peer-optional-conflict-f-w",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-f-w",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-f-z": "1"
+      },
+      "_id": "@isaacs/testing-peer-optional-conflict-f-w@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.4",
+      "dist": {
+        "integrity": "sha512-bPENX1oGtYyWsUULPyDCNefON8innmoLHimntQuGcHzVeC7Aq9xQHSxJIl8Lr892aYOsFX1LJUm7i8PlAS3sRQ==",
+        "shasum": "80f59b34911d56464e0db4ada16f985f99379917",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-f-w/-/testing-peer-optional-conflict-f-w-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 164,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLZCiCRA9TVsSAnZWagAA8Q0P/2zlvCktRxfznZMT3w8c\nO+VxtC1OdrJCrAnod4QPvWnZbMF8JtRS5WbiFgQY+5Q0QQc4EVG91IgDjXOq\nHlYamjvOZ/a54gKn09pBi+y/amXRgu+muWuh71AZQxvJdPLrVYqSUZjod/si\nVY85ixy1BZ2QQV5ZBSIL1UNjSmVg3aJb2qku8Xk8K6i6yrLhck9aZYSHdRfK\nF7PLmZRNsQIGdYKK0OlLfpfz/T3yQog8cIUBUEpOUkGSCpTO+6MJCbHWRGnG\npTRGFjIEqX+2q9R0MVCH0sSkE53HvtxTOgvvc13CFGBjIUTKEfUfs8TuUy7h\nYx+B6E2eofm2IK9FpsEIhH0vS5wegz64dSGjdTWDtEb8yQ42Ztn1YYQvoO2Z\nTLFrYwvv/GW7BaEF0rOmH8fofFZAE75ohtkAGfGluY1WrFza+qNlfkjrObI0\nJkzCiCs7c5OgStDPqfB99f8QNR9C/FWxRNcuy2VqFIoF6GZahCWfU0bKo18u\nJFAmZXt/wKTU3+XF69/UV0ljlxBOIx/krHNDjGiJqW6+KnwRZ5Hgzc5/yYJe\nGCIQG+YTPTTJgK3xkG8hZYSubAWS3gnbdk+O7o0S69raPTAz5PEUEo5EZdJ9\nCMEbXLR8CIQIq6srtw+cyR+c809L1/1FAfklFyNR8+UdxeMwD4YC5MaXsMTV\nql+i\r\n=EYGq\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-f-w_1.0.0_1613598881757_0.45696027955705953"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-17T21:54:41.722Z",
+    "1.0.0": "2021-02-17T21:54:41.903Z",
+    "modified": "2021-02-17T21:54:44.204Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-w.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-w.min.json
@@ -1,0 +1,24 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-f-w",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-f-w",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-f-z": "1"
+      },
+      "dist": {
+        "integrity": "sha512-bPENX1oGtYyWsUULPyDCNefON8innmoLHimntQuGcHzVeC7Aq9xQHSxJIl8Lr892aYOsFX1LJUm7i8PlAS3sRQ==",
+        "shasum": "80f59b34911d56464e0db4ada16f985f99379917",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-f-w/-/testing-peer-optional-conflict-f-w-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 164,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLZCiCRA9TVsSAnZWagAA8Q0P/2zlvCktRxfznZMT3w8c\nO+VxtC1OdrJCrAnod4QPvWnZbMF8JtRS5WbiFgQY+5Q0QQc4EVG91IgDjXOq\nHlYamjvOZ/a54gKn09pBi+y/amXRgu+muWuh71AZQxvJdPLrVYqSUZjod/si\nVY85ixy1BZ2QQV5ZBSIL1UNjSmVg3aJb2qku8Xk8K6i6yrLhck9aZYSHdRfK\nF7PLmZRNsQIGdYKK0OlLfpfz/T3yQog8cIUBUEpOUkGSCpTO+6MJCbHWRGnG\npTRGFjIEqX+2q9R0MVCH0sSkE53HvtxTOgvvc13CFGBjIUTKEfUfs8TuUy7h\nYx+B6E2eofm2IK9FpsEIhH0vS5wegz64dSGjdTWDtEb8yQ42Ztn1YYQvoO2Z\nTLFrYwvv/GW7BaEF0rOmH8fofFZAE75ohtkAGfGluY1WrFza+qNlfkjrObI0\nJkzCiCs7c5OgStDPqfB99f8QNR9C/FWxRNcuy2VqFIoF6GZahCWfU0bKo18u\nJFAmZXt/wKTU3+XF69/UV0ljlxBOIx/krHNDjGiJqW6+KnwRZ5Hgzc5/yYJe\nGCIQG+YTPTTJgK3xkG8hZYSubAWS3gnbdk+O7o0S69raPTAz5PEUEo5EZdJ9\nCMEbXLR8CIQIq6srtw+cyR+c809L1/1FAfklFyNR8+UdxeMwD4YC5MaXsMTV\nql+i\r\n=EYGq\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-02-17T21:54:44.204Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-x.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-x.json
@@ -1,0 +1,63 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-f-x",
+  "name": "@isaacs/testing-peer-optional-conflict-f-x",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-f-x",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-f-w": "1",
+        "@isaacs/testing-peer-optional-conflict-f-y": "1",
+        "@isaacs/testing-peer-optional-conflict-f-z": "1"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/testing-peer-optional-conflict-f-y": {
+          "optional": true
+        }
+      },
+      "_id": "@isaacs/testing-peer-optional-conflict-f-x@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.4",
+      "dist": {
+        "integrity": "sha512-VB5Qtw6tsslX/iLqppiISZ9VaMlkvGswQhs7KFAYOSapvc+hNx2xJNdW4m+ZBjaaTbnqXiANgtl9OOOlc9kEPg==",
+        "shasum": "85d5d46cdb8a4320897a52df1f892398959449a0",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-f-x/-/testing-peer-optional-conflict-f-x-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 388,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLZClCRA9TVsSAnZWagAAtMoP/27ZReRg3mA4aGN7gSTe\n546MkE8BrutJhRvmJoV2rMNvg9apLX0pqoy2koZb+L1/uZ/9csiZjWlauccw\ngUO3asGCpW/lCSFSF8Md/6/2pzervNs+rZ3H7BaOCh0ZMObVgurnLMg46vkS\nfvvGA3KxwJ5Jp/+RDwxyyLm7hp1L8aQsRniSKX3ILt5+9VORy4se3SxH4xnL\n0my9gf8+SRkAiP5uXMaqTh9o147WAjrzr6K2QzfTi9Elavevjyn0dGF59hmn\nA9NGTjPVLMWwuY6lfjKPqDz22awAW0cun61msaX0BCdwEwPRNMrj2h7FvVDy\noN07Jk9Qw/pxTV0M9lyMiqZ+B/QfhnPQrNngWe1IgknWjx8HzBPz1gUbSud+\nIXiKrGbWzUXvEzXMuEFrmORBinxK0gbp2WqQpXFq14Geg+ZkNcDNd/g0zvu3\nTKAnNGcoORo6Z5BBrU6oczVaUd1q9OYXkYcYYQ3gvf+KP46I6p9FvcTIVsCJ\nayEVDvim8KqmUrMEEwtgTVtcCtvzzHuGSULbeXdIn4Isjhq01qcZMsJ4A1xh\ndV4uKsb6KYwUnLOHkWW352b1BUJbVlwnChIJxxiddykJaX4H1k8dQnaGXFTw\n+2LOmMz+DosBCSlmKwhjPrQE9aEjEYfOR9KS3GkkrxTfxEkohTEwGAswAclE\n4cRY\r\n=e8/P\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-f-x_1.0.0_1613598885214_0.48891876479478324"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-17T21:54:45.141Z",
+    "1.0.0": "2021-02-17T21:54:45.316Z",
+    "modified": "2021-02-17T21:54:48.247Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-x.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-x.min.json
@@ -1,0 +1,31 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-f-x",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-f-x",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-f-w": "1",
+        "@isaacs/testing-peer-optional-conflict-f-y": "1",
+        "@isaacs/testing-peer-optional-conflict-f-z": "1"
+      },
+      "dist": {
+        "integrity": "sha512-VB5Qtw6tsslX/iLqppiISZ9VaMlkvGswQhs7KFAYOSapvc+hNx2xJNdW4m+ZBjaaTbnqXiANgtl9OOOlc9kEPg==",
+        "shasum": "85d5d46cdb8a4320897a52df1f892398959449a0",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-f-x/-/testing-peer-optional-conflict-f-x-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 388,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLZClCRA9TVsSAnZWagAAtMoP/27ZReRg3mA4aGN7gSTe\n546MkE8BrutJhRvmJoV2rMNvg9apLX0pqoy2koZb+L1/uZ/9csiZjWlauccw\ngUO3asGCpW/lCSFSF8Md/6/2pzervNs+rZ3H7BaOCh0ZMObVgurnLMg46vkS\nfvvGA3KxwJ5Jp/+RDwxyyLm7hp1L8aQsRniSKX3ILt5+9VORy4se3SxH4xnL\n0my9gf8+SRkAiP5uXMaqTh9o147WAjrzr6K2QzfTi9Elavevjyn0dGF59hmn\nA9NGTjPVLMWwuY6lfjKPqDz22awAW0cun61msaX0BCdwEwPRNMrj2h7FvVDy\noN07Jk9Qw/pxTV0M9lyMiqZ+B/QfhnPQrNngWe1IgknWjx8HzBPz1gUbSud+\nIXiKrGbWzUXvEzXMuEFrmORBinxK0gbp2WqQpXFq14Geg+ZkNcDNd/g0zvu3\nTKAnNGcoORo6Z5BBrU6oczVaUd1q9OYXkYcYYQ3gvf+KP46I6p9FvcTIVsCJ\nayEVDvim8KqmUrMEEwtgTVtcCtvzzHuGSULbeXdIn4Isjhq01qcZMsJ4A1xh\ndV4uKsb6KYwUnLOHkWW352b1BUJbVlwnChIJxxiddykJaX4H1k8dQnaGXFTw\n+2LOmMz+DosBCSlmKwhjPrQE9aEjEYfOR9KS3GkkrxTfxEkohTEwGAswAclE\n4cRY\r\n=e8/P\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "peerDependenciesMeta": {
+        "@isaacs/testing-peer-optional-conflict-f-y": {
+          "optional": true
+        }
+      }
+    }
+  },
+  "modified": "2021-02-17T21:54:48.247Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-y.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-y.json
@@ -1,0 +1,56 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-f-y",
+  "name": "@isaacs/testing-peer-optional-conflict-f-y",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-f-y",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-f-z": "2"
+      },
+      "_id": "@isaacs/testing-peer-optional-conflict-f-y@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.4",
+      "dist": {
+        "integrity": "sha512-HaNdBHdcHsJJneCy3OJkiXebcixSo5PjWffiwpZSpQIGo7cjdeALxi5WrpYd/LKl+SSgM3bgBy/m5PAIRG5q7Q==",
+        "shasum": "dd1e94e7ecd7f91b3b7cd8f1a3c6e483b00ba296",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-f-y/-/testing-peer-optional-conflict-f-y-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 164,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLZCqCRA9TVsSAnZWagAAjS4P/0+JioRg3f+tHFM149hh\nGCToNmS1auLtj35sKQEidri73Hitx3MnPl2F1cfrMZ5amZ9A2KVMHLoWgsFE\n6Da2mKQ90K8lNVakIAaNZjfrDSes8HO05HAwEdUD8SM4w2aw+eeiGV8US37g\nLACoWqzzZp+KQLE9iiU+169tpznYcYZXG5ZqC7zLQnGlmYyGdpmrN4ZVB6rH\n/fbYDIO+Nk9b7nsQShfrQddC49PPUxrGtgEbo7wYYs0mVpO5x475gk8dhCBH\n45nXHXaU+KghZ+hvGFlhQffJY1AiRamBKjsng88h70dKKgFbLChGILioFlrG\npLEWHaa1JXkwCcyRmzc5pZHIzZElBH6MC0K5JEjcyv69kpomySpV0vF56jod\ntcaLrTmMse1xmMhTZZWHFbJWqljpDI9X9GjE9rZYC/cTM8bzGaR21diPst11\nMB353wHEisNexVlMvVjs9m1DobGuo+GkrScSGj6tiSiST8mfeUxEbQvthch2\nVylqYMaCDy7aLJAaRfEJL7C3jaXXlKcvWuTjAackNbUjOqiE2JXWpWUx2lZC\nBlsfPDG4Oy2AY4bxbj2gkxqHMeb6Y3YYDATAvwzZMdx7CYcrXH15QWy5VjSZ\n86RqmkfhpB+mXTi/vjYlaD5AhtmNUFzWbbinTO7Ilm4suqBZK+EYgMrUnY3h\nURRe\r\n=Ah+/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-f-y_1.0.0_1613598889672_0.10989045825888288"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-17T21:54:49.616Z",
+    "1.0.0": "2021-02-17T21:54:49.791Z",
+    "modified": "2021-02-17T21:54:52.028Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-y.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-y.min.json
@@ -1,0 +1,24 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-f-y",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-f-y",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-optional-conflict-f-z": "2"
+      },
+      "dist": {
+        "integrity": "sha512-HaNdBHdcHsJJneCy3OJkiXebcixSo5PjWffiwpZSpQIGo7cjdeALxi5WrpYd/LKl+SSgM3bgBy/m5PAIRG5q7Q==",
+        "shasum": "dd1e94e7ecd7f91b3b7cd8f1a3c6e483b00ba296",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-f-y/-/testing-peer-optional-conflict-f-y-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 164,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLZCqCRA9TVsSAnZWagAAjS4P/0+JioRg3f+tHFM149hh\nGCToNmS1auLtj35sKQEidri73Hitx3MnPl2F1cfrMZ5amZ9A2KVMHLoWgsFE\n6Da2mKQ90K8lNVakIAaNZjfrDSes8HO05HAwEdUD8SM4w2aw+eeiGV8US37g\nLACoWqzzZp+KQLE9iiU+169tpznYcYZXG5ZqC7zLQnGlmYyGdpmrN4ZVB6rH\n/fbYDIO+Nk9b7nsQShfrQddC49PPUxrGtgEbo7wYYs0mVpO5x475gk8dhCBH\n45nXHXaU+KghZ+hvGFlhQffJY1AiRamBKjsng88h70dKKgFbLChGILioFlrG\npLEWHaa1JXkwCcyRmzc5pZHIzZElBH6MC0K5JEjcyv69kpomySpV0vF56jod\ntcaLrTmMse1xmMhTZZWHFbJWqljpDI9X9GjE9rZYC/cTM8bzGaR21diPst11\nMB353wHEisNexVlMvVjs9m1DobGuo+GkrScSGj6tiSiST8mfeUxEbQvthch2\nVylqYMaCDy7aLJAaRfEJL7C3jaXXlKcvWuTjAackNbUjOqiE2JXWpWUx2lZC\nBlsfPDG4Oy2AY4bxbj2gkxqHMeb6Y3YYDATAvwzZMdx7CYcrXH15QWy5VjSZ\n86RqmkfhpB+mXTi/vjYlaD5AhtmNUFzWbbinTO7Ilm4suqBZK+EYgMrUnY3h\nURRe\r\n=Ah+/\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-02-17T21:54:52.028Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-z.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-z.json
@@ -1,0 +1,86 @@
+{
+  "_id": "@isaacs/testing-peer-optional-conflict-f-z",
+  "_rev": "1-c21434b06e4593c7d407a87f3d99f02c",
+  "name": "@isaacs/testing-peer-optional-conflict-f-z",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-f-z",
+      "version": "1.0.0",
+      "_id": "@isaacs/testing-peer-optional-conflict-f-z@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.4",
+      "dist": {
+        "integrity": "sha512-tN2U+DRczopnnLWl7FfP5BcWl9KeqtPUxRv9Ugwx/teVOnaJ7n8otT/afGhijWBT3m2/fGCoTsv8hE0qq41E7g==",
+        "shasum": "619d2f75fe590810194f60c2703b51c8ab04d3ab",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-f-z/-/testing-peer-optional-conflict-f-z-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLZCtCRA9TVsSAnZWagAAndMP/3vzHuzqB+wHsqqBKNl4\nLK9hPisp8m9ZjEpiZbw3k3EOPl6iC+fqxEEaiAdzuo0K7CWwBod5mFishakW\nExBbp/DRC7i+f3EwfzDq0OBOhYyYI5uuXzi3CCC6cJEe7RtjfsrTW1j2PkAu\nzoNy4vY7wmn4OPMnaSSC/dh/lRiwn9Dt1AOcne82yWHxiJtxZfIRQqT+/rKL\nCEGclFuTMjc59CT2xyDA290g/LGP+SoXgSNLbcXP81hK9Kc7Xxflkd5RMcye\nugKD3lwLl5tzkArC4MaBAxya5US+Lh+LyOUCQ/sU4NUnt6O7Gtb1UJViDj4K\nRrWX4Jklb65MyOtn/kVIE1qSrUECumYff0dlM114KBgv75YamWyK4TBUUWq4\n56C4YNVH8HjZYTTsHtipG2lIUVBRX94M1pDOUlsaRT3HshvpkRwFmEhyKucm\n/bMXGM0fyvqw0KM+Kw8jz9qTMkx2HH4fRsS+2MHA939pTSquE6GGoCOT2+zf\nCACmJRdaxiTeWwmR8qOGUNuLcc2FmkJbePuvG0wSSk7huVdUcarVazj27nM6\nhCVR1ATT6ePgQh9HFwyfy0dVivX8lCeSbyQcoxJKNYOc4S6lTHY3XT4NFQ5Z\nBNu0Nx60FQjSrce/gOlx2OdrAahE+pc5xShK2aaIgC3lQm0tRS2kx1JjT5mf\nDhT4\r\n=zNvr\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-f-z_1.0.0_1613598892977_0.34407211444698205"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-f-z",
+      "version": "2.0.0",
+      "_id": "@isaacs/testing-peer-optional-conflict-f-z@2.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.5.4",
+      "dist": {
+        "integrity": "sha512-kcQFJEE2YC+iukBflu4A9aUuHunDSOuvLSIy3Pw6qfRXWgdWq4NQ8vpmnbLkAwp1CQCqLPBS3zr3uGGG7/BsPg==",
+        "shasum": "b5a4e74859440a4619757dcd284777d046f63905",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-f-z/-/testing-peer-optional-conflict-f-z-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLZCwCRA9TVsSAnZWagAAI2QP/3pzC/k9O0iLJfptR0aj\necdlgdjvTF60dJiQfk3jSskW0DMrQEmbKCWaP4NXd+x97GlmvyjMvpgsArho\nt99/F1XXUia79b0Bvsuctz0SLeYQqUYXClhYLYYvuVuUTEsxaAE13bGbPe5v\nPXn9v/yTxTE7LDjfXr7lRP2WJrcaZJ/CO9KaY+XUkE8KA7lU6wRgx5M1z+G7\nJpDpqHBEPKm294Wd3PJJgJJ7ZeCI/YWHVutFpEDnhDD9cUo7uFQM6z2QpwGK\nV6nvWNNasMcDQ7R/CWcwtq2mb4wwfegQbzK3lcrHhrEVwOM9nXAjm/FOE80x\nkaqzBnas2+szVc+51ItTsRZwVrMjIsmq4/gMXzkpzgQjXA7BqeuprYJ6N5wb\n/D6R1/0NAb+pAgdSYSeRYQSldhgOlCw2uYDzSoOAbMYigLDQW+2HTRHEPVbD\nAYI0oRrvZ6glSMDOSCGZqPGJ0blYYiwbEbOVab+ta9hkYA/qcyeU0FVhgvo4\npmYuJy7FqN33D7cdKI3Nb+xoftHPL7sJ9yX+eZndrXQTxYjdicuqE1tIzoLS\n8whcdWYdNooK3/HeV0QbPHRSaEhdRscdMEK6YoP81DgrZW/g1+f6kYQjDFx1\nFkvDSQYBH6zFPYxvNu7reLwDos3UGZRIO4nNqvreSo9xWK/yKdgPTB5WHLzo\nVxRN\r\n=H91d\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-optional-conflict-f-z_2.0.0_1613598896000_0.044281890553892866"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-02-17T21:54:52.938Z",
+    "1.0.0": "2021-02-17T21:54:53.099Z",
+    "modified": "2021-02-17T21:54:58.546Z",
+    "2.0.0": "2021-02-17T21:54:56.146Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-z.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-optional-conflict-f-z.min.json
@@ -1,0 +1,33 @@
+{
+  "name": "@isaacs/testing-peer-optional-conflict-f-z",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-f-z",
+      "version": "1.0.0",
+      "dist": {
+        "integrity": "sha512-tN2U+DRczopnnLWl7FfP5BcWl9KeqtPUxRv9Ugwx/teVOnaJ7n8otT/afGhijWBT3m2/fGCoTsv8hE0qq41E7g==",
+        "shasum": "619d2f75fe590810194f60c2703b51c8ab04d3ab",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-f-z/-/testing-peer-optional-conflict-f-z-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLZCtCRA9TVsSAnZWagAAndMP/3vzHuzqB+wHsqqBKNl4\nLK9hPisp8m9ZjEpiZbw3k3EOPl6iC+fqxEEaiAdzuo0K7CWwBod5mFishakW\nExBbp/DRC7i+f3EwfzDq0OBOhYyYI5uuXzi3CCC6cJEe7RtjfsrTW1j2PkAu\nzoNy4vY7wmn4OPMnaSSC/dh/lRiwn9Dt1AOcne82yWHxiJtxZfIRQqT+/rKL\nCEGclFuTMjc59CT2xyDA290g/LGP+SoXgSNLbcXP81hK9Kc7Xxflkd5RMcye\nugKD3lwLl5tzkArC4MaBAxya5US+Lh+LyOUCQ/sU4NUnt6O7Gtb1UJViDj4K\nRrWX4Jklb65MyOtn/kVIE1qSrUECumYff0dlM114KBgv75YamWyK4TBUUWq4\n56C4YNVH8HjZYTTsHtipG2lIUVBRX94M1pDOUlsaRT3HshvpkRwFmEhyKucm\n/bMXGM0fyvqw0KM+Kw8jz9qTMkx2HH4fRsS+2MHA939pTSquE6GGoCOT2+zf\nCACmJRdaxiTeWwmR8qOGUNuLcc2FmkJbePuvG0wSSk7huVdUcarVazj27nM6\nhCVR1ATT6ePgQh9HFwyfy0dVivX8lCeSbyQcoxJKNYOc4S6lTHY3XT4NFQ5Z\nBNu0Nx60FQjSrce/gOlx2OdrAahE+pc5xShK2aaIgC3lQm0tRS2kx1JjT5mf\nDhT4\r\n=zNvr\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-optional-conflict-f-z",
+      "version": "2.0.0",
+      "dist": {
+        "integrity": "sha512-kcQFJEE2YC+iukBflu4A9aUuHunDSOuvLSIy3Pw6qfRXWgdWq4NQ8vpmnbLkAwp1CQCqLPBS3zr3uGGG7/BsPg==",
+        "shasum": "b5a4e74859440a4619757dcd284777d046f63905",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-optional-conflict-f-z/-/testing-peer-optional-conflict-f-z-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 81,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgLZCwCRA9TVsSAnZWagAAI2QP/3pzC/k9O0iLJfptR0aj\necdlgdjvTF60dJiQfk3jSskW0DMrQEmbKCWaP4NXd+x97GlmvyjMvpgsArho\nt99/F1XXUia79b0Bvsuctz0SLeYQqUYXClhYLYYvuVuUTEsxaAE13bGbPe5v\nPXn9v/yTxTE7LDjfXr7lRP2WJrcaZJ/CO9KaY+XUkE8KA7lU6wRgx5M1z+G7\nJpDpqHBEPKm294Wd3PJJgJJ7ZeCI/YWHVutFpEDnhDD9cUo7uFQM6z2QpwGK\nV6nvWNNasMcDQ7R/CWcwtq2mb4wwfegQbzK3lcrHhrEVwOM9nXAjm/FOE80x\nkaqzBnas2+szVc+51ItTsRZwVrMjIsmq4/gMXzkpzgQjXA7BqeuprYJ6N5wb\n/D6R1/0NAb+pAgdSYSeRYQSldhgOlCw2uYDzSoOAbMYigLDQW+2HTRHEPVbD\nAYI0oRrvZ6glSMDOSCGZqPGJ0blYYiwbEbOVab+ta9hkYA/qcyeU0FVhgvo4\npmYuJy7FqN33D7cdKI3Nb+xoftHPL7sJ9yX+eZndrXQTxYjdicuqE1tIzoLS\n8whcdWYdNooK3/HeV0QbPHRSaEhdRscdMEK6YoP81DgrZW/g1+f6kYQjDFx1\nFkvDSQYBH6zFPYxvNu7reLwDos3UGZRIO4nNqvreSo9xWK/yKdgPTB5WHLzo\nVxRN\r\n=H91d\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-02-17T21:54:58.546Z"
+}


### PR DESCRIPTION

## case D

```
root -> (x, z@1)
x -> PEEROPTIONAL(y)
y -> PEER(z@2)
```

## case E

```
root -> (x, z@1)
x -> PEEROPTIONAL(y) PEER(z@1)
y -> PEER(z@2)
```

## case F

```
root -> (x, z@1)
x -> PEEROPTIONAL(y) PEER(z@1) PEER(w@1)
w -> PEER(z@1)
y -> PEER(z@2)
```

Case F properly reproduces the failure seen by installing
ng-packagr@11.1.3 alongside typescript@4.

Fix: #236

cc: @kyliau