### PR TITLE
Properly handle file:. dep when bundle deps present

### DIFF
--- a/bin/lib/logging.js
+++ b/bin/lib/logging.js
@@ -20,13 +20,21 @@ const levelMap = new Map(levels.reduce((set, level, index) => {
 }, []))
 
 const { inspect, format } = require('util')
+const colors = process.stderr.isTTY
+const magenta = colors ? msg => `\x1B[35m${msg}\x1B[39m` : m => m
 if (loglevel !== 'silent') {
   process.on('log', (level, ...args) => {
     if (levelMap.get(level) < levelMap.get(loglevel))
       return
-    const pref = `${process.pid} ${level} `
+    const pref = `${process.pid} ${magenta(level)} `
     if (level === 'warn' && args[0] === 'ERESOLVE')
-      args[2] = inspect(args[2], { depth: 10 })
+      args[2] = inspect(args[2], { depth: 10, colors })
+    else {
+      args = args.map(a => {
+        return typeof a === 'string' ? a
+          : inspect(a, { depth: 10, colors })
+      })
+    }
     const msg = pref + format(...args).trim().split('\n').join(`\n${pref}`)
     console.error(msg)
   })

--- a/bin/lib/timers.js
+++ b/bin/lib/timers.js
@@ -1,4 +1,5 @@
 const timers = Object.create(null)
+const { format } = require('util')
 
 process.on('time', name => {
   if (timers[name])
@@ -6,17 +7,20 @@ process.on('time', name => {
   timers[name] = process.hrtime()
 })
 
+const dim = process.stderr.isTTY ? msg => `\x1B[2m${msg}\x1B[22m` : m => m
+const red = process.stderr.isTTY ? msg => `\x1B[31m${msg}\x1B[39m` : m => m
 process.on('timeEnd', name => {
   if (!timers[name])
     throw new Error('timer not started! ' + name)
   const res = process.hrtime(timers[name])
   delete timers[name]
-  console.error(`${process.pid} ${name}`, res[0] * 1e3 + res[1] / 1e6)
+  const msg = format(`${process.pid} ${name}`, res[0] * 1e3 + res[1] / 1e6)
+  console.error(dim(msg))
 })
 
 process.on('exit', () => {
   for (const name of Object.keys(timers)) {
-    console.error('Dangling timer: ', name)
+    console.error(red('Dangling timer:'), name)
     process.exitCode = 1
   }
 })

--- a/lib/arborist/rebuild.js
+++ b/lib/arborist/rebuild.js
@@ -115,10 +115,6 @@ module.exports = cls => class Builder extends cls {
       await this[_runScripts]('preinstall')
     if (this[_binLinks] && type !== 'links')
       await this[_linkAllBins]()
-    if (!this[_ignoreScripts]) {
-      await this[_runScripts]('install')
-      await this[_runScripts]('postinstall')
-    }
 
     // links should also run prepare scripts and only link bins after that
     if (type === 'links') {
@@ -126,6 +122,11 @@ module.exports = cls => class Builder extends cls {
 
       if (this[_binLinks])
         await this[_linkAllBins]()
+    }
+
+    if (!this[_ignoreScripts]) {
+      await this[_runScripts]('install')
+      await this[_runScripts]('postinstall')
     }
 
     process.emit('timeEnd', `build:${type}`)

--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -50,6 +50,7 @@ const _diffTrees = Symbol.for('diffTrees')
 const _createSparseTree = Symbol.for('createSparseTree')
 const _loadShrinkwrapsAndUpdateTrees = Symbol.for('loadShrinkwrapsAndUpdateTrees')
 const _shrinkwrapInflated = Symbol('shrinkwrapInflated')
+const _bundleUnpacked = Symbol('bundleUnpacked')
 const _reifyNode = Symbol.for('reifyNode')
 const _extractOrLink = Symbol('extractOrLink')
 // defined by rebuild mixin
@@ -424,7 +425,8 @@ module.exports = cls => class Reifier extends cls {
     const dirs = this.diff.leaves
       .filter(diff => {
         return (diff.action === 'ADD' || diff.action === 'CHANGE') &&
-          !this[_sparseTreeDirs].has(diff.ideal.path)
+          !this[_sparseTreeDirs].has(diff.ideal.path) &&
+          !diff.ideal.isLink
       })
       .map(diff => diff.ideal.path)
 
@@ -504,7 +506,7 @@ module.exports = cls => class Reifier extends cls {
 
     const { npmVersion, nodeVersion } = this.options
     const p = Promise.resolve()
-      .then(() => {
+      .then(async () => {
         // when we reify an optional node, check the engine and platform
         // first. be sure to ignore the --force and --engine-strict flags,
         // since we always want to skip any optional packages we can't install.
@@ -514,11 +516,11 @@ module.exports = cls => class Reifier extends cls {
           checkEngine(node.package, npmVersion, nodeVersion, false)
           checkPlatform(node.package, false)
         }
+        await this[_checkBins](node)
+        await this[_extractOrLink](node)
+        await this[_warnDeprecated](node)
+        await this[_loadAncientPackageDetails](node)
       })
-      .then(() => this[_checkBins](node))
-      .then(() => this[_extractOrLink](node))
-      .then(() => this[_warnDeprecated](node))
-      .then(() => this[_loadAncientPackageDetails](node))
 
     return this[_handleOptionalFailure](node, p)
       .then(() => {
@@ -564,10 +566,11 @@ module.exports = cls => class Reifier extends cls {
       })
   }
 
-  [_symlink] (node) {
+  async [_symlink] (node) {
     const dir = dirname(node.path)
     const target = node.realpath
     const rel = relative(dir, target)
+    await mkdirp(dir)
     return symlink(rel, node.path, 'junction')
   }
 
@@ -634,8 +637,10 @@ module.exports = cls => class Reifier extends cls {
   [_loadBundlesAndUpdateTrees] (
     depth = 0, bundlesByDepth = this[_getBundlesByDepth]()
   ) {
-    if (depth === 0)
+    if (depth === 0) {
+      this[_bundleUnpacked] = new Set()
       process.emit('time', 'reify:loadBundles')
+    }
     const maxBundleDepth = bundlesByDepth.get('maxBundleDepth')
     if (depth > maxBundleDepth) {
       // if we did something, then prune the tree and update the diffs
@@ -651,13 +656,17 @@ module.exports = cls => class Reifier extends cls {
     // shallower bundle overwriting them with a bundled meta-dep.
     const set = (bundlesByDepth.get(depth) || [])
       .filter(node => node.root === this.idealTree &&
+        node.target !== node.root &&
         !this[_trashList].has(node.path))
 
     if (!set.length)
       return this[_loadBundlesAndUpdateTrees](depth + 1, bundlesByDepth)
 
     // extract all the nodes with bundles
-    return promiseAllRejectLate(set.map(node => this[_reifyNode](node)))
+    return promiseAllRejectLate(set.map(node => {
+      this[_bundleUnpacked].add(node)
+      return this[_reifyNode](node)
+    }))
     // then load their unpacked children and move into the ideal tree
       .then(nodes =>
         promiseAllRejectLate(nodes.map(node => new this.constructor({
@@ -679,8 +688,13 @@ module.exports = cls => class Reifier extends cls {
       tree: this.diff,
       visit: diff => {
         const node = diff.ideal
-        if (node && !node.isProjectRoot && node.package.bundleDependencies &&
-            node.package.bundleDependencies.length) {
+        if (!node)
+          return
+        if (node.isProjectRoot || (node.target && node.target.isProjectRoot))
+          return
+
+        const { bundleDependencies } = node.package
+        if (bundleDependencies && bundleDependencies.length) {
           maxBundleDepth = Math.max(maxBundleDepth, node.depth)
           if (!bundlesByDepth.has(node.depth))
             bundlesByDepth.set(node.depth, [node])
@@ -785,14 +799,14 @@ module.exports = cls => class Reifier extends cls {
           return
 
         const node = diff.ideal
-        const bd = node.package.bundleDependencies
+        const bd = this[_bundleUnpacked].has(node)
         const sw = this[_shrinkwrapInflated].has(node)
 
         // check whether we still need to unpack this one.
         // test the inDepBundle last, since that's potentially a tree walk.
         const doUnpack = node && // can't unpack if removed!
           !node.isRoot && // root node already exists
-          !(bd && bd.length) && // already unpacked to read bundle
+          !bd && // already unpacked to read bundle
           !sw && // already unpacked to read sw
           !node.inDepBundle // already unpacked by another dep's bundle
 

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -12,6 +12,7 @@
 
 // run in debug mode if explicitly requested, running arborist tests,
 // or working in the arborist project directory.
+
 const debug = process.env.ARBORIST_DEBUG !== '0' && (
   process.env.ARBORIST_DEBUG === '1' ||
   /\barborist\b/.test(process.env.NODE_DEBUG || '') ||
@@ -21,4 +22,10 @@ const debug = process.env.ARBORIST_DEBUG !== '0' && (
 )
 
 module.exports = debug ? fn => fn() : () => {}
-module.exports.log = (...msg) => module.exports(() => console.error(...msg))
+const red = process.stderr.isTTY ? msg => `\x1B[31m${msg}\x1B[39m` : m => m
+module.exports.log = (...msg) => module.exports(() => {
+  const { format } = require('util')
+  const prefix = `\n${process.pid} ${red(format(msg.shift()))} `
+  msg = (prefix + format(...msg).trim().split('\n').join(prefix)).trim()
+  console.error(msg)
+})

--- a/tap-snapshots/test/arborist/reify.js.test.cjs
+++ b/tap-snapshots/test/arborist/reify.js.test.cjs
@@ -15137,6 +15137,67 @@ exports[`test/arborist/reify.js TAP packageLockOnly can add deps > must match sn
 
 `
 
+exports[`test/arborist/reify.js TAP project with bundled deps and a link dep on itself > result 1`] = `
+ArboristNode {
+  "children": Map {
+    "@isaacs/testing-bundle-self-link" => ArboristLink {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "@isaacs/testing-bundle-self-link",
+          "spec": "file:.",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/@isaacs/testing-bundle-self-link",
+      "name": "@isaacs/testing-bundle-self-link",
+      "path": "{CWD}/test/arborist/tap-testdir-reify-project-with-bundled-deps-and-a-link-dep-on-itself/node_modules/@isaacs/testing-bundle-self-link",
+      "realpath": "{CWD}/test/arborist/tap-testdir-reify-project-with-bundled-deps-and-a-link-dep-on-itself",
+      "resolved": "file:../..",
+      "target": ArboristNode {
+        "location": "",
+      },
+      "version": "1.0.0",
+    },
+    "abbrev" => ArboristNode {
+      "bundled": true,
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "abbrev",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/abbrev",
+      "name": "abbrev",
+      "path": "{CWD}/test/arborist/tap-testdir-reify-project-with-bundled-deps-and-a-link-dep-on-itself/node_modules/abbrev",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "version": "1.1.1",
+    },
+  },
+  "edgesOut": Map {
+    "@isaacs/testing-bundle-self-link" => EdgeOut {
+      "name": "@isaacs/testing-bundle-self-link",
+      "spec": "file:.",
+      "to": "node_modules/@isaacs/testing-bundle-self-link",
+      "type": "prod",
+    },
+    "abbrev" => EdgeOut {
+      "name": "abbrev",
+      "spec": "*",
+      "to": "node_modules/abbrev",
+      "type": "prod",
+    },
+  },
+  "location": "",
+  "name": "tap-testdir-reify-project-with-bundled-deps-and-a-link-dep-on-itself",
+  "packageName": "@isaacs/testing-bundle-self-link",
+  "path": "{CWD}/test/arborist/tap-testdir-reify-project-with-bundled-deps-and-a-link-dep-on-itself",
+  "version": "1.0.0",
+}
+`
+
 exports[`test/arborist/reify.js TAP reify from old package-lock with bins > should add bins entry to package-lock packages entry 1`] = `
 Object {
   "dependencies": Object {


### PR DESCRIPTION
If a package had a dependency on `file:.` (ie, to create a symbolic link
to the root project within `node_modules`), as well as a
`bundleDependencies` list, the reifier got into a very strange state and
would fail to resolve its promise, causing npm to exit with a `cb()
never called` error.

The solution is:

- Do not do the extract-and-loadActual pass on dependencies that are
  links.
- Do not create sparse tree folders for dependencies that are links.
  (This wasn't a part of the issue, just a weird inefficiency
  encountered along the way.  We created a dir, only to delete it and
  replace with a symlink later.)
- Later on in the process, when we check to see whether a node has
  already been reified by virtue of having bundleDependencies, instead
  of merely looking at the package.json data, actually keep a list of
  nodes reified ahead of time in this way.
- Lastly, do not run `preinstall`, `install`, and `postinstall` scripts
  for links before linking their bins.  We have to run `prepare` on link
  deps prior to linking their bins, but we should still be linking the
  bins ahead of running the other build scripts, like we do for non-link
  deps.

Based on https://github.com/npm/arborist/pull/265, land that first.