### PR TITLE
feat: edge.explain - include bundled flag

### DIFF
--- a/lib/edge.js
+++ b/lib/edge.js
@@ -92,6 +92,7 @@ class Edge {
       type: this.type,
       name: this.name,
       spec: this.spec,
+      bundled: this.to ? this.to.getBundler() === this.from : false,
       ...(error ? { error } : {}),
       ...(from ? { from: from.explain(null, seen) } : {}),
     }

--- a/test/edge.js
+++ b/test/edge.js
@@ -45,6 +45,9 @@ const top = {
   },
   isTop: true,
   parent: null,
+  getBundler () {
+    return null
+  },
   resolve (n) {
     return n === 'a' ? a : n === 'b' ? b : null
   },
@@ -66,6 +69,9 @@ const a = {
   },
   isTop: false,
   parent: top,
+  getBundler () {
+    return null
+  },
   resolve (n) {
     return n === 'aa' ? aa : this.parent.resolve(n)
   },
@@ -87,6 +93,9 @@ const b = {
   },
   isTop: false,
   parent: top,
+  getBundler () {
+    return null
+  },
   resolve (n) {
     return n === 'aa' ? aa : this.parent.resolve(n)
   },
@@ -108,6 +117,9 @@ const bb = {
   },
   isTop: false,
   parent: b,
+  getBundler () {
+    return null
+  },
   resolve (n) {
     return this.parent.resolve(n)
   },
@@ -129,6 +141,9 @@ const aa = {
   },
   isTop: false,
   parent: a,
+  getBundler () {
+    return null
+  },
   resolve (n) {
     return this.parent.resolve(n)
   },
@@ -150,6 +165,9 @@ const c = {
   },
   isTop: false,
   parent: top,
+  getBundler () {
+    return null
+  },
   resolve (n) {
     return this.parent.resolve(n)
   },

--- a/test/node.js
+++ b/test/node.js
@@ -1601,7 +1601,7 @@ t.test('explain yourself', t => {
     name: 'x',
     version: '1.2.3',
     location: 'node_modules/x',
-    dependents: [{ name: 'x', type: 'prod', spec: '1', from: n.explain() }],
+    dependents: [{ name: 'x', type: 'prod', spec: '1', bundled: false, from: n.explain() }],
   })
 
   const virtual = new Node({
@@ -1634,6 +1634,7 @@ t.test('explain yourself', t => {
         type: 'prod',
         name: 'y',
         spec: '2',
+        bundled: false,
         from: n.explain(),
       },
     ],
@@ -1648,6 +1649,7 @@ t.test('explain yourself', t => {
         type: 'prod',
         name: 'z',
         spec: '3',
+        bundled: false,
         from: y.explain(),
       },
     ],
@@ -1662,6 +1664,7 @@ t.test('explain yourself', t => {
         type: 'prod',
         name: 'a',
         spec: '4',
+        bundled: false,
         from: z.explain(),
       },
     ],
@@ -1704,7 +1707,7 @@ t.test('explain yourself', t => {
     name: 'b',
     version: '9.9.9',
     location: 'node_modules/b',
-    dependents: [{ type: 'prod', name: 'b', spec: '1.2.3', error: 'INVALID', from: n.explain() }],
+    dependents: [{ type: 'prod', name: 'b', spec: '1.2.3', error: 'INVALID', bundled: false, from: n.explain() }],
   })
 
   // explain with a given edge
@@ -1731,6 +1734,7 @@ t.test('explain yourself', t => {
         type: 'prod',
         name: 'b',
         spec: '9',
+        bundled: false,
         from: { location: '/virtual-root' },
       },
     ],
@@ -1756,6 +1760,7 @@ t.test('explain yourself', t => {
         type: 'prod',
         name: 'b',
         spec: '1',
+        bundled: false,
         from: {
           name: 'a',
           version: '1.1.1',
@@ -1765,6 +1770,7 @@ t.test('explain yourself', t => {
               type: 'prod',
               name: 'a',
               spec: '1',
+              bundled: false,
               from: {
                 name: 'b',
                 version: '1.1.1',
@@ -1775,6 +1781,7 @@ t.test('explain yourself', t => {
               type: 'prod',
               name: 'a',
               spec: '1',
+              bundled: false,
               from: {
                 name: 'c',
                 version: '1.1.1',
@@ -1784,6 +1791,7 @@ t.test('explain yourself', t => {
                     type: 'prod',
                     name: 'c',
                     spec: '1',
+                    bundled: false,
                     from: {
                       location: '/cy/cle',
                     },
@@ -1832,6 +1840,7 @@ t.test('explain yourself', t => {
           type: 'prod',
           name: 'd',
           spec: '1',
+          bundled: false,
           from: {
             name: 'c',
             version: '1.2.3',
@@ -1846,6 +1855,7 @@ t.test('explain yourself', t => {
                 type: 'prod',
                 name: 'c',
                 spec: '1',
+                bundled: false,
                 from: {
                   name: 'b',
                   version: '1.2.3',
@@ -1855,6 +1865,7 @@ t.test('explain yourself', t => {
                       type: 'prod',
                       name: 'b',
                       spec: '1',
+                      bundled: false,
                       from: {
                         name: 'a',
                         version: '1.2.3',
@@ -1864,6 +1875,7 @@ t.test('explain yourself', t => {
                             type: 'prod',
                             name: 'a',
                             spec: '1',
+                            bundled: false,
                             from: {
                               location: '/project',
                             },


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

when analyzing a dep graph its useful to see if an Edge is a `bundledDependencies` edge. this is especially useful when trying to understand the provenance of a package's content.

This PR adds a `bundled` flag to the `Edge.prototype.explain` result to indicate if his dependency linkage is a bundled dependency.

## Alternate Implementation

instead of just adding this to the `Edge.prototype.explain` result, it could be added (e.g. as a getter) on the `Edge.prototype` itself, allowing for the package consumer to inspect if an edge is a `bundledDependencies` edge or not.

## References
  Related to https://github.com/npm/cli/pull/2750
