### PR TITLE
feat: add packumentCache option

### DIFF
--- a/lib/arborist/index.js
+++ b/lib/arborist/index.js
@@ -54,7 +54,7 @@ class Arborist extends Base {
       ...options,
       path: options.path || '.',
       cache: options.cache || `${homedir()}/.npm/_cacache`,
-      packumentCache: new Map(),
+      packumentCache: options.packumentCache || new Map(),
       log: options.log || procLog,
     }
     this.cache = resolve(this.options.cache)


### PR DESCRIPTION
If you have a use where you use arborist but also need to make packument/manifest requests, it is helpful to pass in a reference to your own cache to prevent duplicate requests:

```javascript
const packumentCache = new Map()
const arb = new Arborist({ packumentCache })

// reuse in pacote calls
await pacote.packument('foo', { packumentCache })
```

I figured I would first open this PR since it was a one line addition, and discuss if there was value in another approach which is more work.  

If there was a reference on the `Node` or `Edge` which enabled getting the packument from the cache (`.getPackument` for example) this would not be necessary and would probably also be a better interface for my use case. I *think* `npm outdated` is [not sharing this cache here](https://github.com/npm/cli/blob/13843f489401d918e7f1a41ed1ff636fc3feb603/lib/outdated.js#L132-L139) but get's around the problem by making a unique set of names outside of arborist.  I think that arborist managing this detail for users would both simplify `npm`'s implementation here, as well as make it better for other consumers of `arborist`.

EDIT: In my very unscientific testing, sharing this cache reliably produces a ~25-50% perf improvement running against the project I am testing with where there are quite a bit of duplicate packages in the tree.