### PR TITLE
Respect link deps when calculating peerDep sets

### DIFF
--- a/lib/printable.js
+++ b/lib/printable.js
@@ -63,6 +63,13 @@ class ArboristNode {
   }
 }
 
+class ArboristVirtualNode extends ArboristNode {
+  constructor (tree, path) {
+    super(tree, path)
+    this.sourceReference = printableTree(tree.sourceReference, path)
+  }
+}
+
 class ArboristLink extends ArboristNode {
   constructor (tree, path) {
     super(tree, path)
@@ -119,10 +126,14 @@ class EdgeIn extends Edge {
 }
 
 const printableTree = (tree, path = []) => {
-  if (path.includes(tree))
-    return { location: tree.location }
+  const Cls = tree.isLink ? ArboristLink
+    : tree.sourceReference ? ArboristVirtualNode
+    : ArboristNode
+  if (path.includes(tree)) {
+    const obj = Object.create(Cls.prototype)
+    return Object.assign(obj, { location: tree.location })
+  }
   path.push(tree)
-  const Cls = tree.isLink ? ArboristLink : ArboristNode
   return new Cls(tree, path)
 }
 

--- a/tap-snapshots/test-arborist-load-actual.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-load-actual.js-TAP.test.js
@@ -1893,7 +1893,7 @@ ArboristNode {
       "path": "install-types/node_modules/symlink",
       "realpath": "install-types/abbrev-link-target",
       "resolved": "file:../abbrev-link-target",
-      "target": Object {
+      "target": ArboristNode {
         "location": "abbrev-link-target",
       },
       "version": "1.1.1",
@@ -2045,7 +2045,7 @@ ArboristNode {
       "path": "link-dep-cycle/node_modules/a",
       "realpath": "link-dep-cycle/a",
       "resolved": "file:../a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "a",
       },
     },
@@ -2063,7 +2063,7 @@ ArboristNode {
       "path": "link-dep-cycle/node_modules/b",
       "realpath": "link-dep-cycle/b",
       "resolved": "file:../b",
-      "target": Object {
+      "target": ArboristNode {
         "location": "b",
       },
     },
@@ -2115,7 +2115,7 @@ ArboristNode {
                 "path": "link-dep-cycle/b/node_modules/a",
                 "realpath": "link-dep-cycle/a",
                 "resolved": "file:../../a",
-                "target": Object {
+                "target": ArboristNode {
                   "location": "a",
                 },
               },
@@ -2146,7 +2146,7 @@ ArboristNode {
       "name": "a",
       "path": "link-dep-cycle/a",
     },
-    Object {
+    ArboristNode {
       "location": "b",
     },
   },
@@ -2174,7 +2174,7 @@ ArboristNode {
       "path": "link-dep-nested/node_modules/foo",
       "realpath": "link-dep-nested/once",
       "resolved": "file:../once",
-      "target": Object {
+      "target": ArboristNode {
         "location": "once",
       },
       "version": "1.4.0",
@@ -2193,7 +2193,7 @@ ArboristNode {
       "path": "link-dep-nested/node_modules/once",
       "realpath": "link-dep-nested/once",
       "resolved": "file:../once",
-      "target": Object {
+      "target": ArboristNode {
         "location": "once",
       },
       "version": "1.4.0",
@@ -2295,7 +2295,7 @@ ArboristNode {
             "path": "link-dep-nested/node_modules/foo",
             "realpath": "link-dep-nested/once",
             "resolved": "file:../once",
-            "target": Object {
+            "target": ArboristNode {
               "location": "../once",
             },
             "version": "1.4.0",
@@ -2314,7 +2314,7 @@ ArboristNode {
             "path": "link-dep-nested/node_modules/once",
             "realpath": "link-dep-nested/once",
             "resolved": "file:../once",
-            "target": Object {
+            "target": ArboristNode {
               "location": "../once",
             },
             "version": "1.4.0",
@@ -2818,7 +2818,7 @@ ArboristNode {
       "path": "links-all-over/node_modules/link-link",
       "realpath": "links-all-over/node_modules/nest/node_modules/a/node_modules/b/node_modules/c/node_modules/d/node_modules/deep",
       "resolved": "file:nest/node_modules/a/node_modules/b/node_modules/c/node_modules/d/node_modules/deep",
-      "target": Object {
+      "target": ArboristNode {
         "location": "node_modules/nest/node_modules/a/node_modules/b/node_modules/c/node_modules/d/node_modules/deep",
       },
       "version": "1.2.3",
@@ -2838,7 +2838,7 @@ ArboristNode {
       "path": "links-all-over/node_modules/link-outside-nest",
       "realpath": "links-all-over/real",
       "resolved": "file:../real",
-      "target": Object {
+      "target": ArboristNode {
         "location": "real",
       },
       "version": "1.2.3",
@@ -2853,7 +2853,7 @@ ArboristNode {
                   "children": Map {
                     "d" => ArboristNode {
                       "children": Map {
-                        "deep" => Object {
+                        "deep" => ArboristNode {
                           "location": "node_modules/nest/node_modules/a/node_modules/b/node_modules/c/node_modules/d/node_modules/deep",
                         },
                       },
@@ -2965,7 +2965,7 @@ ArboristNode {
           "path": "links-all-over/node_modules/nest/node_modules/link-in-nest",
           "realpath": "links-all-over/real",
           "resolved": "file:../../../real",
-          "target": Object {
+          "target": ArboristNode {
             "location": "real",
           },
           "version": "1.2.3",
@@ -5315,7 +5315,7 @@ ArboristNode {
       "path": "pnpm/node_modules/@scope/x",
       "realpath": "pnpm/node_modules/.pnpm/registry.npmjs.org/@scope/x/1.0.0/node_modules/@scope/x",
       "resolved": "file:../.pnpm/registry.npmjs.org/@scope/x/1.0.0/node_modules/@scope/x",
-      "target": Object {
+      "target": ArboristNode {
         "location": "node_modules/.pnpm/registry.npmjs.org/@scope/x/1.0.0/node_modules/@scope/x",
       },
       "version": "1.0.0",
@@ -5334,7 +5334,7 @@ ArboristNode {
       "path": "pnpm/node_modules/a",
       "realpath": "pnpm/node_modules/.pnpm/registry.npmjs.org/a/1.0.0/node_modules/a",
       "resolved": "file:.pnpm/registry.npmjs.org/a/1.0.0/node_modules/a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "node_modules/.pnpm/registry.npmjs.org/a/1.0.0/node_modules/a",
       },
       "version": "1.0.0",
@@ -5486,7 +5486,7 @@ ArboristNode {
     },
     ArboristNode {
       "children": Map {
-        "a" => Object {
+        "a" => ArboristNode {
           "location": "node_modules/.pnpm/registry.npmjs.org/a/1.0.0/node_modules/a",
         },
         "b" => ArboristLink {
@@ -5503,7 +5503,7 @@ ArboristNode {
           "path": "pnpm/node_modules/.pnpm/registry.npmjs.org/a/1.0.0/node_modules/b",
           "realpath": "pnpm/node_modules/.pnpm/registry.npmjs.org/b/1.0.0/node_modules/b",
           "resolved": "file:../../../b/1.0.0/node_modules/b",
-          "target": Object {
+          "target": ArboristNode {
             "location": "node_modules/.pnpm/registry.npmjs.org/b/1.0.0/node_modules/b",
           },
           "version": "1.0.0",
@@ -5522,7 +5522,7 @@ ArboristNode {
           "path": "pnpm/node_modules/.pnpm/registry.npmjs.org/a/1.0.0/node_modules/c",
           "realpath": "pnpm/node_modules/.pnpm/registry.npmjs.org/c/1.0.0/node_modules/c",
           "resolved": "file:../../../c/1.0.0/node_modules/c",
-          "target": Object {
+          "target": ArboristNode {
             "location": "node_modules/.pnpm/registry.npmjs.org/c/1.0.0/node_modules/c",
           },
           "version": "1.0.0",
@@ -5534,7 +5534,7 @@ ArboristNode {
     },
     ArboristNode {
       "children": Map {
-        "b" => Object {
+        "b" => ArboristNode {
           "location": "node_modules/.pnpm/registry.npmjs.org/b/1.0.0/node_modules/b",
         },
         "c" => ArboristLink {
@@ -5551,7 +5551,7 @@ ArboristNode {
           "path": "pnpm/node_modules/.pnpm/registry.npmjs.org/b/1.0.0/node_modules/c",
           "realpath": "pnpm/node_modules/.pnpm/registry.npmjs.org/c/1.0.0/node_modules/c",
           "resolved": "file:../../../c/1.0.0/node_modules/c",
-          "target": Object {
+          "target": ArboristNode {
             "location": "node_modules/.pnpm/registry.npmjs.org/c/1.0.0/node_modules/c",
           },
           "version": "1.0.0",
@@ -5577,12 +5577,12 @@ ArboristNode {
           "path": "pnpm/node_modules/.pnpm/registry.npmjs.org/c/1.0.0/node_modules/@scope/x",
           "realpath": "pnpm/node_modules/.pnpm/registry.npmjs.org/@scope/x/1.0.0/node_modules/@scope/x",
           "resolved": "file:../../../../@scope/x/1.0.0/node_modules/@scope/x",
-          "target": Object {
+          "target": ArboristNode {
             "location": "node_modules/.pnpm/registry.npmjs.org/@scope/x/1.0.0/node_modules/@scope/x",
           },
           "version": "1.0.0",
         },
-        "c" => Object {
+        "c" => ArboristNode {
           "location": "node_modules/.pnpm/registry.npmjs.org/c/1.0.0/node_modules/c",
         },
       },
@@ -6071,7 +6071,7 @@ ArboristNode {
     },
     "foo" => ArboristNode {
       "children": Map {
-        "glob" => Object {
+        "glob" => ArboristNode {
           "location": "node_modules/foo/node_modules/glob",
         },
         "selflink" => ArboristLink {
@@ -6088,7 +6088,7 @@ ArboristNode {
           "path": "selflink/node_modules/foo/node_modules/selflink",
           "realpath": "selflink",
           "resolved": "file:../../..",
-          "target": Object {
+          "target": ArboristNode {
             "location": "",
           },
           "version": "1.2.3",
@@ -6301,7 +6301,7 @@ ArboristNode {
     },
     "foo" => ArboristNode {
       "children": Map {
-        "glob" => Object {
+        "glob" => ArboristNode {
           "location": "node_modules/foo/node_modules/glob",
         },
         "selflink" => ArboristLink {
@@ -6318,7 +6318,7 @@ ArboristNode {
           "path": "selflink/node_modules/foo/node_modules/selflink",
           "realpath": "selflink",
           "resolved": "file:../../..",
-          "target": Object {
+          "target": ArboristNode {
             "location": "",
           },
           "version": "1.2.3",
@@ -6458,7 +6458,7 @@ ArboristNode {
       "path": "workspace/node_modules/a",
       "realpath": "workspace/packages/a",
       "resolved": "file:../packages/a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/a",
       },
     },
@@ -6476,7 +6476,7 @@ ArboristNode {
       "path": "workspace/node_modules/b",
       "realpath": "workspace/packages/b",
       "resolved": "file:../packages/b",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/b",
       },
     },
@@ -6494,7 +6494,7 @@ ArboristNode {
       "path": "workspace/node_modules/c",
       "realpath": "workspace/packages/c",
       "resolved": "file:../packages/c",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/c",
       },
     },
@@ -6552,7 +6552,7 @@ ArboristNode {
                 "path": "workspace/packages/b/node_modules/a",
                 "realpath": "workspace/packages/a",
                 "resolved": "file:../../a",
-                "target": Object {
+                "target": ArboristNode {
                   "location": "packages/a",
                 },
               },
@@ -6586,7 +6586,7 @@ ArboristNode {
                       "path": "workspace/packages/c/node_modules/a",
                       "realpath": "workspace/packages/a",
                       "resolved": "file:../../a",
-                      "target": Object {
+                      "target": ArboristNode {
                         "location": "packages/a",
                       },
                     },
@@ -6604,7 +6604,7 @@ ArboristNode {
                       "path": "workspace/packages/c/node_modules/b",
                       "realpath": "workspace/packages/b",
                       "resolved": "file:../../b",
-                      "target": Object {
+                      "target": ArboristNode {
                         "location": "packages/b",
                       },
                     },
@@ -6662,7 +6662,7 @@ ArboristNode {
           "path": "workspace/packages/a/node_modules/c",
           "realpath": "workspace/packages/c",
           "resolved": "file:../../c",
-          "target": Object {
+          "target": ArboristNode {
             "location": "packages/c",
           },
         },
@@ -6685,10 +6685,10 @@ ArboristNode {
       "name": "a",
       "path": "workspace/packages/a",
     },
-    Object {
+    ArboristNode {
       "location": "packages/b",
     },
-    Object {
+    ArboristNode {
       "location": "packages/c",
     },
   },
@@ -6775,7 +6775,7 @@ ArboristNode {
           "path": "workspace2/node_modules/c/node_modules/d",
           "realpath": "workspace2/node_modules/b/node_modules/d",
           "resolved": "file:../../b/node_modules/d",
-          "target": Object {
+          "target": ArboristNode {
             "location": "node_modules/b/node_modules/d",
           },
           "version": "1.2.3",
@@ -6794,7 +6794,7 @@ ArboristNode {
           "path": "workspace2/node_modules/c/node_modules/x",
           "realpath": "workspace2/x",
           "resolved": "file:../../../x",
-          "target": Object {
+          "target": ArboristNode {
             "location": "x",
           },
           "version": "1.2.3",
@@ -6899,7 +6899,7 @@ ArboristNode {
       "peer": true,
       "realpath": "workspace3/packages/a",
       "resolved": "file:../packages/a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/a",
       },
       "version": "1.2.3",
@@ -6914,7 +6914,7 @@ ArboristNode {
       "peer": true,
       "realpath": "workspace3/app",
       "resolved": "file:../app",
-      "target": Object {
+      "target": ArboristNode {
         "location": "app",
       },
       "version": "1.2.3",
@@ -6949,7 +6949,7 @@ ArboristNode {
       "peer": true,
       "realpath": "workspace3/packages/b",
       "resolved": "file:../packages/b",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/b",
       },
       "version": "1.2.3",
@@ -6984,7 +6984,7 @@ ArboristNode {
       "peer": true,
       "realpath": "workspace3/packages/c",
       "resolved": "file:../packages/c",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/c",
       },
       "version": "1.2.3",
@@ -7221,7 +7221,7 @@ ArboristNode {
       "path": "workspaces-simple/node_modules/a",
       "realpath": "workspaces-simple/a",
       "resolved": "file:../a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "a",
       },
       "version": "1.0.0",
@@ -7246,7 +7246,7 @@ ArboristNode {
       "path": "workspaces-simple/node_modules/b",
       "realpath": "workspaces-simple/b",
       "resolved": "file:../b",
-      "target": Object {
+      "target": ArboristNode {
         "location": "b",
       },
       "version": "1.0.0",
@@ -7312,7 +7312,7 @@ ArboristNode {
       "path": "workspaces-simple/node_modules/a",
       "realpath": "workspaces-simple/a",
       "resolved": "file:../a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "a",
       },
       "version": "1.0.0",
@@ -7337,7 +7337,7 @@ ArboristNode {
       "path": "workspaces-simple/node_modules/b",
       "realpath": "workspaces-simple/b",
       "resolved": "file:../b",
-      "target": Object {
+      "target": ArboristNode {
         "location": "b",
       },
       "version": "1.0.0",

--- a/tap-snapshots/test-arborist-load-virtual.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-load-virtual.js-TAP.test.js
@@ -651,7 +651,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/edit-package-json/workspaces-changed/node_modules/a",
       "realpath": "{CWD}/test/fixtures/edit-package-json/workspaces-changed/a",
       "resolved": "file:../a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "a",
       },
       "version": "1.0.0",
@@ -670,7 +670,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/edit-package-json/workspaces-changed/node_modules/b",
       "realpath": "{CWD}/test/fixtures/edit-package-json/workspaces-changed/b",
       "resolved": "file:../b",
-      "target": Object {
+      "target": ArboristNode {
         "location": "b",
       },
       "version": "1.0.0",
@@ -737,7 +737,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-simple-virtual/node_modules/a",
       "realpath": "{CWD}/test/fixtures/workspaces-simple-virtual/a",
       "resolved": "file:../a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "a",
       },
       "version": "1.0.0",
@@ -762,7 +762,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-simple-virtual/node_modules/b",
       "realpath": "{CWD}/test/fixtures/workspaces-simple-virtual/b",
       "resolved": "file:../b",
-      "target": Object {
+      "target": ArboristNode {
         "location": "b",
       },
       "version": "1.0.0",
@@ -12795,7 +12795,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/pnpm/node_modules/@scope/x",
       "realpath": "{CWD}/test/fixtures/pnpm/node_modules/.pnpm/registry.npmjs.org/@scope/x/1.0.0/node_modules/@scope/x",
       "resolved": "file:../.pnpm/registry.npmjs.org/@scope/x/1.0.0/node_modules/@scope/x",
-      "target": Object {
+      "target": ArboristNode {
         "location": "node_modules/.pnpm/registry.npmjs.org/@scope/x/1.0.0/node_modules/@scope/x",
       },
       "version": "1.0.0",
@@ -12814,7 +12814,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/pnpm/node_modules/a",
       "realpath": "{CWD}/test/fixtures/pnpm/node_modules/.pnpm/registry.npmjs.org/a/1.0.0/node_modules/a",
       "resolved": "file:.pnpm/registry.npmjs.org/a/1.0.0/node_modules/a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "node_modules/.pnpm/registry.npmjs.org/a/1.0.0/node_modules/a",
       },
       "version": "1.0.0",
@@ -12966,7 +12966,7 @@ ArboristNode {
     },
     ArboristNode {
       "children": Map {
-        "a" => Object {
+        "a" => ArboristNode {
           "location": "node_modules/.pnpm/registry.npmjs.org/a/1.0.0/node_modules/a",
         },
         "b" => ArboristLink {
@@ -12983,7 +12983,7 @@ ArboristNode {
           "path": "{CWD}/test/fixtures/pnpm/node_modules/.pnpm/registry.npmjs.org/a/1.0.0/node_modules/b",
           "realpath": "{CWD}/test/fixtures/pnpm/node_modules/.pnpm/registry.npmjs.org/b/1.0.0/node_modules/b",
           "resolved": "file:../../../b/1.0.0/node_modules/b",
-          "target": Object {
+          "target": ArboristNode {
             "location": "node_modules/.pnpm/registry.npmjs.org/b/1.0.0/node_modules/b",
           },
           "version": "1.0.0",
@@ -13002,7 +13002,7 @@ ArboristNode {
           "path": "{CWD}/test/fixtures/pnpm/node_modules/.pnpm/registry.npmjs.org/a/1.0.0/node_modules/c",
           "realpath": "{CWD}/test/fixtures/pnpm/node_modules/.pnpm/registry.npmjs.org/c/1.0.0/node_modules/c",
           "resolved": "file:../../../c/1.0.0/node_modules/c",
-          "target": Object {
+          "target": ArboristNode {
             "location": "node_modules/.pnpm/registry.npmjs.org/c/1.0.0/node_modules/c",
           },
           "version": "1.0.0",
@@ -13014,7 +13014,7 @@ ArboristNode {
     },
     ArboristNode {
       "children": Map {
-        "b" => Object {
+        "b" => ArboristNode {
           "location": "node_modules/.pnpm/registry.npmjs.org/b/1.0.0/node_modules/b",
         },
         "c" => ArboristLink {
@@ -13031,7 +13031,7 @@ ArboristNode {
           "path": "{CWD}/test/fixtures/pnpm/node_modules/.pnpm/registry.npmjs.org/b/1.0.0/node_modules/c",
           "realpath": "{CWD}/test/fixtures/pnpm/node_modules/.pnpm/registry.npmjs.org/c/1.0.0/node_modules/c",
           "resolved": "file:../../../c/1.0.0/node_modules/c",
-          "target": Object {
+          "target": ArboristNode {
             "location": "node_modules/.pnpm/registry.npmjs.org/c/1.0.0/node_modules/c",
           },
           "version": "1.0.0",
@@ -13057,12 +13057,12 @@ ArboristNode {
           "path": "{CWD}/test/fixtures/pnpm/node_modules/.pnpm/registry.npmjs.org/c/1.0.0/node_modules/@scope/x",
           "realpath": "{CWD}/test/fixtures/pnpm/node_modules/.pnpm/registry.npmjs.org/@scope/x/1.0.0/node_modules/@scope/x",
           "resolved": "file:../../../../@scope/x/1.0.0/node_modules/@scope/x",
-          "target": Object {
+          "target": ArboristNode {
             "location": "node_modules/.pnpm/registry.npmjs.org/@scope/x/1.0.0/node_modules/@scope/x",
           },
           "version": "1.0.0",
         },
-        "c" => Object {
+        "c" => ArboristNode {
           "location": "node_modules/.pnpm/registry.npmjs.org/c/1.0.0/node_modules/c",
         },
       },
@@ -13606,7 +13606,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/install-types/node_modules/symlink",
       "realpath": "{CWD}/test/fixtures/install-types/abbrev-link-target",
       "resolved": "file:../abbrev-link-target",
-      "target": Object {
+      "target": ArboristNode {
         "location": "abbrev-link-target",
       },
       "version": "1.1.1",
@@ -13618,7 +13618,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/install-types/node_modules/symlink-in-tree",
       "realpath": "{CWD}/test/fixtures/install-types/node_modules/abbrev",
       "resolved": "file:abbrev",
-      "target": Object {
+      "target": ArboristNode {
         "location": "node_modules/abbrev",
       },
       "version": "1.1.1",
@@ -14288,7 +14288,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/install-types/node_modules/symlink",
       "realpath": "{CWD}/test/fixtures/install-types/abbrev-link-target",
       "resolved": "file:../abbrev-link-target",
-      "target": Object {
+      "target": ArboristNode {
         "location": "abbrev-link-target",
       },
       "version": "1.1.1",
@@ -14300,7 +14300,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/install-types/node_modules/symlink-in-tree",
       "realpath": "{CWD}/test/fixtures/install-types/node_modules/abbrev",
       "resolved": "file:abbrev",
-      "target": Object {
+      "target": ArboristNode {
         "location": "node_modules/abbrev",
       },
       "version": "1.1.1",
@@ -14970,7 +14970,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/load-virtual-load-from-npm-shrinkwrap-json/node_modules/symlink",
       "realpath": "{CWD}/test/arborist/load-virtual-load-from-npm-shrinkwrap-json/abbrev-link-target",
       "resolved": "file:../abbrev-link-target",
-      "target": Object {
+      "target": ArboristNode {
         "location": "abbrev-link-target",
       },
     },
@@ -14981,7 +14981,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/load-virtual-load-from-npm-shrinkwrap-json/node_modules/symlink-in-tree",
       "realpath": "{CWD}/test/arborist/load-virtual-load-from-npm-shrinkwrap-json/node_modules/abbrev",
       "resolved": "file:abbrev",
-      "target": Object {
+      "target": ArboristNode {
         "location": "node_modules/abbrev",
       },
       "version": "1.1.1",
@@ -15568,7 +15568,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/install-types-sw-only/node_modules/symlink",
       "realpath": "{CWD}/test/fixtures/install-types-sw-only/abbrev-link-target",
       "resolved": "file:../abbrev-link-target",
-      "target": Object {
+      "target": ArboristNode {
         "location": "abbrev-link-target",
       },
     },
@@ -15579,7 +15579,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/install-types-sw-only/node_modules/symlink-in-tree",
       "realpath": "{CWD}/test/fixtures/install-types-sw-only/node_modules/abbrev",
       "resolved": "file:abbrev",
-      "target": Object {
+      "target": ArboristNode {
         "location": "node_modules/abbrev",
       },
       "version": "1.1.1",
@@ -15658,7 +15658,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/cli-750/node_modules/app",
       "realpath": "{CWD}/test/fixtures/cli-750/app",
       "resolved": "file:../app",
-      "target": Object {
+      "target": ArboristNode {
         "location": "app",
       },
     },
@@ -15676,7 +15676,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/cli-750/node_modules/lib",
       "realpath": "{CWD}/test/fixtures/cli-750/lib",
       "resolved": "file:../lib",
-      "target": Object {
+      "target": ArboristNode {
         "location": "lib",
       },
     },
@@ -15733,7 +15733,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-simple-virtual/node_modules/a",
       "realpath": "{CWD}/test/fixtures/workspaces-simple-virtual/a",
       "resolved": "file:../a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "a",
       },
       "version": "1.0.0",
@@ -15758,7 +15758,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-simple-virtual/node_modules/b",
       "realpath": "{CWD}/test/fixtures/workspaces-simple-virtual/b",
       "resolved": "file:../b",
-      "target": Object {
+      "target": ArboristNode {
         "location": "b",
       },
       "version": "1.0.0",
@@ -15824,7 +15824,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-conflicting-versions-virtual/node_modules/a",
       "realpath": "{CWD}/test/fixtures/workspaces-conflicting-versions-virtual/packages/a",
       "resolved": "file:../packages/a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/a",
       },
       "version": "1.0.0",
@@ -15858,7 +15858,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-conflicting-versions-virtual/node_modules/b",
       "realpath": "{CWD}/test/fixtures/workspaces-conflicting-versions-virtual/packages/b",
       "resolved": "file:../packages/b",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/b",
       },
       "version": "1.0.0",
@@ -15973,7 +15973,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-version-unsatisfied-virtual/node_modules/a",
       "realpath": "{CWD}/test/fixtures/workspaces-version-unsatisfied-virtual/packages/a",
       "resolved": "file:../packages/a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/a",
       },
       "version": "1.0.0",
@@ -15992,7 +15992,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-version-unsatisfied-virtual/node_modules/abbrev",
       "realpath": "{CWD}/test/fixtures/workspaces-version-unsatisfied-virtual/packages/abbrev",
       "resolved": "file:../packages/abbrev",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/abbrev",
       },
       "version": "2.0.0",
@@ -16076,7 +16076,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-ignore-nm-virtual/node_modules/a",
       "realpath": "{CWD}/test/fixtures/workspaces-ignore-nm-virtual/packages/a",
       "resolved": "file:../packages/a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/a",
       },
       "version": "1.0.0",
@@ -16122,7 +16122,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-transitive-deps-virtual/node_modules/a",
       "realpath": "{CWD}/test/fixtures/workspaces-transitive-deps-virtual/packages/a",
       "resolved": "file:../packages/a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/a",
       },
       "version": "1.0.0",
@@ -16217,7 +16217,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-top-level-link-virtual/node_modules/a",
       "realpath": "{CWD}/test/fixtures/workspaces-top-level-link-virtual/packages/a",
       "resolved": "file:../packages/a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/a",
       },
       "version": "1.0.0",
@@ -16264,7 +16264,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-prefer-linking-virtual/node_modules/a",
       "realpath": "{CWD}/test/fixtures/workspaces-prefer-linking-virtual/packages/a",
       "resolved": "file:../packages/a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/a",
       },
       "version": "1.0.0",
@@ -16289,7 +16289,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-prefer-linking-virtual/node_modules/abbrev",
       "realpath": "{CWD}/test/fixtures/workspaces-prefer-linking-virtual/packages/abbrev",
       "resolved": "file:../packages/abbrev",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/abbrev",
       },
       "version": "2.0.0",
@@ -16356,7 +16356,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-shared-deps-virtual/node_modules/a",
       "realpath": "{CWD}/test/fixtures/workspaces-shared-deps-virtual/packages/a",
       "resolved": "file:../packages/a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/a",
       },
       "version": "1.0.0",
@@ -16396,7 +16396,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-shared-deps-virtual/node_modules/b",
       "realpath": "{CWD}/test/fixtures/workspaces-shared-deps-virtual/packages/b",
       "resolved": "file:../packages/b",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/b",
       },
       "version": "1.0.0",
@@ -16415,7 +16415,7 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-shared-deps-virtual/node_modules/c",
       "realpath": "{CWD}/test/fixtures/workspaces-shared-deps-virtual/packages/c",
       "resolved": "file:../packages/c",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/c",
       },
       "version": "1.0.0",

--- a/tap-snapshots/test-arborist-reify.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-reify.js-TAP.test.js
@@ -28,7 +28,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-a-workspace-with-a-duplicated-nested-conflicted-dep/node_modules/bar",
       "realpath": "{CWD}/test/arborist/reify-a-workspace-with-a-duplicated-nested-conflicted-dep/packages/bar",
       "resolved": "file:../packages/bar",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/bar",
       },
       "version": "1.2.3",
@@ -47,7 +47,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-a-workspace-with-a-duplicated-nested-conflicted-dep/node_modules/foo",
       "realpath": "{CWD}/test/arborist/reify-a-workspace-with-a-duplicated-nested-conflicted-dep/packages/foo",
       "resolved": "file:../packages/foo",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/foo",
       },
       "version": "1.2.3",
@@ -417,7 +417,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-create-link-deps/node_modules/linked-dep",
       "realpath": "{CWD}/test/arborist/reify-create-link-deps/target",
       "resolved": "file:../target",
-      "target": Object {
+      "target": ArboristNode {
         "location": "target",
       },
       "version": "1.2.3",
@@ -1114,7 +1114,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-dry-run-do-not-get-anything-wet-link-dep-empty/node_modules/linked-dep",
       "realpath": "{CWD}/test/arborist/reify-dry-run-do-not-get-anything-wet-link-dep-empty/target",
       "resolved": "file:../target",
-      "target": Object {
+      "target": ArboristNode {
         "location": "target",
       },
       "version": "1.2.3",
@@ -1207,7 +1207,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-dry-run-do-not-get-anything-wet-link-meta-deps-empty/node_modules/linked-dep",
       "realpath": "{CWD}/test/arborist/reify-dry-run-do-not-get-anything-wet-link-meta-deps-empty/node_modules/@isaacs/testing-link-dep/target",
       "resolved": "file:@isaacs/testing-link-dep/target",
-      "target": Object {
+      "target": ArboristNode {
         "location": "node_modules/@isaacs/testing-link-dep/target",
       },
     },
@@ -1713,7 +1713,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-link-deps-already-in-place/node_modules/linked-dep",
       "realpath": "{CWD}/test/arborist/reify-link-deps-already-in-place/target",
       "resolved": "file:../target",
-      "target": Object {
+      "target": ArboristNode {
         "location": "target",
       },
       "version": "1.2.3",
@@ -1806,7 +1806,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-link-meta-deps-fresh-install/node_modules/linked-dep",
       "realpath": "{CWD}/test/arborist/reify-link-meta-deps-fresh-install/node_modules/@isaacs/testing-link-dep/target",
       "resolved": "file:@isaacs/testing-link-dep/target",
-      "target": Object {
+      "target": ArboristNode {
         "location": "node_modules/@isaacs/testing-link-dep/target",
       },
     },
@@ -1850,7 +1850,7 @@ ArboristNode {
           "path": "{CWD}/test/arborist/reify-link-meta-deps-update/node_modules/@isaacs/testing-link-dep/node_modules/linked-dep",
           "realpath": "{CWD}/test/arborist/reify-link-meta-deps-update/node_modules/@isaacs/testing-link-dep/target",
           "resolved": "file:../target",
-          "target": Object {
+          "target": ArboristNode {
             "location": "node_modules/@isaacs/testing-link-dep/target",
           },
           "version": "1.2.3",
@@ -1940,7 +1940,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-link-metadep-cli-750/node_modules/app",
       "realpath": "{CWD}/test/arborist/reify-link-metadep-cli-750/app",
       "resolved": "file:../app",
-      "target": Object {
+      "target": ArboristNode {
         "location": "app",
       },
     },
@@ -1958,7 +1958,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-link-metadep-cli-750/node_modules/lib",
       "realpath": "{CWD}/test/arborist/reify-link-metadep-cli-750/lib",
       "resolved": "file:../lib",
-      "target": Object {
+      "target": ArboristNode {
         "location": "lib",
       },
     },
@@ -2015,7 +2015,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-link-metadep-cli-750-fresh/node_modules/app",
       "realpath": "{CWD}/test/arborist/reify-link-metadep-cli-750-fresh/app",
       "resolved": "file:../app",
-      "target": Object {
+      "target": ArboristNode {
         "location": "app",
       },
     },
@@ -2033,7 +2033,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-link-metadep-cli-750-fresh/node_modules/lib",
       "realpath": "{CWD}/test/arborist/reify-link-metadep-cli-750-fresh/lib",
       "resolved": "file:../lib",
-      "target": Object {
+      "target": ArboristNode {
         "location": "lib",
       },
     },
@@ -29765,7 +29765,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-transitive-deps-containing-asymmetrical-bin-no-lockfile/node_modules/a",
       "realpath": "{CWD}/test/arborist/reify-transitive-deps-containing-asymmetrical-bin-no-lockfile/a",
       "resolved": "file:../a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "a",
       },
       "version": "1.0.0",
@@ -29784,7 +29784,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-transitive-deps-containing-asymmetrical-bin-no-lockfile/node_modules/b",
       "realpath": "{CWD}/test/arborist/reify-transitive-deps-containing-asymmetrical-bin-no-lockfile/b",
       "resolved": "file:../b",
-      "target": Object {
+      "target": ArboristNode {
         "location": "b",
       },
       "version": "1.0.0",
@@ -29876,7 +29876,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-transitive-deps-containing-asymmetrical-bin-with-lockfile/node_modules/a",
       "realpath": "{CWD}/test/arborist/reify-transitive-deps-containing-asymmetrical-bin-with-lockfile/a",
       "resolved": "file:../a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "a",
       },
       "version": "1.0.0",
@@ -29895,7 +29895,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-transitive-deps-containing-asymmetrical-bin-with-lockfile/node_modules/b",
       "realpath": "{CWD}/test/arborist/reify-transitive-deps-containing-asymmetrical-bin-with-lockfile/b",
       "resolved": "file:../b",
-      "target": Object {
+      "target": ArboristNode {
         "location": "b",
       },
       "version": "1.0.0",
@@ -49019,7 +49019,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-workspaces-reify-from-an-actual-loaded-workspace-env/node_modules/pkg-a",
       "realpath": "{CWD}/test/arborist/reify-workspaces-reify-from-an-actual-loaded-workspace-env/a",
       "resolved": "file:../a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "a",
       },
     },
@@ -49078,7 +49078,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-workspaces-reify-simple-workspaces/node_modules/a",
       "realpath": "{CWD}/test/arborist/reify-workspaces-reify-simple-workspaces/a",
       "resolved": "file:../a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "a",
       },
       "version": "1.0.0",
@@ -49103,7 +49103,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-workspaces-reify-simple-workspaces/node_modules/b",
       "realpath": "{CWD}/test/arborist/reify-workspaces-reify-simple-workspaces/b",
       "resolved": "file:../b",
-      "target": Object {
+      "target": ArboristNode {
         "location": "b",
       },
       "version": "1.0.0",
@@ -49169,7 +49169,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-workspaces-reify-workspaces-bin-files/node_modules/a",
       "realpath": "{CWD}/test/arborist/reify-workspaces-reify-workspaces-bin-files/packages/a",
       "resolved": "file:../packages/a",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/a",
       },
       "version": "1.0.0",
@@ -49188,7 +49188,7 @@ ArboristNode {
       "path": "{CWD}/test/arborist/reify-workspaces-reify-workspaces-bin-files/node_modules/b",
       "realpath": "{CWD}/test/arborist/reify-workspaces-reify-workspaces-bin-files/packages/b",
       "resolved": "file:../packages/b",
-      "target": Object {
+      "target": ArboristNode {
         "location": "packages/b",
       },
       "version": "1.0.0",

--- a/tap-snapshots/test-calc-dep-flags.js-TAP.test.js
+++ b/tap-snapshots/test-calc-dep-flags.js-TAP.test.js
@@ -64,7 +64,7 @@ ArboristNode {
           "path": "/x/node_modules/devdep/node_modules/linky",
           "realpath": "/x/y/z",
           "resolved": "file:../../../y/z",
-          "target": Object {
+          "target": ArboristNode {
             "location": "y/z",
           },
           "version": "1.2.3",

--- a/tap-snapshots/test-printable.js-TAP.test.js
+++ b/tap-snapshots/test-printable.js-TAP.test.js
@@ -194,3 +194,24 @@ optional:true,
 peer:true,
 target:{location:'c'}}}}
 `
+
+exports[`test/printable.js TAP virtual roots are shown with their sourceReference > must match snapshot 1`] = `
+ArboristVirtualNode{
+"dev":true,
+"extraneous":true,
+"location":undefined,
+"name":"baz",
+"optional":true,
+"path":null,
+"peer":true,
+"sourceReference":{
+"dev":true,
+"extraneous":true,
+"location":"",
+"name":"baz",
+"optional":true,
+"path":"/foo/bar/baz",
+"peer":true,
+"version":"1.2.3",},
+"version":"1.2.3",}
+`

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-vv.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-vv.json
@@ -1,0 +1,92 @@
+{
+  "_id": "@isaacs/testing-peer-dep-conflict-chain-vv",
+  "_rev": "1-efdd1288ff2d87bb801612ad93be34b2",
+  "name": "@isaacs/testing-peer-dep-conflict-chain-vv",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-vv",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-v": "1"
+      },
+      "_id": "@isaacs/testing-peer-dep-conflict-chain-vv@1.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.6.0",
+      "dist": {
+        "integrity": "sha512-8CbQaqnv9GsTN+Kz6iWPLYLV7hOVQIDTpeZdDM3FXs7WW03uDI7S3rlFRdkc0ansSPMpnZb2SYTHbKn/W56G3g==",
+        "shasum": "6e7d8c0d29e215e2a74656483c4bdeb05b91174d",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-vv/-/testing-peer-dep-conflict-chain-vv-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 163,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgR8kHCRA9TVsSAnZWagAAIjAP/jw+div6Cal6j9QvCdPX\n1anNxvxYW2/ykeZpN0atcNaAYsnDaAIC7vmCeNOk6RJfIin7ASOefKQ0MhZY\nxjRPTn/9MoeuQgsqXbtjEzy0+ubn7FuX5PjayhDUtkp+dWN4gkEY99Y9Fi+k\nlq+XxtkAhuFj4+soT3tTLeXQDX6SPuiq8DgIF2owzejvXo4aR0AL+EJ3dBKD\nvAFXZb46Yty3Qgg7uu6sw4CKxSlMvdVr4ubfJ8libLFoLKhelvwjOs6cT3GP\n/JUsuYOjf2sfW8mMjUyG7kK7vO7PteQQp6wURJIgJWpAfHOgIS3uAC8xrfde\nPGNJXkECPJ7P3ixDEsjRAsecPKalsmojiSuXzVhmlFZNG4n81VMXGG7X6Irl\n3ZUAnMqBRma8DqD/gI+D32wrw3kM/ZvHK4aybVitjw2uSYKR7KXbnnN1zkDp\nPUuSP+2/FRQS0LTRU9xfhnb5Fcmap6jDrn4KpVkx6VbvwDaSigxh5zO+mpOi\nx29gc6q8niWuUdUUFYjyR75hl1wIJHyk5d40xW+1oIaCY8K1aE2cFbtXyOwo\nk4cO36c0hjQzFb6p25DHVfqz7TzS/tHdh5H6XpdSZcp3XI9xF50RSj8TSmxY\nyIobDniIeHQc+wlOiWSQZIlbvuTLiZb22RuqOktIlZd3/f2NMoCc9fzkFqK3\nriTZ\r\n=LyXS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-conflict-chain-vv_1.0.0_1615317254590_0.5802183600068374"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-vv",
+      "version": "2.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-v": "2"
+      },
+      "_id": "@isaacs/testing-peer-dep-conflict-chain-vv@2.0.0",
+      "_nodeVersion": "15.3.0",
+      "_npmVersion": "7.6.0",
+      "dist": {
+        "integrity": "sha512-GKxX5OHPD+i0EmjO03QnUSKxXQr6QzFVAza0fkEEUyg2/ju07BuhzhkpbxsEByFaiiQhIfsx2kmcSHtXY5hwTg==",
+        "shasum": "27f9622c7253589a5575e60c29fbb2380f14c54f",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-vv/-/testing-peer-dep-conflict-chain-vv-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 163,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgR8kNCRA9TVsSAnZWagAA97QP/i2ccR4jX9imu4EL0m+2\nD7OINfojL59pXHsCUgB25pD8OBnt4oN77RTjQQ8t930Z+PFOf7gsLA9ApJDd\nNIisf89786ymKDleuh6BR09AazyzSkM5oiEYvnNnAf6KvIctHJ5kPAq8VOyO\nIDjL40TSisuL0Om8h6NXaOdzR+TdyRP61hjPdse8VOpNwkui4gzTjiSX+WJg\nJ9xBnCS0wBkKVXoi4pCebtATUmLGGhOMv0pq0mY+bHdRa7n4r8J81v74nlyw\ndzWL6/J6b/ncUyX9Jy4ilDvnfH1I8h6U28xqzAHAYzpu0BzeTfnhJo9m+M8Y\nmNDIkXDWPeOP+pJqSocGUhYzFdBIY5EgNOcdUcD3AamocnxaOZ8Sm2ywLuBi\nv4mTj2QA0BD0WzVaJmqhQDuo6oTmP4jftg0MXz195Ncnz0xFgUdz3JDdqUas\nhTNRyw+M/h/sGgxhISELPN3fyeRiidB6whkrZZBmy5dSJQhByP2t+4JtbTL0\npNOTfQvofFeZicXBCcxAxICrKisQNua9htN8qh4lZGT3CejNWJjwB0YekwZc\nfDstNcpDOiSf0CWpWeoBHs5/n0VovZDCiRu1EigGyKjwgClF8QCpE5e+H0br\nXRpwHYLinSBtR4wdDCvAOJbvoFuKSn4jxV3FC9ajl+pOzcis4Vm/I4fsqW1O\nplqA\r\n=cfvi\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-conflict-chain-vv_2.0.0_1615317261274_0.7280452006330511"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-03-09T19:14:14.528Z",
+    "1.0.0": "2021-03-09T19:14:14.695Z",
+    "modified": "2021-03-09T19:14:23.579Z",
+    "2.0.0": "2021-03-09T19:14:21.403Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-vv.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-vv.min.json
@@ -1,0 +1,39 @@
+{
+  "name": "@isaacs/testing-peer-dep-conflict-chain-vv",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-vv",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-v": "1"
+      },
+      "dist": {
+        "integrity": "sha512-8CbQaqnv9GsTN+Kz6iWPLYLV7hOVQIDTpeZdDM3FXs7WW03uDI7S3rlFRdkc0ansSPMpnZb2SYTHbKn/W56G3g==",
+        "shasum": "6e7d8c0d29e215e2a74656483c4bdeb05b91174d",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-vv/-/testing-peer-dep-conflict-chain-vv-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 163,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgR8kHCRA9TVsSAnZWagAAIjAP/jw+div6Cal6j9QvCdPX\n1anNxvxYW2/ykeZpN0atcNaAYsnDaAIC7vmCeNOk6RJfIin7ASOefKQ0MhZY\nxjRPTn/9MoeuQgsqXbtjEzy0+ubn7FuX5PjayhDUtkp+dWN4gkEY99Y9Fi+k\nlq+XxtkAhuFj4+soT3tTLeXQDX6SPuiq8DgIF2owzejvXo4aR0AL+EJ3dBKD\nvAFXZb46Yty3Qgg7uu6sw4CKxSlMvdVr4ubfJ8libLFoLKhelvwjOs6cT3GP\n/JUsuYOjf2sfW8mMjUyG7kK7vO7PteQQp6wURJIgJWpAfHOgIS3uAC8xrfde\nPGNJXkECPJ7P3ixDEsjRAsecPKalsmojiSuXzVhmlFZNG4n81VMXGG7X6Irl\n3ZUAnMqBRma8DqD/gI+D32wrw3kM/ZvHK4aybVitjw2uSYKR7KXbnnN1zkDp\nPUuSP+2/FRQS0LTRU9xfhnb5Fcmap6jDrn4KpVkx6VbvwDaSigxh5zO+mpOi\nx29gc6q8niWuUdUUFYjyR75hl1wIJHyk5d40xW+1oIaCY8K1aE2cFbtXyOwo\nk4cO36c0hjQzFb6p25DHVfqz7TzS/tHdh5H6XpdSZcp3XI9xF50RSj8TSmxY\nyIobDniIeHQc+wlOiWSQZIlbvuTLiZb22RuqOktIlZd3/f2NMoCc9fzkFqK3\nriTZ\r\n=LyXS\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-vv",
+      "version": "2.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-v": "2"
+      },
+      "dist": {
+        "integrity": "sha512-GKxX5OHPD+i0EmjO03QnUSKxXQr6QzFVAza0fkEEUyg2/ju07BuhzhkpbxsEByFaiiQhIfsx2kmcSHtXY5hwTg==",
+        "shasum": "27f9622c7253589a5575e60c29fbb2380f14c54f",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-vv/-/testing-peer-dep-conflict-chain-vv-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 163,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgR8kNCRA9TVsSAnZWagAA97QP/i2ccR4jX9imu4EL0m+2\nD7OINfojL59pXHsCUgB25pD8OBnt4oN77RTjQQ8t930Z+PFOf7gsLA9ApJDd\nNIisf89786ymKDleuh6BR09AazyzSkM5oiEYvnNnAf6KvIctHJ5kPAq8VOyO\nIDjL40TSisuL0Om8h6NXaOdzR+TdyRP61hjPdse8VOpNwkui4gzTjiSX+WJg\nJ9xBnCS0wBkKVXoi4pCebtATUmLGGhOMv0pq0mY+bHdRa7n4r8J81v74nlyw\ndzWL6/J6b/ncUyX9Jy4ilDvnfH1I8h6U28xqzAHAYzpu0BzeTfnhJo9m+M8Y\nmNDIkXDWPeOP+pJqSocGUhYzFdBIY5EgNOcdUcD3AamocnxaOZ8Sm2ywLuBi\nv4mTj2QA0BD0WzVaJmqhQDuo6oTmP4jftg0MXz195Ncnz0xFgUdz3JDdqUas\nhTNRyw+M/h/sGgxhISELPN3fyeRiidB6whkrZZBmy5dSJQhByP2t+4JtbTL0\npNOTfQvofFeZicXBCcxAxICrKisQNua9htN8qh4lZGT3CejNWJjwB0YekwZc\nfDstNcpDOiSf0CWpWeoBHs5/n0VovZDCiRu1EigGyKjwgClF8QCpE5e+H0br\nXRpwHYLinSBtR4wdDCvAOJbvoFuKSn4jxV3FC9ajl+pOzcis4Vm/I4fsqW1O\nplqA\r\n=cfvi\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-03-09T19:14:23.579Z"
+}

--- a/test/fixtures/testing-peer-dep-conflict-chain/vv/1/package.json
+++ b/test/fixtures/testing-peer-dep-conflict-chain/vv/1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-dep-conflict-chain-vv",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-dep-conflict-chain-v": "1"
+  }
+}

--- a/test/fixtures/testing-peer-dep-conflict-chain/vv/2/package.json
+++ b/test/fixtures/testing-peer-dep-conflict-chain/vv/2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-dep-conflict-chain-vv",
+  "version": "2.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-dep-conflict-chain-v": "2"
+  }
+}

--- a/test/printable.js
+++ b/test/printable.js
@@ -213,3 +213,16 @@ t.test('printable Node', t => {
   })
   t.end()
 })
+
+t.test('virtual roots are shown with their sourceReference', t => {
+  const node = new Node({
+    path: '/foo/bar/baz',
+    pkg: {
+      name: 'baz',
+      version: '1.2.3',
+    },
+  })
+  const virtual = new Node({ sourceReference: node })
+  t.matchSnapshot(printable(virtual))
+  t.end()
+})


### PR DESCRIPTION
Previously, we were not including link targets in the virtual trees
where peer dependency sets are calculated.  Additionally, we were still
using the path `/virtual-root` for the virtual node, even though this is
no longer load-bearing.  (And, as of the other change in this PR to the Node
printable output, no longer necessary or particularly helpful for
debugging.)

As a result, a link dependency from the root node like `file:../../foo`
would get resolved against `/virtual-root`, resulting in `/foo`, which
of course does not match any Node in the virtual tree.  The outcome was
an ERESOLVE error where the `current` Node is shown as having no name
or version (because it is an unsatisfied Link).

The solution is two-part.

First, the path of the virtual tree root now matches the path of the
Node that it is sourced from.

Second, any Link children of the source node have their targets mirrored
in the virtual tree, resulting in them being matched appropriately.

The result is that a Link dependency can now properly satisfy a
peerDependency.  Test shows an example of using a Link to a local Node
as a workaround for a peerSet that otherwise would not be resolveable.

This can of course be abused to get around valid peerDep contracts, but
if they user takes it on themselves to use a local fork of a dependency,
we should respect that in buildIdealTree as we do elsewhere.

Fix: npm/cli#2199