### PR TITLE
test: package-lock gen missing integrity values

### DIFF
--- a/tap-snapshots/test/arborist/reify.js.test.cjs
+++ b/tap-snapshots/test/arborist/reify.js.test.cjs
@@ -15100,6 +15100,36 @@ ArboristNode {
 }
 `
 
+exports[`test/arborist/reify.js TAP package-lock contents when generated from actual tree with no hidden lockfile or package-lock > should result in package-lock with integrity and resolved values 1`] = `
+{
+  "name": "package-lock-from-actual",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "dependencies": {
+        "abbrev": "^1.1.1"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    }
+  },
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    }
+  }
+}
+
+`
+
 exports[`test/arborist/reify.js TAP packageLockOnly can add deps > must match snapshot 1`] = `
 {
   "dependencies": {

--- a/test/arborist/reify.js
+++ b/test/arborist/reify.js
@@ -1497,6 +1497,12 @@ t.test('properly update one module when multiple are present', async t => {
   t.equal(JSON.parse(fs.readFileSync(oncepj, 'utf8')).version, '1.4.0')
 })
 
+t.test('package-lock contents when generated from actual tree with no hidden lockfile or package-lock', async t => {
+  const path = fixture(t, 'package-lock-from-actual')
+  await reify(path)
+  t.matchSnapshot(fs.readFileSync(path + '/package-lock.json', 'utf8'), 'should result in package-lock with integrity and resolved values')
+})
+
 t.test('saving should not replace file: dep with version', async t => {
   // need to run in the path, as if the user typed `npm i file:abbrev`
   const cwd = process.cwd()

--- a/test/fixtures/package-lock-from-actual/node_modules/abbrev/LICENSE
+++ b/test/fixtures/package-lock-from-actual/node_modules/abbrev/LICENSE
@@ -1,0 +1,46 @@
+This software is dual-licensed under the ISC and MIT licenses.
+You may use this software under EITHER of the following licenses.
+
+----------
+
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+----------
+
+Copyright Isaac Z. Schlueter and Contributors
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/test/fixtures/package-lock-from-actual/node_modules/abbrev/README.md
+++ b/test/fixtures/package-lock-from-actual/node_modules/abbrev/README.md
@@ -1,0 +1,23 @@
+# abbrev-js
+
+Just like [ruby's Abbrev](http://apidock.com/ruby/Abbrev).
+
+Usage:
+
+    var abbrev = require("abbrev");
+    abbrev("foo", "fool", "folding", "flop");
+    
+    // returns:
+    { fl: 'flop'
+    , flo: 'flop'
+    , flop: 'flop'
+    , fol: 'folding'
+    , fold: 'folding'
+    , foldi: 'folding'
+    , foldin: 'folding'
+    , folding: 'folding'
+    , foo: 'foo'
+    , fool: 'fool'
+    }
+
+This is handy for command-line scripts, or other cases where you want to be able to accept shorthands.

--- a/test/fixtures/package-lock-from-actual/node_modules/abbrev/abbrev.js
+++ b/test/fixtures/package-lock-from-actual/node_modules/abbrev/abbrev.js
@@ -1,0 +1,61 @@
+module.exports = exports = abbrev.abbrev = abbrev
+
+abbrev.monkeyPatch = monkeyPatch
+
+function monkeyPatch () {
+  Object.defineProperty(Array.prototype, 'abbrev', {
+    value: function () { return abbrev(this) },
+    enumerable: false, configurable: true, writable: true
+  })
+
+  Object.defineProperty(Object.prototype, 'abbrev', {
+    value: function () { return abbrev(Object.keys(this)) },
+    enumerable: false, configurable: true, writable: true
+  })
+}
+
+function abbrev (list) {
+  if (arguments.length !== 1 || !Array.isArray(list)) {
+    list = Array.prototype.slice.call(arguments, 0)
+  }
+  for (var i = 0, l = list.length, args = [] ; i < l ; i ++) {
+    args[i] = typeof list[i] === "string" ? list[i] : String(list[i])
+  }
+
+  // sort them lexicographically, so that they're next to their nearest kin
+  args = args.sort(lexSort)
+
+  // walk through each, seeing how much it has in common with the next and previous
+  var abbrevs = {}
+    , prev = ""
+  for (var i = 0, l = args.length ; i < l ; i ++) {
+    var current = args[i]
+      , next = args[i + 1] || ""
+      , nextMatches = true
+      , prevMatches = true
+    if (current === next) continue
+    for (var j = 0, cl = current.length ; j < cl ; j ++) {
+      var curChar = current.charAt(j)
+      nextMatches = nextMatches && curChar === next.charAt(j)
+      prevMatches = prevMatches && curChar === prev.charAt(j)
+      if (!nextMatches && !prevMatches) {
+        j ++
+        break
+      }
+    }
+    prev = current
+    if (j === cl) {
+      abbrevs[current] = current
+      continue
+    }
+    for (var a = current.substr(0, j) ; j <= cl ; j ++) {
+      abbrevs[a] = current
+      a += current.charAt(j)
+    }
+  }
+  return abbrevs
+}
+
+function lexSort (a, b) {
+  return a === b ? 0 : a > b ? 1 : -1
+}

--- a/test/fixtures/package-lock-from-actual/node_modules/abbrev/package.json
+++ b/test/fixtures/package-lock-from-actual/node_modules/abbrev/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "abbrev",
+  "version": "1.1.1",
+  "description": "Like ruby's abbrev module, but in js",
+  "author": "Isaac Z. Schlueter <i@izs.me>",
+  "main": "abbrev.js",
+  "scripts": {
+    "test": "tap test.js --100",
+    "preversion": "npm test",
+    "postversion": "npm publish",
+    "postpublish": "git push origin --all; git push origin --tags"
+  },
+  "repository": "http://github.com/isaacs/abbrev-js",
+  "license": "ISC",
+  "devDependencies": {
+    "tap": "^10.1"
+  },
+  "files": [
+    "abbrev.js"
+  ]
+}

--- a/test/fixtures/package-lock-from-actual/package.json
+++ b/test/fixtures/package-lock-from-actual/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-lock-from-actual",
+  "version": "1.0.0",
+  "dependencies": {
+    "abbrev": "^1.1.1"
+  }
+}

--- a/test/fixtures/reify-cases/package-lock-from-actual.js
+++ b/test/fixtures/reify-cases/package-lock-from-actual.js
@@ -1,0 +1,171 @@
+// generated from test/fixtures/package-lock-from-actual
+module.exports = t => {
+  const path = t.testdir({
+  "node_modules": {
+    "abbrev": {
+      "LICENSE": `This software is dual-licensed under the ISC and MIT licenses.
+You may use this software under EITHER of the following licenses.
+
+----------
+
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+----------
+
+Copyright Isaac Z. Schlueter and Contributors
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+`,
+      "README.md": `# abbrev-js
+
+Just like [ruby's Abbrev](http://apidock.com/ruby/Abbrev).
+
+Usage:
+
+    var abbrev = require("abbrev");
+    abbrev("foo", "fool", "folding", "flop");
+    
+    // returns:
+    { fl: 'flop'
+    , flo: 'flop'
+    , flop: 'flop'
+    , fol: 'folding'
+    , fold: 'folding'
+    , foldi: 'folding'
+    , foldin: 'folding'
+    , folding: 'folding'
+    , foo: 'foo'
+    , fool: 'fool'
+    }
+
+This is handy for command-line scripts, or other cases where you want to be able to accept shorthands.
+`,
+      "abbrev.js": `module.exports = exports = abbrev.abbrev = abbrev
+
+abbrev.monkeyPatch = monkeyPatch
+
+function monkeyPatch () {
+  Object.defineProperty(Array.prototype, 'abbrev', {
+    value: function () { return abbrev(this) },
+    enumerable: false, configurable: true, writable: true
+  })
+
+  Object.defineProperty(Object.prototype, 'abbrev', {
+    value: function () { return abbrev(Object.keys(this)) },
+    enumerable: false, configurable: true, writable: true
+  })
+}
+
+function abbrev (list) {
+  if (arguments.length !== 1 || !Array.isArray(list)) {
+    list = Array.prototype.slice.call(arguments, 0)
+  }
+  for (var i = 0, l = list.length, args = [] ; i < l ; i ++) {
+    args[i] = typeof list[i] === "string" ? list[i] : String(list[i])
+  }
+
+  // sort them lexicographically, so that they're next to their nearest kin
+  args = args.sort(lexSort)
+
+  // walk through each, seeing how much it has in common with the next and previous
+  var abbrevs = {}
+    , prev = ""
+  for (var i = 0, l = args.length ; i < l ; i ++) {
+    var current = args[i]
+      , next = args[i + 1] || ""
+      , nextMatches = true
+      , prevMatches = true
+    if (current === next) continue
+    for (var j = 0, cl = current.length ; j < cl ; j ++) {
+      var curChar = current.charAt(j)
+      nextMatches = nextMatches && curChar === next.charAt(j)
+      prevMatches = prevMatches && curChar === prev.charAt(j)
+      if (!nextMatches && !prevMatches) {
+        j ++
+        break
+      }
+    }
+    prev = current
+    if (j === cl) {
+      abbrevs[current] = current
+      continue
+    }
+    for (var a = current.substr(0, j) ; j <= cl ; j ++) {
+      abbrevs[a] = current
+      a += current.charAt(j)
+    }
+  }
+  return abbrevs
+}
+
+function lexSort (a, b) {
+  return a === b ? 0 : a > b ? 1 : -1
+}
+`,
+      "package.json": JSON.stringify({
+        "name": "abbrev",
+        "version": "1.1.1",
+        "description": "Like ruby's abbrev module, but in js",
+        "author": "Isaac Z. Schlueter <i@izs.me>",
+        "main": "abbrev.js",
+        "scripts": {
+          "test": "tap test.js --100",
+          "preversion": "npm test",
+          "postversion": "npm publish",
+          "postpublish": "git push origin --all; git push origin --tags"
+        },
+        "repository": "http://github.com/isaacs/abbrev-js",
+        "license": "ISC",
+        "devDependencies": {
+          "tap": "^10.1"
+        },
+        "files": [
+          "abbrev.js"
+        ]
+      })
+    }
+  },
+  "package.json": JSON.stringify({
+    "name": "package-lock-from-actual",
+    "version": "1.0.0",
+    "dependencies": {
+      "abbrev": "^1.1.1"
+    }
+  })
+})
+  return path
+}


### PR DESCRIPTION
When generating a `package-lock.json` file out of an existent and valid actual tree based only in the contents of the `node_modules` folder AND no `package-lock.json` OR hidden lockfile currently available in the project folder, the resulting `package-lock.json` files has no `integrity` or `resolved` values.

### Context

From a UX point of view, `package-lock.json` files are meant to be checked in and tracked by source control systems. It's very unexpected and adds extra friction and unnecessary churn to be excluding `integrity` and `resolved` fields from a resulting `package-lock.json` file when basing a reifycation in an actual tree that contains no lockfile (or hidden lockfile) to cache that data.

### Current test result for quick ref:

Notice that the expected `resolved` and `integrity` values are missing. An extraneous (but probably desirable) `license` field is also added in this case, which is very likely to be a separated problem but it would be nice to make sure to include it in the package-lock-based-reify if that's the expected outcome.

```
 ✖ should result in package-lock with integrity and resolved values

  await reify(path)
  t.matchSnapshot(fs.readFileSync(path + '/package-lock.json', 'utf8'), 'should result in package-lock with integrity and resolved values')
----^
})

  --- expected
  +++ actual
  @@ -4,24 +4,22 @@
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
       "": {
  +      "name": "package-lock-from-actual",
         "version": "1.0.0",
         "dependencies": {
           "abbrev": "^1.1.1"
         }
       },
       "node_modules/abbrev": {
         "version": "1.1.1",
  -      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
  -      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
  +      "license": "ISC"
       }
     },
     "dependencies": {
       "abbrev": {
  -      "version": "1.1.1",
  -      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
  -      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
  +      "version": "1.1.1"
       }
     }
   }

  test: test/arborist/reify.js package-lock contents when generated from actual
    tree with no hidden lockfile or package-lock
  at:
    line: 1503
    column: 5
    file: test/arborist/reify.js
    type: Test
  stack: |
    Test.<anonymous> (test/arborist/reify.js:1503:5)
```