### PR TITLE
Never bundle when saving as peer/peerOptional

### DIFF
--- a/lib/add-rm-pkg-deps.js
+++ b/lib/add-rm-pkg-deps.js
@@ -71,7 +71,7 @@ const addSingle = ({pkg, spec, saveBundle, saveType}) => {
       pkg.devDependencies[name] = pkg.peerDependencies[name]
   }
 
-  if (saveBundle) {
+  if (saveBundle && saveType !== 'peer' && saveType !== 'peerOptional') {
     // keep it sorted, keep it unique
     const bd = new Set(pkg.bundleDependencies || [])
     bd.add(spec.name)

--- a/test/add-rm-pkg-deps.js
+++ b/test/add-rm-pkg-deps.js
@@ -39,6 +39,36 @@ t.test('add', t => {
   }, 'move to bundle deps, foo to deps, leave bar version unchanged')
 
   t.strictSame(add({
+    pkg: {
+      dependencies: { bar: '1' },
+      devDependencies: { foo: '2' },
+    },
+    add: [foo1, bar],
+    saveBundle: true,
+    saveType: 'peer',
+  }), {
+    devDependencies: { foo: '1' },
+    peerDependencies: { foo: '1', bar: '*' },
+  }, 'never bundle peerDeps')
+
+  t.strictSame(add({
+    pkg: {
+      dependencies: { bar: '1' },
+      devDependencies: { foo: '2' },
+    },
+    add: [foo1, bar],
+    saveBundle: true,
+    saveType: 'peerOptional',
+  }), {
+    devDependencies: { foo: '1' },
+    peerDependencies: { foo: '1', bar: '*' },
+    peerDependenciesMeta: {
+      foo: { optional: true },
+      bar: { optional: true },
+    },
+  }, 'never bundle peerDeps')
+
+  t.strictSame(add({
     pkg: {},
     add: [foo1, bar],
     saveBundle: true,


### PR DESCRIPTION
There's a bit of logic in npm/cli that sets the `saveBundle` option to
false based on the various `--save-xyz` flags.  It is easier and safer
to just never bundle if we're saving a peer dep, in the one place where
that decision is made.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
