### PR TITLE
Prevent and eliminate unnecessary duplicates

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -47,6 +47,7 @@ const _flagsSuspect = Symbol.for('flagsSuspect')
 const _workspaces = Symbol.for('workspaces')
 const _prune = Symbol('prune')
 const _preferDedupe = Symbol('preferDedupe')
+const _pruneDedupable = Symbol('pruneDedupable')
 const _legacyBundling = Symbol('legacyBundling')
 const _parseSettings = Symbol('parseSettings')
 const _initTree = Symbol('initTree')
@@ -1342,6 +1343,21 @@ This is a one-time fix-up, please be patient...
         // this is an overridden peer dep
         this[_warnPeerConflict](edge)
       }
+
+      // if we get a KEEP in a update scenario, then we MAY have something
+      // already duplicating this unnecessarily!  For example:
+      // ```
+      // root
+      // +-- x (dep: y@1.x)
+      // |   +-- y@1.0.0
+      // +-- y@1.1.0
+      // ```
+      // Now say we do `reify({update:['y']})`, and the latest version is
+      // 1.1.0, which we already have in the root.  We'll try to place y@1.1.0
+      // first in x, then in the root, ending with KEEP, because we already
+      // have it.  In that case, we ought to REMOVE the nm/x/nm/y node, because
+      // it is an unnecessary duplicate.
+      this[_pruneDedupable](target, true)
       return []
     }
 
@@ -1397,8 +1413,8 @@ This is a one-time fix-up, please be patient...
     // MAY end up putting a better/identical node further up the tree in
     // a way that causes an unnecessary duplication.  If so, remove the
     // now-unnecessary node.
-    if (edge.valid && edge.to.parent !== target && newDep.canReplace(edge.to))
-      edge.to.parent = null
+    if (edge.valid && edge.to && edge.to !== newDep)
+      this[_pruneDedupable](edge.to, false)
 
     // visit any dependents who are upset by this change
     // if it's an angry overridden peer edge, however, make sure we
@@ -1414,30 +1430,8 @@ This is a one-time fix-up, please be patient...
     // prune anything deeper in the tree that can be replaced by this
     if (this.idealTree) {
       for (const node of this.idealTree.inventory.query('name', newDep.name)) {
-        if (node !== newDep &&
-            node.isDescendantOf(target) &&
-            !node.inShrinkwrap &&
-            !node.inBundle &&
-            node.canReplaceWith(newDep)) {
-          // don't prune if the dupe is necessary!
-          // root (a, d)
-          // +-- a (b, c2)
-          // |   +-- b (c2) <-- place c2 for b, lands at root
-          // +-- d (e)
-          //     +-- e (c1, d)
-          //         +-- c1
-          //         +-- f (c2)
-          //             +-- c2 <-- pruning this would be bad
-
-          const mask = node.parent !== target &&
-            node.parent &&
-            node.parent.parent &&
-            node.parent.parent !== target &&
-            node.parent.parent.resolve(newDep.name)
-
-          if (!mask || mask === newDep || node.canReplaceWith(mask))
-            node.parent = null
-        }
+        if (node.isDescendantOf(target))
+          this[_pruneDedupable](node, false)
       }
     }
 
@@ -1468,6 +1462,21 @@ This is a one-time fix-up, please be patient...
     this[_virtualRoots].delete(virtualRoot.sourceReference)
 
     return placed
