### PR TITLE
fix: honor explicit prefix

### DIFF
--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -890,7 +890,7 @@ module.exports = cls => class Reifier extends cls {
       const root = this.idealTree
       const pkg = root.package
       for (const { name } of this[_resolvedAdd]) {
-        const req = npa(root.edgesOut.get(name).spec, root.realpath)
+        const req = npa.resolve(name, root.edgesOut.get(name).spec, root.realpath)
         const {rawSpec, subSpec} = req
 
         const spec = subSpec ? subSpec.rawSpec : rawSpec

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "promise-call-limit": "^1.0.1",
         "read-package-json-fast": "^2.0.2",
         "readdir-scoped-modules": "^1.1.0",
-        "semver": "^7.3.4",
+        "semver": "^7.3.5",
         "tar": "^6.1.0",
         "treeverse": "^1.0.4",
         "walk-up-path": "^1.0.0"
@@ -4358,9 +4358,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -11018,9 +11018,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "promise-call-limit": "^1.0.1",
     "read-package-json-fast": "^2.0.2",
     "readdir-scoped-modules": "^1.1.0",
-    "semver": "^7.3.4",
+    "semver": "^7.3.5",
     "tar": "^6.1.0",
     "treeverse": "^1.0.4",
     "walk-up-path": "^1.0.0"

--- a/tap-snapshots/test-arborist-reify.js-TAP.test.js
+++ b/tap-snapshots/test-arborist-reify.js-TAP.test.js
@@ -29029,6 +29029,11 @@ Object {
       "extraneous": true,
       "resolved": "https://registry.npmjs.org/g/-/g-1.2.3.tgz",
     },
+    "h": Object {
+      "extraneous": true,
+      "resolved": "https://registry.npmjs.org/h/-/h-1.2.3.tgz",
+      "version": "1.2.3",
+    },
   },
   "lockfileVersion": 2,
   "name": "reify-saving-the-ideal-tree-save-some-stuff",
@@ -29046,6 +29051,7 @@ Object {
         "e": "file:e",
         "f": "git+https://user:pass@github.com/baz/quux.git#asdf",
         "g": "*",
+        "h": "~1.2.3",
       },
       "devDependencies": Object {
         "c": "git+ssh://git@githost.com:a/b/c.git#master",
@@ -29091,6 +29097,11 @@ Object {
     "node_modules/g": Object {
       "extraneous": true,
       "resolved": "https://registry.npmjs.org/g/-/g-1.2.3.tgz",
+    },
+    "node_modules/h": Object {
+      "extraneous": true,
+      "resolved": "https://registry.npmjs.org/h/-/h-1.2.3.tgz",
+      "version": "1.2.3",
     },
   },
   "requires": true,

--- a/test/arborist/reify.js
+++ b/test/arborist/reify.js
@@ -808,11 +808,12 @@ t.test('saving the ideal tree', t => {
       dependencies: {
         a: 'git+ssh://git@github.com:foo/bar#baz',
         b: '',
-        d: 'd@npm:c@1.x <1.9.9',
+        d: 'npm:c@1.x <1.9.9',
         // XXX: should we remove dependencies that are also workspaces?
         e: 'file:e',
         f: 'git+https://user:pass@github.com/baz/quux#asdf',
         g: '',
+        h: '~1.2.3',
       },
       devDependencies: {
         c: `git+ssh://git@githost.com:a/b/c.git#master`,
@@ -891,6 +892,16 @@ t.test('saving the ideal tree', t => {
         },
         parent: tree,
       })
+      new Node({
+        name: 'h',
+        resolved: 'https://registry.npmjs.org/h/-/h-1.2.3.tgz',
+        pkg: {
+          name: 'h',
+          version: '1.2.3',
+        },
+        parent: tree,
+      })
+
       const target = new Node({
         name: 'e',
         pkg: {
@@ -917,12 +928,11 @@ t.test('saving the ideal tree', t => {
         npa('e'),
         npa('f@git+https://user:pass@github.com/baz/quux#asdf'),
         npa('g'),
+        npa('h@~1.2.3'),
       ]
       // NB: these are all going to be marked as extraneous, because we're
       // skipping the actual buildIdealTree step that flags them properly
-      return a[kSaveIdealTree]({
-        savePrefix: '~',
-      })
+      return a[kSaveIdealTree]({})
     }).then(() => {
       t.matchSnapshot(require(path + '/package-lock.json'), 'lock after save')
       t.strictSame(require(path + '/package.json'), {
@@ -934,6 +944,7 @@ t.test('saving the ideal tree', t => {
           e: 'file:e',
           f: 'git+https://user:pass@github.com/baz/quux.git#asdf',
           g: '*',
+          h: '~1.2.3',
         },
         workspaces: [
           'e',


### PR DESCRIPTION
## Summary

Honors explicit prefix. npm-package-arg was being used incorrectly in reify when saving the ideal tree. Only the spec was being passed in, which resulted in some unusual results (submitted a ticket to address that in npm-package-arg as well).

Once this was addressed, another issue was spotted, where passing no version on a new package results in `*` being added. Previously, the type resolved to `tag`. This now resolves correctly to `range`. When resolving the variable `range` shortly after, though, existing checks are now truthy. Before, it was short-circuited as falsey due to `type`. Also, node-semver returns false when comparing subsets of `*` other than itself (it's documented in the code). The now falsey resolution makes  spec(`*`) used in a user's `package.json` rather than `prefixRange`.

This request addresses the false semver subset check by checking if `spec` is `*`. `*` should still resolve in a `package.json` if `child.version` is falsy for any reason.

In addition, there was a test which had an unusual alias. This fix brought that abnormality to light. This request corrects that test.

## References

Fixes #253.