### PR TITLE
Feature: Edges have a "bundled" getter for when they represents a bundled dependency

### DIFF
--- a/lib/edge.js
+++ b/lib/edge.js
@@ -87,14 +87,22 @@ class Edge {
 
   // return the edge data, and an explanation of how that edge came to be here
   [_explain] (seen) {
-    const { error, from } = this
+    const { error, from, bundled } = this
     return {
       type: this.type,
       name: this.name,
       spec: this.spec,
+      ...(bundled ? { bundled } : {}),
       ...(error ? { error } : {}),
       ...(from ? { from: from.explain(null, seen) } : {}),
     }
+  }
+
+  get bundled () {
+    if (!this.from)
+      return false
+    const { package: { bundleDependencies = [] } } = this.from
+    return bundleDependencies.includes(this.name)
   }
 
   get workspace () {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

when analyzing a dep graph its useful to see if an Edge is a `bundledDependencies` edge. this is especially useful when trying to understand the provenance of a package's content.

This PR adds a `bundled` getter property to the `Edge.prototype` which returns true if its a `bundledDependencies` edge or not.

## References
  Related to https://github.com/npm/cli/pull/2750