+  }
+
+  // prune all the nodes in a branch of the tree that can be safely removed
+  // This is only the most basic duplication detection; it finds if there
+  // is another satisfying node further up the tree, and if so, dedupes.
+  // Even in legacyBundling mode, we do this amount of deduplication.
+  [_pruneDedupable] (node, descend = true) {
+    if (node.canDedupe(this[_preferDedupe])) {
+      node.root = null
+      return
+    }
+    if (descend) {
+      for (const child of node.children.values())
+        this[_pruneDedupable](child)
+    }
   }
 
   [_pruneForReplacement] (node, oldDeps) {

--- a/test/fixtures/registry-mocks/content/isaacs/testing-bundle-dupes-a.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-bundle-dupes-a.json
@@ -1,0 +1,95 @@
+{
+  "_id": "@isaacs/testing-bundle-dupes-a",
+  "_rev": "1-b57a0c74978014ad83d692ffec9b803a",
+  "name": "@isaacs/testing-bundle-dupes-a",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-bundle-dupes-a",
+      "version": "1.0.0",
+      "dependencies": {
+        "@isaacs/testing-bundle-dupes-b": "1"
+      },
+      "description": "``` a@1 -> b@1 a@2 -> b@2 ```",
+      "_id": "@isaacs/testing-bundle-dupes-a@1.0.0",
+      "_nodeVersion": "16.0.0",
+      "_npmVersion": "7.10.0",
+      "dist": {
+        "integrity": "sha512-q+ZUjdhA5vqvlWFXW92VqTDFVgySt4Cdok3OdeXo30EtFtZYDbWIfNZiQB8YeKS9JmG5DQUDWKd/ygRUxjGhVw==",
+        "shasum": "c15b878ac41284d61c385bf98667a1374c6c2b8b",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-bundle-dupes-a/-/testing-bundle-dupes-a-1.0.0.tgz",
+        "fileCount": 2,
+        "unpackedSize": 451,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJggvSTCRA9TVsSAnZWagAA+IUP/3zwluKM0FRYXu0HXj22\nz0hCDYrWfaTofZvbIvikXeX1mXEIXFsCfSwHYcbxJATe8oO3nE1r1EUMqOJZ\ngYShkS23baGY3GO+g4hDiilIkSBZOHAtDmtsWN/5BnPuHbgsUlX/kSXj8JJ+\n2W0CQbN1BwtE0bSzlboz7nJi4F9rBruKiZ9Barx9BGJkdl5Q0EsKN1VQFz8K\n+4Jspm+zObK22+qT/d9BCEwWNgXlaC0SqCLyJeJp1nFQq/0EPmWxuEeXjbQO\nqaRaCzRK74dzjkGnTklCAIfa5KsKe9In0L7uS6m464dgIQALQbCIrrF9Z5a1\niQ2OtzzQaqPVqb0BZirUcyP10WoZH3QdjFtiyDs9vm7iC2BbWgNUxvwDkGWj\nNeruY0CINw7ic8QXhC51ewoLRnCNmpD1oiwoN/IVdKQfOAkKbLRuKmpgRvnV\n2EQlNtphRF+TasTWQw/VkHFCM8iNf9xVPmhJVkQc+ARXYplvXcM1EPfExdgC\nR8qy6TCxWVUTEVZJPvycqi7aG7evw+08Qz6qNsokjTYWxJ+kVDUcr1uUNx56\nInT9sFT46pix/fSJQOCk1Wrt+/UgOwokjj6493JbJTLch4tJo8zqfeOX+n+f\n+urUjt0HFZe1Gio7F12lqLZPGZt18iJu9q/Xnw1lC2XbTHqutkZ5YsxVpyRt\n9Nif\r\n=VLk3\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-bundle-dupes-a_1.0.0_1619195026806_0.7276246416411416"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-bundle-dupes-a",
+      "version": "2.0.0",
+      "dependencies": {
+        "@isaacs/testing-bundle-dupes-b": "2"
+      },
+      "description": "``` a@1 -> b@1 a@2 -> b@2 ```",
+      "_id": "@isaacs/testing-bundle-dupes-a@2.0.0",
+      "_nodeVersion": "16.0.0",
+      "_npmVersion": "7.10.0",
+      "dist": {
+        "integrity": "sha512-L2LsNX6QYfIvsEVwlFOmyp04Z5gLc4oRD41T5Ih7sCqxhTUcWgCzGKsEeA0qCtDdtqhEsqznznsoDKwjFnn+KQ==",
+        "shasum": "d7ccd1f2b9f6eb84b3e4b7347931f977f1ae2be4",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-bundle-dupes-a/-/testing-bundle-dupes-a-2.0.0.tgz",
+        "fileCount": 2,
+        "unpackedSize": 451,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJggvSWCRA9TVsSAnZWagAAA4AP/3akbV6ThjlZeAWC3VMt\nIGbjJROGmxLBa/gPTWwh3bAKp7Oic5Hgl058NjsXTO7VgQ1/83i30dSN8xAv\nURWvdOMd/wWfSvZb+2W6QQhswd/lb4tMWjcR1Jki7IwsQGQWHjmEYnNHnnTV\nIEu5z0Bw5aAKfPnrToliwDXl5LhfnQgOiOkmA88M8ZFN0+fd35GnKM8EBb9v\nOdS0wqgfDVCWX8D3B9cy/ZGmXMbkHdgWm2SOjjA3QS3BDGJSTLQhThqO67cV\n+Dyvb36s4Z2vL80qyA9KUCryyyBZw15z4pXmKG5szE+hUUBYp+gXFqRit/W9\n8jSOW3fhYNTXLPs42R2JJVT1SvYiEzSAazzbUKwM9e/WvYkK1KZr6m3AvklW\nkU1ODR4HghD3FnHof9ngvQkP0H2Ks5Rj2bPOv68MFCO7DkH7o8E/32KKUsEa\n9hPBQYKdIrIDit/n2ZpMJvpxOUSTFQU+HCB3+rK9bZ8LBW3SGzKCdtwNRiVW\nla7b7QScnGiyCTp5fH4Cw01D+S8/SOk9rP7qnCEShktCPA+0g+JlgTwUqPw4\nCIjI0YPGH/d5olLTZQ8SOSyTINgZ/VPa5bWFUl8wm7tdqqEI/aG/Q41H7jP/\nSadgBjWZKcGissWXHzik7c/+Rya7kW0BmddTL2TPHFxyEdg3HyMSCOyIX26E\ntjP/\r\n=A/s/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-bundle-dupes-a_2.0.0_1619195030155_0.5752048793816165"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-04-23T16:23:46.759Z",
+    "1.0.0": "2021-04-23T16:23:46.910Z",
+    "modified": "2021-04-23T16:23:53.972Z",
+    "2.0.0": "2021-04-23T16:23:50.292Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "description": "``` a@1 -> b@1 a@2 -> b@2 ```",
+  "readme": "# testing-bundle-dupes\n\n```\na@1 -> b@1\na@2 -> b@2\n```\n\nStart:\n\n```\nroot -> BUNDLE(a@1, b@1)\n\nroot\n+-- b@1\n+-- a@1\n```\n\nAdd `a@2.0.0` to root (before b@2.1.0 publish time)\n\n```\nroot\n+-- b@1\n+-- a@2.0.0\n    +-- b@2.0.0\n```\n\n`b@2.1.0` is published\n\nAdd `b@2.1.0` to root\n\nExpect:\n\n```\nroot\n+-- b@2.1.0\n+-- a@2.0.0\n```\n",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-bundle-dupes-a.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-bundle-dupes-a.min.json
@@ -1,0 +1,39 @@
+{
+  "name": "@isaacs/testing-bundle-dupes-a",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-bundle-dupes-a",
+      "version": "1.0.0",
+      "dependencies": {
+        "@isaacs/testing-bundle-dupes-b": "1"
+      },
+      "dist": {
+        "integrity": "sha512-q+ZUjdhA5vqvlWFXW92VqTDFVgySt4Cdok3OdeXo30EtFtZYDbWIfNZiQB8YeKS9JmG5DQUDWKd/ygRUxjGhVw==",
+        "shasum": "c15b878ac41284d61c385bf98667a1374c6c2b8b",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-bundle-dupes-a/-/testing-bundle-dupes-a-1.0.0.tgz",
+        "fileCount": 2,
+        "unpackedSize": 451,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJggvSTCRA9TVsSAnZWagAA+IUP/3zwluKM0FRYXu0HXj22\nz0hCDYrWfaTofZvbIvikXeX1mXEIXFsCfSwHYcbxJATe8oO3nE1r1EUMqOJZ\ngYShkS23baGY3GO+g4hDiilIkSBZOHAtDmtsWN/5BnPuHbgsUlX/kSXj8JJ+\n2W0CQbN1BwtE0bSzlboz7nJi4F9rBruKiZ9Barx9BGJkdl5Q0EsKN1VQFz8K\n+4Jspm+zObK22+qT/d9BCEwWNgXlaC0SqCLyJeJp1nFQq/0EPmWxuEeXjbQO\nqaRaCzRK74dzjkGnTklCAIfa5KsKe9In0L7uS6m464dgIQALQbCIrrF9Z5a1\niQ2OtzzQaqPVqb0BZirUcyP10WoZH3QdjFtiyDs9vm7iC2BbWgNUxvwDkGWj\nNeruY0CINw7ic8QXhC51ewoLRnCNmpD1oiwoN/IVdKQfOAkKbLRuKmpgRvnV\n2EQlNtphRF+TasTWQw/VkHFCM8iNf9xVPmhJVkQc+ARXYplvXcM1EPfExdgC\nR8qy6TCxWVUTEVZJPvycqi7aG7evw+08Qz6qNsokjTYWxJ+kVDUcr1uUNx56\nInT9sFT46pix/fSJQOCk1Wrt+/UgOwokjj6493JbJTLch4tJo8zqfeOX+n+f\n+urUjt0HFZe1Gio7F12lqLZPGZt18iJu9q/Xnw1lC2XbTHqutkZ5YsxVpyRt\n9Nif\r\n=VLk3\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-bundle-dupes-a",
+      "version": "2.0.0",
+      "dependencies": {
+        "@isaacs/testing-bundle-dupes-b": "2"
+      },
+      "dist": {
+        "integrity": "sha512-L2LsNX6QYfIvsEVwlFOmyp04Z5gLc4oRD41T5Ih7sCqxhTUcWgCzGKsEeA0qCtDdtqhEsqznznsoDKwjFnn+KQ==",
+        "shasum": "d7ccd1f2b9f6eb84b3e4b7347931f977f1ae2be4",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-bundle-dupes-a/-/testing-bundle-dupes-a-2.0.0.tgz",
+        "fileCount": 2,
+        "unpackedSize": 451,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJggvSWCRA9TVsSAnZWagAAA4AP/3akbV6ThjlZeAWC3VMt\nIGbjJROGmxLBa/gPTWwh3bAKp7Oic5Hgl058NjsXTO7VgQ1/83i30dSN8xAv\nURWvdOMd/wWfSvZb+2W6QQhswd/lb4tMWjcR1Jki7IwsQGQWHjmEYnNHnnTV\nIEu5z0Bw5aAKfPnrToliwDXl5LhfnQgOiOkmA88M8ZFN0+fd35GnKM8EBb9v\nOdS0wqgfDVCWX8D3B9cy/ZGmXMbkHdgWm2SOjjA3QS3BDGJSTLQhThqO67cV\n+Dyvb36s4Z2vL80qyA9KUCryyyBZw15z4pXmKG5szE+hUUBYp+gXFqRit/W9\n8jSOW3fhYNTXLPs42R2JJVT1SvYiEzSAazzbUKwM9e/WvYkK1KZr6m3AvklW\nkU1ODR4HghD3FnHof9ngvQkP0H2Ks5Rj2bPOv68MFCO7DkH7o8E/32KKUsEa\n9hPBQYKdIrIDit/n2ZpMJvpxOUSTFQU+HCB3+rK9bZ8LBW3SGzKCdtwNRiVW\nla7b7QScnGiyCTp5fH4Cw01D+S8/SOk9rP7qnCEShktCPA+0g+JlgTwUqPw4\nCIjI0YPGH/d5olLTZQ8SOSyTINgZ/VPa5bWFUl8wm7tdqqEI/aG/Q41H7jP/\nSadgBjWZKcGissWXHzik7c/+Rya7kW0BmddTL2TPHFxyEdg3HyMSCOyIX26E\ntjP/\r\n=A/s/\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-04-23T16:23:53.972Z"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-bundle-dupes-b.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-bundle-dupes-b.json
@@ -1,0 +1,122 @@
+{
+  "_id": "@isaacs/testing-bundle-dupes-b",
+  "_rev": "2-2f575a9bfbeca40f7567dc834047849b",
+  "name": "@isaacs/testing-bundle-dupes-b",
+  "dist-tags": {
+    "latest": "2.1.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-bundle-dupes-b",
+      "version": "1.0.0",
+      "description": "``` a@1 -> b@1 a@2 -> b@2 ```",
+      "_id": "@isaacs/testing-bundle-dupes-b@1.0.0",
+      "_nodeVersion": "16.0.0",
+      "_npmVersion": "7.10.0",
+      "dist": {
+        "integrity": "sha512-ky9g4wHryNMfgAmz2+P/+YizWDEenh11V8yNpc4ZpUUOWfF6QZlCqwe5Tk58Rb1TuaX5bfN5Qe0Q90wogMK8XA==",
+        "shasum": "e3ceba663d9367b27d57b27d18fff4fd9b7bd485",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-bundle-dupes-b/-/testing-bundle-dupes-b-1.0.0.tgz",
+        "fileCount": 2,
+        "unpackedSize": 384,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJggvScCRA9TVsSAnZWagAAK5gQAKTGBmG8oju03vRa4HIS\n0TzKPlEyCAoajxGAxE3aV+YPbdFbyyz/rmeQ63mD+WF0vihh/QQo76k9VHwP\n1RGsrQFeIKK1pP2XGbbCTDALA7GER8JyJuCzjMS6OLHeoc7MyAn0kaXJSKgY\n5+O0aejBJbLZSjET0oYjWZ6vEyszmiQDJG/ImyfjNKVhLRhcFfDT7tqlZtCF\n5nhfTbI/8B5kVhY33mYd426gWDN06RGGpghBfZZCbgzS3fEN8wGAzAnrXNjh\nAGyeksUuiHHcu9gDzQbCUNZkEqP4CWY5GUR6vLJwKmyBVPWzG0MEYuG2J9uW\n3UNUtFHIXTbt9Y1V4W4VPwsJQd4VYalTKHDs1rwP18G9BYPWvaoJ5A7xsY/Y\njNDHOCIO5ctul7uIPsSgVdRGkczeeO47+dBMK1gSIgwC3Me1RWd8DCOw1KNr\nObU+wNplmH9yyLhpYz70v8oAz6lQY6WDWASFSsay9wluKoVTR4nz4WKEkG54\nYxFklW/uWqOKnxgAFTpdgOwrkMlKc+Rm9MvCAJuRlfA/zpACKa+tTy/OTYrV\nXkR1U+2QOYwuc7ppvNWtc+h5hI0Yoi7ijDMlsFT3EiBK1gf2Vb0C8t2Wvofm\nj0zVfAVPRPUjo4FyXBQIaxfNnNCaUymp1b5oB4RWGQvzMIXdmIkJY74GiZeS\nCIzE\r\n=iizz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-bundle-dupes-b_1.0.0_1619195036262_0.2254712955428868"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-bundle-dupes-b",
+      "version": "2.0.0",
+      "description": "``` a@1 -> b@1 a@2 -> b@2 ```",
+      "_id": "@isaacs/testing-bundle-dupes-b@2.0.0",
+      "_nodeVersion": "16.0.0",
+      "_npmVersion": "7.10.0",
+      "dist": {
+        "integrity": "sha512-wVwKUhO2Dfcgzu2kX0GUTebqsdpmpfTKLR5hYcFzEqG5gwmO44P3TsjexkJsTymBzlWRgqZTtJyeom9YGpWUuA==",
+        "shasum": "78f23ddae27e7f47ded581cf08220edd3e0d26d0",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-bundle-dupes-b/-/testing-bundle-dupes-b-2.0.0.tgz",
+        "fileCount": 2,
+        "unpackedSize": 384,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJggvSgCRA9TVsSAnZWagAAtq0P/RYbj7ZXyuyc0LJp9cYs\nrzz5b1u0sQpMYl2MMMLsgF2oyP8YpqfXsNymzt8wz4wkWcSKyijDPNTieqEk\nX33Jb3KuSQA4Btn+CEA4cWBLUkjJbaVDK//XjdQLutzaKy5mpYFZgkUcC1QZ\nWP1Y5zv8LFCcfmnvCp5XliYd8xAATlv7W7I73JccccQQ9mWB98BHJutuYA/u\n/3oVN5VaRERcstLAXNNk6qsKg2CPSQ2a3B+AcXmZdLACu49INVwasHrbGTwn\nQWhXyqlj+L+/KYQb08qScWbHUnU1e5Qwr6lsv4ulDPb/snceZq3qj0y634J9\nEW1sya4ZQCfbSdj2CCcdlxHvzhupPnHEdWVHlDIiiUtljFgqDEiWP5f6XEgd\nHT0ynfDmcoapY/BqDf2yXmntodHxz7erzadQzFWRkwYmAF4ZVW64vf0xQBX1\nqBM/MZqjRvx43JM42UY8Ncn5CmJEDQee2FHMcqGugmvtT540FwbBmXQABZQv\nI8WGjVUSSsZ0cMDOoph+T4Uc87gYg3yGt4CZzZ6fPmLWGyd6ILjRYo2WEBj9\nHR4SUJXpM8bFLRH6eRa1nWYB2umGBq5ZZSDDWR9w1DhyjirtGeKG629cSwOk\nIT8mVcKvZ8Tqyt7BJXqjvqI7XZgWT7AIUeuE0/8g1F4NFUkfsHRtW4rIAvPl\nu8fK\r\n=WRDP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-bundle-dupes-b_2.0.0_1619195039732_0.3381094822467585"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.1.0": {
+      "name": "@isaacs/testing-bundle-dupes-b",
+      "version": "2.1.0",
+      "description": "``` a@1 -> b@1 a@2 -> b@2 ```",
+      "_id": "@isaacs/testing-bundle-dupes-b@2.1.0",
+      "_nodeVersion": "16.0.0",
+      "_npmVersion": "7.10.0",
+      "dist": {
+        "integrity": "sha512-IA0NhfF2i7iURyGfTtoe6z4en6wUTerikYp0ZFFIFdgDN5j1WZIBK3OLFefjKEDaCX6hwOQR2vyjXv6KKK9xkQ==",
+        "shasum": "53a5e3dbbef454cedd2624161cd8c4666bbdd8e4",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-bundle-dupes-b/-/testing-bundle-dupes-b-2.1.0.tgz",
+        "fileCount": 2,
+        "unpackedSize": 384,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJggvTsCRA9TVsSAnZWagAAsQgP/0E8kTdy2IohKZtpKjWP\nFIjhFnJHP/rz4MUE4EW90YTLyyI5sKX1rv4Itv1VCIEd8HWIQOO84a3RT3xh\nlVPfuc0AGKL5xavCe6YAdzLiqkNxFxtblpmQXqOEL0tdmUeMN7ZLLl4F8lU5\nHMtWDQ2kTfSngG4gDY8d3BgQBl0IaFiB6msygpQbvnmaxO/EYocJu28pf9Wy\n/1xOZqWR0dkUdVhcq7UIip1BfIZJmIZds+PolMjfUTeQBIDpXPxHB7FbRINx\n0m3w/epOREvZlbGzIRe+mwy1PAbTIIZf4rYXAxNAKPnDAdhV5JfDX0sn8EDX\nUaWPmcI/DJlw5k26LBayIR4QbIPFNVFnAqY5P26igZxOIgQM1VlQyuMyHlGx\nAmqyI9OUXXmOf6IKlHiGL5NoDjJxWu6zhBj2EbpUxZp2rhn/Hb1u1E+0g+Dn\n9hY1AeUiraiW9dPLgscjyQrpziz0IIVCNGcBiezA/qClbH61L2VPoL6jo0X6\nuxrNkO6s5hYn543AIJb3EbXe5zsgB+Mb7C0wEl0t/NNoOIFdqh5IqzCR72u0\nJLCNSmSKVapKy0JnxAI3dKT6aqdo7h905kwJ9Ig01+KTyH02AIOvSD2CZRdd\n5kmhkk3FZGrU0c8ZF7qJVyB3HbGDRmKIqgVcmrNtE/79yWdJHJKonHUO/GNo\nz4Eq\r\n=lCuL\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-bundle-dupes-b_2.1.0_1619195115785_0.9923225624360594"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-04-23T16:23:56.215Z",
+    "1.0.0": "2021-04-23T16:23:56.389Z",
+    "modified": "2021-04-23T16:25:19.192Z",
+    "2.0.0": "2021-04-23T16:23:59.888Z",
+    "2.1.0": "2021-04-23T16:25:15.922Z"
+  },
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "description": "``` a@1 -> b@1 a@2 -> b@2 ```",
+  "readme": "# testing-bundle-dupes\n\n```\na@1 -> b@1\na@2 -> b@2\n```\n\nStart:\n\n```\nroot -> BUNDLE(a@1, b@1)\n\nroot\n+-- b@1\n+-- a@1\n```\n\nAdd `a@2.0.0` to root (before b@2.1.0 publish time)\n\n```\nroot\n+-- b@1\n+-- a@2.0.0\n    +-- b@2.0.0\n```\n\n`b@2.1.0` is published\n\nAdd `b@2.1.0` to root\n\nExpect:\n\n```\nroot\n+-- b@2.1.0\n+-- a@2.0.0\n```\n",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/isaacs/testing-bundle-dupes-b.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-bundle-dupes-b.min.json
@@ -1,0 +1,45 @@
+{
+  "name": "@isaacs/testing-bundle-dupes-b",
+  "dist-tags": {
+    "latest": "2.1.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@isaacs/testing-bundle-dupes-b",
+      "version": "1.0.0",
+      "dist": {
+        "integrity": "sha512-ky9g4wHryNMfgAmz2+P/+YizWDEenh11V8yNpc4ZpUUOWfF6QZlCqwe5Tk58Rb1TuaX5bfN5Qe0Q90wogMK8XA==",
+        "shasum": "e3ceba663d9367b27d57b27d18fff4fd9b7bd485",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-bundle-dupes-b/-/testing-bundle-dupes-b-1.0.0.tgz",
+        "fileCount": 2,
+        "unpackedSize": 384,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJggvScCRA9TVsSAnZWagAAK5gQAKTGBmG8oju03vRa4HIS\n0TzKPlEyCAoajxGAxE3aV+YPbdFbyyz/rmeQ63mD+WF0vihh/QQo76k9VHwP\n1RGsrQFeIKK1pP2XGbbCTDALA7GER8JyJuCzjMS6OLHeoc7MyAn0kaXJSKgY\n5+O0aejBJbLZSjET0oYjWZ6vEyszmiQDJG/ImyfjNKVhLRhcFfDT7tqlZtCF\n5nhfTbI/8B5kVhY33mYd426gWDN06RGGpghBfZZCbgzS3fEN8wGAzAnrXNjh\nAGyeksUuiHHcu9gDzQbCUNZkEqP4CWY5GUR6vLJwKmyBVPWzG0MEYuG2J9uW\n3UNUtFHIXTbt9Y1V4W4VPwsJQd4VYalTKHDs1rwP18G9BYPWvaoJ5A7xsY/Y\njNDHOCIO5ctul7uIPsSgVdRGkczeeO47+dBMK1gSIgwC3Me1RWd8DCOw1KNr\nObU+wNplmH9yyLhpYz70v8oAz6lQY6WDWASFSsay9wluKoVTR4nz4WKEkG54\nYxFklW/uWqOKnxgAFTpdgOwrkMlKc+Rm9MvCAJuRlfA/zpACKa+tTy/OTYrV\nXkR1U+2QOYwuc7ppvNWtc+h5hI0Yoi7ijDMlsFT3EiBK1gf2Vb0C8t2Wvofm\nj0zVfAVPRPUjo4FyXBQIaxfNnNCaUymp1b5oB4RWGQvzMIXdmIkJY74GiZeS\nCIzE\r\n=iizz\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "@isaacs/testing-bundle-dupes-b",
+      "version": "2.0.0",
+      "dist": {
+        "integrity": "sha512-wVwKUhO2Dfcgzu2kX0GUTebqsdpmpfTKLR5hYcFzEqG5gwmO44P3TsjexkJsTymBzlWRgqZTtJyeom9YGpWUuA==",
+        "shasum": "78f23ddae27e7f47ded581cf08220edd3e0d26d0",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-bundle-dupes-b/-/testing-bundle-dupes-b-2.0.0.tgz",
+        "fileCount": 2,
+        "unpackedSize": 384,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJggvSgCRA9TVsSAnZWagAAtq0P/RYbj7ZXyuyc0LJp9cYs\nrzz5b1u0sQpMYl2MMMLsgF2oyP8YpqfXsNymzt8wz4wkWcSKyijDPNTieqEk\nX33Jb3KuSQA4Btn+CEA4cWBLUkjJbaVDK//XjdQLutzaKy5mpYFZgkUcC1QZ\nWP1Y5zv8LFCcfmnvCp5XliYd8xAATlv7W7I73JccccQQ9mWB98BHJutuYA/u\n/3oVN5VaRERcstLAXNNk6qsKg2CPSQ2a3B+AcXmZdLACu49INVwasHrbGTwn\nQWhXyqlj+L+/KYQb08qScWbHUnU1e5Qwr6lsv4ulDPb/snceZq3qj0y634J9\nEW1sya4ZQCfbSdj2CCcdlxHvzhupPnHEdWVHlDIiiUtljFgqDEiWP5f6XEgd\nHT0ynfDmcoapY/BqDf2yXmntodHxz7erzadQzFWRkwYmAF4ZVW64vf0xQBX1\nqBM/MZqjRvx43JM42UY8Ncn5CmJEDQee2FHMcqGugmvtT540FwbBmXQABZQv\nI8WGjVUSSsZ0cMDOoph+T4Uc87gYg3yGt4CZzZ6fPmLWGyd6ILjRYo2WEBj9\nHR4SUJXpM8bFLRH6eRa1nWYB2umGBq5ZZSDDWR9w1DhyjirtGeKG629cSwOk\nIT8mVcKvZ8Tqyt7BJXqjvqI7XZgWT7AIUeuE0/8g1F4NFUkfsHRtW4rIAvPl\nu8fK\r\n=WRDP\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.1.0": {
+      "name": "@isaacs/testing-bundle-dupes-b",
+      "version": "2.1.0",
+      "dist": {
+        "integrity": "sha512-IA0NhfF2i7iURyGfTtoe6z4en6wUTerikYp0ZFFIFdgDN5j1WZIBK3OLFefjKEDaCX6hwOQR2vyjXv6KKK9xkQ==",
+        "shasum": "53a5e3dbbef454cedd2624161cd8c4666bbdd8e4",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-bundle-dupes-b/-/testing-bundle-dupes-b-2.1.0.tgz",
+        "fileCount": 2,
+        "unpackedSize": 384,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJggvTsCRA9TVsSAnZWagAAsQgP/0E8kTdy2IohKZtpKjWP\nFIjhFnJHP/rz4MUE4EW90YTLyyI5sKX1rv4Itv1VCIEd8HWIQOO84a3RT3xh\nlVPfuc0AGKL5xavCe6YAdzLiqkNxFxtblpmQXqOEL0tdmUeMN7ZLLl4F8lU5\nHMtWDQ2kTfSngG4gDY8d3BgQBl0IaFiB6msygpQbvnmaxO/EYocJu28pf9Wy\n/1xOZqWR0dkUdVhcq7UIip1BfIZJmIZds+PolMjfUTeQBIDpXPxHB7FbRINx\n0m3w/epOREvZlbGzIRe+mwy1PAbTIIZf4rYXAxNAKPnDAdhV5JfDX0sn8EDX\nUaWPmcI/DJlw5k26LBayIR4QbIPFNVFnAqY5P26igZxOIgQM1VlQyuMyHlGx\nAmqyI9OUXXmOf6IKlHiGL5NoDjJxWu6zhBj2EbpUxZp2rhn/Hb1u1E+0g+Dn\n9hY1AeUiraiW9dPLgscjyQrpziz0IIVCNGcBiezA/qClbH61L2VPoL6jo0X6\nuxrNkO6s5hYn543AIJb3EbXe5zsgB+Mb7C0wEl0t/NNoOIFdqh5IqzCR72u0\nJLCNSmSKVapKy0JnxAI3dKT6aqdo7h905kwJ9Ig01+KTyH02AIOvSD2CZRdd\n5kmhkk3FZGrU0c8ZF7qJVyB3HbGDRmKIqgVcmrNtE/79yWdJHJKonHUO/GNo\nz4Eq\r\n=lCuL\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2021-04-23T16:25:19.192Z"
+}

--- a/test/fixtures/testing-bundle-dupes/README.md
+++ b/test/fixtures/testing-bundle-dupes/README.md
@@ -1,0 +1,37 @@
+# testing-bundle-dupes
+
+```
+a@1 -> b@1
+a@2 -> b@2
+```
+
+Start:
+
+```
+root -> BUNDLE(a@1, b@1)
+
+root
++-- b@1
++-- a@1
+```
+
+Add `a@2.0.0` to root (before b@2.1.0 publish time)
+
+```
+root
++-- b@1
++-- a@2.0.0
+    +-- b@2.0.0
+```
+
+`b@2.1.0` is published
+
+Add `b@2.1.0` to root
+
+Expect:
+
+```
+root
++-- b@2.1.0
++-- a@2.0.0
+```

--- a/test/fixtures/testing-bundle-dupes/a/1/package.json
+++ b/test/fixtures/testing-bundle-dupes/a/1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-bundle-dupes-a",
+  "version": "1.0.0",
+  "dependencies": {
+    "@isaacs/testing-bundle-dupes-b": "1"
+  }
+}

--- a/test/fixtures/testing-bundle-dupes/a/2/package.json
+++ b/test/fixtures/testing-bundle-dupes/a/2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-bundle-dupes-a",
+  "version": "2.0.0",
+  "dependencies": {
+    "@isaacs/testing-bundle-dupes-b": "2"
+  }
+}

--- a/test/fixtures/testing-bundle-dupes/b/1/package.json
+++ b/test/fixtures/testing-bundle-dupes/b/1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-bundle-dupes-b",
+  "version": "1.0.0"
+}

--- a/test/fixtures/testing-bundle-dupes/b/2.0/package.json
+++ b/test/fixtures/testing-bundle-dupes/b/2.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-bundle-dupes-b",
+  "version": "2.0.0"
+}

--- a/test/fixtures/testing-bundle-dupes/b/2.1/package.json
+++ b/test/fixtures/testing-bundle-dupes/b/2.1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@isaacs/testing-bundle-dupes-b",
+  "version": "2.1.0"
+}


### PR DESCRIPTION
When the root package tree bundles its dependencies, previously Arborist
would treat that as a normal bundled dependency (rather than a
transitive dependency bundled _by_ a dependency) and refuse to touch it.

This resulted in a strange situation where npm would stubbornly refuse
to modify the copy of npm-registry-fetch nested underneath its pacote
dependency, even when pacote or nrf were updated explicitly, requiring
the deletion of the node_modules tree in order to resolve properly.

A `canDedupe()` method is added to the Node class, and this is used in
multiple previously (slightly) duplicative code paths where we test to
see if we can dedupe out a nested Node in the tree, thus both preventing
and correcting the unnecessary duplicates that would otherwise have
occurred.

This does introduce the bug/feature/change where now installing a new
package at the top level will cause npm to remove anything nested within
the tree that could be deduped against it, as long as that nested
transitive dependency is not contained in a dep bundle or shrinkwrap.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
