### PR TITLE
support resolvable partial intersecting peerSets

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -1631,32 +1631,137 @@ This is a one-time fix-up, please be patient...
         // placed here as well.  the virtualRoot already has the appropriate
         // overrides applied.
         if (peerEntryEdge) {
-          const peerSet = getPeerSet(current)
-          OUTER: for (const p of peerSet) {
-            // if any have a non-peer dep from the target, or a peer dep if
-            // the target is root, then cannot safely replace and dupe deeper.
-            for (const edge of p.edgesIn) {
-              if (peerSet.has(edge.from))
-                continue
+          const currentPeerSet = getPeerSet(current)
 
-              // only respect valid edges, however, since we're likely trying
-              // to fix the very one that's currently broken!  If the virtual
-              // root's replacement is ok, and doesn't have any invalid edges
-              // indicating that it was an overridden peer, then ignore the
-              // conflict and continue.  If it WAS an override, then we need
-              // to get the conflict here so that we can decide whether to
-              // accept the current dep node, clobber it, or fail the install.
-              if (edge.from === target && edge.valid) {
-                const rep = dep.parent.children.get(edge.name)
-                const override = rep && ([...rep.edgesIn].some(e => !e.valid))
-                if (!rep || !rep.satisfies(edge) || override) {
+          // We are effectively replacing currentPeerSet with newPeerSet
+          // If there are any non-peer deps coming into the currentPeerSet,
+          // which are currently valid, and are from the target, then that
+          // means that we have to ensure that they're not going to be made
+          // invalid by putting the newPeerSet in place.
+          // If the edge comes from somewhere deeper than the target, then
+          // that's fine, because we'll create an invalid edge, detect it,
+          // and duplicate the node further into the tree.
+          // loop through the currentPeerSet checking for valid edges on
+          // the members of the peer set which will be made invalid.
+          const targetEdges = new Set()
+          for (const p of currentPeerSet) {
+            for (const edge of p.edgesIn) {
+              // edge from within the peerSet, ignore
+              if (currentPeerSet.has(edge.from))
+                continue
+              // only care about valid edges from target.
+              // edges from elsewhere can dupe if offended, invalid edges
+              // are already being fixed or will be later.
+              if (edge.from !== target || !edge.valid)
+                continue
+              targetEdges.add(edge)
+            }
+          }
+
+          for (const edge of targetEdges) {
+            // see if we intend to replace this one anyway
+            const rep = dep.parent.children.get(edge.name)
+            const current = edge.to
+            if (!rep) {
+              // this isn't one we're replacing.  but it WAS included in the
+              // peerSet for some reason, so make sure that it's still
+              // ok with the replacements in the new peerSet
+              for (const curEdge of current.edgesOut.values()) {
+                const newRepDep = dep.parent.children.get(curEdge.name)
+                if (curEdge.valid && newRepDep && !newRepDep.satisfies(curEdge)) {
                   canReplace = false
-                  break OUTER
+                  break
                 }
               }
+              continue
+            }
+
+            // was this replacement already an override of some sort?
+            const override = [...rep.edgesIn].some(e => !e.valid)
+            // if we have a rep, and it's ok to put in this location, and
+            // it's not already part of an override in the peerSet, then
+            // we can continue with it.
+            if (rep.satisfies(edge) && !override)
+              continue
+            // Otherwise, we cannot replace.
+            canReplace = false
+            break
+          }
+          // if we're going to be replacing the peerSet, we have to remove
+          // and re-resolve any members of the old peerSet that are not
+          // present in the new one, and which will have invalid edges.
+          // We know that they're not depended upon by the target, or else
+          // they would have caused a conflict, so they'll get landed deeper
+          // in the tree, if possible.
+          if (canReplace) {
+            let needNesting = false
+            OUTER: for (const node of currentPeerSet) {
+              const rep = dep.parent.children.get(node.name)
+              // has a replacement, already addressed above
+              if (rep)
+                continue
+
+              // ok, it has been placed here to dedupe, see if it needs to go
+              // back deeper within the tree.
+              for (const edge of node.edgesOut.values()) {
+                const repDep = dep.parent.children.get(edge.name)
+                // not in new peerSet, maybe fine.
+                if (!repDep)
+                  continue
+
+                // new thing will be fine, no worries
+                if (repDep.satisfies(edge))
+                  continue
+
+                // uhoh, we'll have to nest them.
+                needNesting = true
+                break OUTER
+              }
+            }
+
+            // to nest, just delete everything without a target dep
+            // that's in the current peerSet, and add their dependants
+            // to the _depsQueue for evaluation.  Some of these MAY end
+            // up in the same location again, and that's fine.
+            if (needNesting) {
+              // avoid mutating the tree while we're examining it
+              const dependants = new Set()
+              const reresolve = new Set()
+              OUTER: for (const node of currentPeerSet) {
+                const rep = dep.parent.children.get(node.name)
+                if (rep)
+                  continue
+                // create a separate set for each one, so we can skip any
+                // that might somehow have an incoming target edge
+                const deps = new Set()
+                for (const edge of node.edgesIn) {
+                  // a target dep, skip this dep entirely, already addressed
+                  // ignoring for coverage, because it really ought to be
+                  // impossible, but I can't prove it yet, so this is here
+                  // for safety.
+                  /* istanbul ignore if - should be impossible */
+                  if (edge.from === target)
+                    continue OUTER
+                  // ignore this edge, it'll either be replaced or re-resolved
+                  if (currentPeerSet.has(edge.from))
+                    continue
+                  // ok, we care about this one.
+                  deps.add(edge.from)
+                }
+                reresolve.add(node)
+                for (const d of deps)
+                  dependants.add(d)
+              }
+              for (const dependant of dependants) {
+                this[_depsQueue].push(dependant)
+                this[_depsSeen].delete(dependant)
+              }
+              for (const node of reresolve)
+                node.root = null
             }
           }
         }
+
         if (canReplace) {
           const ret = this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge, peerPath, isSource)
           /* istanbul ignore else - extremely rare that the peer set would

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-a.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-a.json
@@ -1,9 +1,9 @@
 {
   "_id": "@isaacs/testing-peer-dep-conflict-chain-a",
-  "_rev": "1-5cc787aebbc9a690e0e0d1001a44aa57",
+  "_rev": "2-69f02659d90038d0294e6078c0b1485b",
   "name": "@isaacs/testing-peer-dep-conflict-chain-a",
   "dist-tags": {
-    "latest": "2.0.0"
+    "latest": "3.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -75,13 +75,48 @@
         "tmp": "tmp/testing-peer-dep-conflict-chain-a_2.0.0_1597792474569_0.04243294736758885"
       },
       "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+      "version": "3.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-b": "3"
+      },
+      "_id": "@isaacs/testing-peer-dep-conflict-chain-a@3.0.0",
+      "_nodeVersion": "16.0.0",
+      "_npmVersion": "7.11.1",
+      "dist": {
+        "integrity": "sha512-n9ICK3COzUPtDP+Qo8iEPSGxffOA3S58/oaSViZPOJR+if2VGaGF6CYzfcK9CuNdEwJAqtS6RMYrTZlFpXyk/Q==",
+        "shasum": "d5f2bc83fa71a3388a8d34c76b41ca7cbd2f3f59",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-a/-/testing-peer-dep-conflict-chain-a-3.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 144,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiJ16CRA9TVsSAnZWagAA/Z0P/1pkIufroMPa5us6CwBj\nqqbgEer1Rs6e7VuLZoRJWMS8C6T8M5hwWzdMnfqDBzQZ/3ekHXl4DS354TZP\n7FpaXBgl33k/TLgtWBzCaDtkCZ8FE5M+ZnZ47t8dq3WYFkmlmHpgoSsNLv2j\ntk4Q7sdT5Wu/M8lZVa4nTRrzMKaTcKYyexwN9zzHowCvlUB3Vje/sX/Nhfc+\nmu7lndBftXgX4WiAW2l8hSxiLzEYeaLo4Y3og1ocE3cUEi1aA+gCPdL/bkIl\n2juoopoqbBkJF1ES7lWTNRS3zVqmHvvpKSse9Eq13IK1XE8Bv60yAK79rHKH\n0hV3Va1UDzA+JkmPN0hSondjMSTnk29XZpFKFazqMOSpr6MUaXDaOCSjx06i\nQjzHvwUsn5WQZQ9TmasMWOpPmiltwKD0O4rQxDqaopcxM7lySq+HvFJ0Q5CT\n8zER6pSHhT9uaT+YIVCrVU4V4hkmCoR32PZsik1HFxWP3ykqpnpwxZq6XwTt\nLcpidIBytUHa4SD5sqpukN4qZ/+TWvcss+/743untXhpmXzZQBdz7iD6lAhq\nO06JfBxrHEQbZULc/9OD0ILGqrgRvOnxAGcuUpRPMUHOfDSLZGPmjQRMuqs/\nMkH38SpuMkzDvb2C9VFCZTi6S0cSSlXXKhlieTQZ83//dGN5BptPHjd3+4cW\n3S1Z\r\n=hOCb\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-conflict-chain-a_3.0.0_1619565946310_0.8175739035056382"
+      },
+      "_hasShrinkwrap": false
     }
   },
   "time": {
     "created": "2020-08-18T23:13:30.243Z",
     "1.0.0": "2020-08-18T23:13:30.343Z",
-    "modified": "2020-08-18T23:14:38.056Z",
-    "2.0.0": "2020-08-18T23:14:34.668Z"
+    "modified": "2021-04-27T23:25:48.581Z",
+    "2.0.0": "2020-08-18T23:14:34.668Z",
+    "3.0.0": "2021-04-27T23:25:46.413Z"
   },
   "maintainers": [
     {
@@ -89,7 +124,6 @@
       "email": "i@izs.me"
     }
   ],
-  "description": "A chain of peer deps.  Installing v1 of any of them requires v1 of all of them.  v2 of any requires v2 of all.  No v1 can coexist with any v2.",
-  "readme": "A chain of peer deps.  Installing v1 of any of them requires v1 of all of\nthem.  v2 of any requires v2 of all.  No v1 can coexist with any v2.\n",
-  "readmeFilename": "README.md"
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
 }

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-a.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-a.min.json
@@ -1,7 +1,7 @@
 {
   "name": "@isaacs/testing-peer-dep-conflict-chain-a",
   "dist-tags": {
-    "latest": "2.0.0"
+    "latest": "3.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -33,7 +33,22 @@
         "unpackedSize": 287,
         "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfPGDbCRA9TVsSAnZWagAAHmIP/RZxhtapQUX2KvQakJ4/\ndLyiEZVYlKgTEQhG2VZc+ygVfwhfpAgKPSw8W7Vm2itwVLVjnup9volYdnfF\n0g3Buw/jOCLvU3mbvFdSeWTkv/XucCaiHvmXbv3yf7DzQvvxgzwxxWhpBjo/\nCoqq/xvCwyDcF75OyRaOPZVwWADMeq8SNgwXaCoqDgkV8RVBtAJQ1frGTQPb\nwAzAak5WQZyQgh4up32UNyOK4vl2qVXE0KBz114UHxxfxWQ+ag3+TLsErz69\nRB5/QAHwQAmk8eovoF9OETp2U5w4q+Mdy6SnHDM4kSGeAIvL4xK+qPoA+Pj7\n49nfJoA4GVYV730betlJbm2mCNeDVuM/UWx5X77s0IlFw7fdVNKfjmpZFreg\nzsSdax//3naehtfj/BESs5oGi9PULIh9h6eANnDZVHo9lK/KbP7VQ7PzV1TX\n633Wi52snJhHQX+i/N4KhOYm5gZArFhMawIhrQGMcyQ9pXvyn0Q/r+0P/y42\nLaK0AWe3ODAt8RfnQTAxXZ/FPOHTHMYsyg13ko7A1sGA5osijIH5iaDbSTiy\nFBqQD93+xYRWXAac8COUirH8h7bH6iNiUyMp2fclsN+fqPEqLT0exoBlQss7\nIN5QiGn2iXL3KPK7RyuNkNP5myJWCZmYzA5HbDZhV3JjBHwVIVbuHp9vGXDi\ng/ev\r\n=Up6o\r\n-----END PGP SIGNATURE-----\r\n"
       }
+    },
+    "3.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-a",
+      "version": "3.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-b": "3"
+      },
+      "dist": {
+        "integrity": "sha512-n9ICK3COzUPtDP+Qo8iEPSGxffOA3S58/oaSViZPOJR+if2VGaGF6CYzfcK9CuNdEwJAqtS6RMYrTZlFpXyk/Q==",
+        "shasum": "d5f2bc83fa71a3388a8d34c76b41ca7cbd2f3f59",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-a/-/testing-peer-dep-conflict-chain-a-3.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 144,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiJ16CRA9TVsSAnZWagAA/Z0P/1pkIufroMPa5us6CwBj\nqqbgEer1Rs6e7VuLZoRJWMS8C6T8M5hwWzdMnfqDBzQZ/3ekHXl4DS354TZP\n7FpaXBgl33k/TLgtWBzCaDtkCZ8FE5M+ZnZ47t8dq3WYFkmlmHpgoSsNLv2j\ntk4Q7sdT5Wu/M8lZVa4nTRrzMKaTcKYyexwN9zzHowCvlUB3Vje/sX/Nhfc+\nmu7lndBftXgX4WiAW2l8hSxiLzEYeaLo4Y3og1ocE3cUEi1aA+gCPdL/bkIl\n2juoopoqbBkJF1ES7lWTNRS3zVqmHvvpKSse9Eq13IK1XE8Bv60yAK79rHKH\n0hV3Va1UDzA+JkmPN0hSondjMSTnk29XZpFKFazqMOSpr6MUaXDaOCSjx06i\nQjzHvwUsn5WQZQ9TmasMWOpPmiltwKD0O4rQxDqaopcxM7lySq+HvFJ0Q5CT\n8zER6pSHhT9uaT+YIVCrVU4V4hkmCoR32PZsik1HFxWP3ykqpnpwxZq6XwTt\nLcpidIBytUHa4SD5sqpukN4qZ/+TWvcss+/743untXhpmXzZQBdz7iD6lAhq\nO06JfBxrHEQbZULc/9OD0ILGqrgRvOnxAGcuUpRPMUHOfDSLZGPmjQRMuqs/\nMkH38SpuMkzDvb2C9VFCZTi6S0cSSlXXKhlieTQZ83//dGN5BptPHjd3+4cW\n3S1Z\r\n=hOCb\r\n-----END PGP SIGNATURE-----\r\n"
+      }
     }
   },
-  "modified": "2020-08-18T23:14:38.056Z"
+  "modified": "2021-04-27T23:25:48.581Z"
 }

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-b.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-b.json
@@ -1,9 +1,9 @@
 {
   "_id": "@isaacs/testing-peer-dep-conflict-chain-b",
-  "_rev": "1-422c8aed92df7e31faafbd2f8019112c",
+  "_rev": "2-bc7e0e1ab2ee7b7050820bcd40ef3611",
   "name": "@isaacs/testing-peer-dep-conflict-chain-b",
   "dist-tags": {
-    "latest": "2.0.0"
+    "latest": "3.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -75,13 +75,48 @@
         "tmp": "tmp/testing-peer-dep-conflict-chain-b_2.0.0_1597792482846_0.01393504666505141"
       },
       "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-b",
+      "version": "3.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-c": "3"
+      },
+      "_id": "@isaacs/testing-peer-dep-conflict-chain-b@3.0.0",
+      "_nodeVersion": "16.0.0",
+      "_npmVersion": "7.11.1",
+      "dist": {
+        "integrity": "sha512-Aip2zXyqNDevJeC6Xktj8ycy39Gq9qCnGJrv7z6rct03Rwyt1qeDS9m9y3UYKWdeEIju63P2vQQ+nmh6ZzpGGQ==",
+        "shasum": "d02035351ad25351074ea09fac0a9460d0a02c8e",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-b/-/testing-peer-dep-conflict-chain-b-3.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 144,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiJ19CRA9TVsSAnZWagAATfAP/1T6GIbX0Yhr7j2FrzYE\nmcKvubm664xdMrFFqr/ry3K3lGAimkwNXiedzmig+qBbP9mVYOWJKdv10jqf\nc66QQElqk6UrgWuZDSy9P/7SnBu617WwtTszwdQKCyc9ljIzHicY31b8FX4m\nWKShKhw2xmRidMpweSocemUk7/ZyFB0G3S1ro40iIDrL7BfOcBIWTZQB4FV8\n1qjxP1ZsG1jfl8MhKllKO5XNfQD8F7QzEqWw/vjt0uWsfm/JhmZoFgVFfzD8\nzBKCmuRzm70DaxUlVUF1Tr+1sI1wRKRzpnfEfHirJrGbJSld8B3dYXSehE01\n6BMOILsnuGB/fg6+UEbNA6nl9TKn/DYgEVTL4GKFSzigizNtRUHqh9cwtTL4\nLF7tgKqtzKUZFyc5+Wt9OCdPmBY/Nfzo09v9rhdkuJYBv+mWEUlV3pMsA4Ee\n45Ct8lV++H1skW/76Rpopk/mjHJWgaFqQawgIzSNuJDyMxGjZsD3jkitN4u3\nkmJPfr1enxywpu/4p8G7tB/vSxjkd/ZbJ6rXMm/I8wmSu2GfRpVXp6txNQd2\nNT3SXfwPxUnBitEUr1ZsZQbYcRX20SB/VhPuDKmpkhbXfrteDkozMgq9lNtq\nu/OPfYftUiTsibKrfzN8cwmeigZV8Bm7aIDyu4yQWPASpZjwUeEvzRl/9fI9\nYSf4\r\n=pxb1\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-conflict-chain-b_3.0.0_1619565949545_0.9046564755736393"
+      },
+      "_hasShrinkwrap": false
     }
   },
   "time": {
     "created": "2020-08-18T23:14:39.329Z",
     "1.0.0": "2020-08-18T23:14:39.418Z",
-    "modified": "2020-08-18T23:14:45.121Z",
-    "2.0.0": "2020-08-18T23:14:42.952Z"
+    "modified": "2021-04-27T23:25:51.836Z",
+    "2.0.0": "2020-08-18T23:14:42.952Z",
+    "3.0.0": "2021-04-27T23:25:49.685Z"
   },
   "maintainers": [
     {
@@ -89,7 +124,6 @@
       "email": "i@izs.me"
     }
   ],
-  "description": "A chain of peer deps.  Installing v1 of any of them requires v1 of all of them.  v2 of any requires v2 of all.  No v1 can coexist with any v2.",
-  "readme": "A chain of peer deps.  Installing v1 of any of them requires v1 of all of\nthem.  v2 of any requires v2 of all.  No v1 can coexist with any v2.\n",
-  "readmeFilename": "README.md"
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
 }

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-b.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-b.min.json
@@ -1,7 +1,7 @@
 {
   "name": "@isaacs/testing-peer-dep-conflict-chain-b",
   "dist-tags": {
-    "latest": "2.0.0"
+    "latest": "3.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -33,7 +33,22 @@
         "unpackedSize": 287,
         "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfPGDjCRA9TVsSAnZWagAAcFsP/jYnZYohv1w7VBq+jA6o\n5/usLyaWtBiWXvlY27zKg/3twZM0sHNiMiictbc5qSPKv06OAoc/G166R8eG\nKXTCUlIFk7KYaluRreJL1meEa5R34qi1iIBeZ1Ih2nixHvKRzCbCtFuJ5+/W\ni+BECJLpHBygY/4qhgX9HaRK2lpAFju79J76clVgXzJ+1zSznalHA8j1UvDl\nopG2sQA9LZ00qU8J1kLc+FLJI/3gBjlLCjGgG1PMRen32UWmWKBvnrDp3FWF\nZ8fJ5P+KiNbZ0Bx0GOMEnFHOIrfW+GZJIkCR2xPOThKi4IHhpPXVjWS7KM3H\n36P1hTdLHSYwlDgNBXmZGWvmYjUMRu+1Eb2MEBDr69g/uKy/njYjH3wmFJOQ\nykSEOmkLxWbNXIsIaDPsjgZuY55FyHidpjwTrbH9YtDfogUNS54oEmHf4mav\nQP6QMQBoLlf7x226w4D1h6WKlFAsYUMLa7GFQAyEkoAqm+Ep6kjqZcUlHtF7\n5C2Bru8msKYPOx/YmgPXKUkK9FzlnCPrg7faFFFqXWQLDKwQUj8H1QX+yzgC\n4Q7hPHqFzddP61Gr5HNjtfV2XBHfjr2pS+7Izm45/vb13xfYnTJe6N3RoYeR\nRSjYpf/V/dBlo+Oo+FrS9xzPKD9n6Pi+kwdS/0FQz/WgFk9S1Iw+p51WuEc5\nIsMx\r\n=KF+o\r\n-----END PGP SIGNATURE-----\r\n"
       }
+    },
+    "3.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-b",
+      "version": "3.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-c": "3"
+      },
+      "dist": {
+        "integrity": "sha512-Aip2zXyqNDevJeC6Xktj8ycy39Gq9qCnGJrv7z6rct03Rwyt1qeDS9m9y3UYKWdeEIju63P2vQQ+nmh6ZzpGGQ==",
+        "shasum": "d02035351ad25351074ea09fac0a9460d0a02c8e",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-b/-/testing-peer-dep-conflict-chain-b-3.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 144,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiJ19CRA9TVsSAnZWagAATfAP/1T6GIbX0Yhr7j2FrzYE\nmcKvubm664xdMrFFqr/ry3K3lGAimkwNXiedzmig+qBbP9mVYOWJKdv10jqf\nc66QQElqk6UrgWuZDSy9P/7SnBu617WwtTszwdQKCyc9ljIzHicY31b8FX4m\nWKShKhw2xmRidMpweSocemUk7/ZyFB0G3S1ro40iIDrL7BfOcBIWTZQB4FV8\n1qjxP1ZsG1jfl8MhKllKO5XNfQD8F7QzEqWw/vjt0uWsfm/JhmZoFgVFfzD8\nzBKCmuRzm70DaxUlVUF1Tr+1sI1wRKRzpnfEfHirJrGbJSld8B3dYXSehE01\n6BMOILsnuGB/fg6+UEbNA6nl9TKn/DYgEVTL4GKFSzigizNtRUHqh9cwtTL4\nLF7tgKqtzKUZFyc5+Wt9OCdPmBY/Nfzo09v9rhdkuJYBv+mWEUlV3pMsA4Ee\n45Ct8lV++H1skW/76Rpopk/mjHJWgaFqQawgIzSNuJDyMxGjZsD3jkitN4u3\nkmJPfr1enxywpu/4p8G7tB/vSxjkd/ZbJ6rXMm/I8wmSu2GfRpVXp6txNQd2\nNT3SXfwPxUnBitEUr1ZsZQbYcRX20SB/VhPuDKmpkhbXfrteDkozMgq9lNtq\nu/OPfYftUiTsibKrfzN8cwmeigZV8Bm7aIDyu4yQWPASpZjwUeEvzRl/9fI9\nYSf4\r\n=pxb1\r\n-----END PGP SIGNATURE-----\r\n"
+      }
     }
   },
-  "modified": "2020-08-18T23:14:45.121Z"
+  "modified": "2021-04-27T23:25:51.836Z"
 }

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-c.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-c.json
@@ -1,9 +1,9 @@
 {
   "_id": "@isaacs/testing-peer-dep-conflict-chain-c",
-  "_rev": "1-223c988c61f2532c79508eae823aa6dc",
+  "_rev": "2-0362e5a8e2f05af7b9c3944af47cf8ea",
   "name": "@isaacs/testing-peer-dep-conflict-chain-c",
   "dist-tags": {
-    "latest": "2.0.0"
+    "latest": "3.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -75,13 +75,48 @@
         "tmp": "tmp/testing-peer-dep-conflict-chain-c_2.0.0_1597792489286_0.8882582940219907"
       },
       "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-c",
+      "version": "3.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-d": "3"
+      },
+      "_id": "@isaacs/testing-peer-dep-conflict-chain-c@3.0.0",
+      "_nodeVersion": "16.0.0",
+      "_npmVersion": "7.11.1",
+      "dist": {
+        "integrity": "sha512-79gG69UhEDjuhB4PAgPCwh0iU2qrxIPOO+ZTmJuGZwI9guWkbVFHoS9aLAnXd74EaYSVs8Wp++DmMxglRa63Ag==",
+        "shasum": "bd11ba9616e09de300ae73b40bd64b2e884cd864",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-c/-/testing-peer-dep-conflict-chain-c-3.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 144,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiJ2BCRA9TVsSAnZWagAATQkP/iFdG4Bas6Ks7FfwNMHo\nbPef/1664CKdOnRHnZ6xsCslzJrwcKiLBvxehPBhemod344HGXZfkPmRb3vc\nzxjczDfFBdXwLD3bCrPf/pUQbFfePjZDwrup50S1WCajTgs7QNxwnIMGF7Su\nXiaVGHug9dzDRusnTtmLPjX+mA/PywSK0dQ9TE7ouEuhBiubFsz4U3asA0cw\nVTPLF7sgA3V7oKh+y22BLvl9v0EKR5+95dbi65gAKL2QCSpnbuWfDRLaCku/\nyjEV2OoGFHBBPm192o7VohVGEYnF2Koah4ihs2zY3uSHMxXB8FPcR5Du+P04\n/45qVUUMzNKoCCTHKIGDkg0+/CfvC7UCqK8HNlDH7Raa9L9wyX7Bg3Ys4Byr\neQULGKTAQnzALRadcM4fil8O+4UCBQDHwb+GiTmALhvPDLLF22m3veL+1+9S\nnNqh6mUeEGuk7soMPpWlriITSyl2BKEhxWPwOS4gsEQdt739oL0VizwWD5hq\nCJT8Ng32sqrabnabaN0pM0u6R2i0Z6c7zmZh4J9sLNdUOILh7rcGFJTljVSl\nfVChylkSgbiLUaKqslqm4WsK7Nb2gaM1H3oTU+iiwAS7cSGFGOqyuL9trlBD\nn8e7h2rGgaK5X5/LDIYVXng268pWeMeg/BtU0L4wFOS1aIGxk37bhSQg8FT3\n51NE\r\n=8yn0\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-conflict-chain-c_3.0.0_1619565952953_0.5270649167225998"
+      },
+      "_hasShrinkwrap": false
     }
   },
   "time": {
     "created": "2020-08-18T23:14:46.119Z",
     "1.0.0": "2020-08-18T23:14:46.225Z",
-    "modified": "2020-08-18T23:14:51.550Z",
-    "2.0.0": "2020-08-18T23:14:49.379Z"
+    "modified": "2021-04-27T23:25:55.235Z",
+    "2.0.0": "2020-08-18T23:14:49.379Z",
+    "3.0.0": "2021-04-27T23:25:53.085Z"
   },
   "maintainers": [
     {
@@ -89,7 +124,6 @@
       "email": "i@izs.me"
     }
   ],
-  "description": "A chain of peer deps.  Installing v1 of any of them requires v1 of all of them.  v2 of any requires v2 of all.  No v1 can coexist with any v2.",
-  "readme": "A chain of peer deps.  Installing v1 of any of them requires v1 of all of\nthem.  v2 of any requires v2 of all.  No v1 can coexist with any v2.\n",
-  "readmeFilename": "README.md"
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
 }

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-c.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-c.min.json
@@ -1,7 +1,7 @@
 {
   "name": "@isaacs/testing-peer-dep-conflict-chain-c",
   "dist-tags": {
-    "latest": "2.0.0"
+    "latest": "3.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -33,7 +33,22 @@
         "unpackedSize": 287,
         "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfPGDpCRA9TVsSAnZWagAApX0P/jHWjR6ZGDhGhMvoAqJw\nM4/M85GrJ1k3Q3z9VlSy3QdUvI18xpyQHfrJpm8EAtZRRI49bZuQLUzgT65/\nxdObuYPLLvjpWxKGY6JfOg8j/BdXUQ1j9SV6lDmGQ/q7xqVsR2aH1JAfXhJw\nq2cdLZxw3Sxr7flqp0OyjfNVrTFNygT0r9ijOjPbJpGvkaUi83pDKXlXupRi\nLfgVRxnrUqzL8SBM7bnIQXQYdPP070aFg1wrP7uYCPX86itDi+vz3ckoYqBo\nU69nRvrcqhEzMMiKvhmcuncegF0LhPVqozDI/pOK2lSTnuA1o3xCG9/PjfMN\npo8Ha4uSEMFHBMhgU8Dr6umjp5tA11p9Z2d5mvCMlDFa9MocSQLPZgdsH5ul\nxjGdgJubRvAmAMIRaufg7kAIFNMurIYihysG7qxhH5ZXpiuYDdUaK6dWnMlU\nhVdjac7rWNre+JHfSTlubkiQTUITUuX5HGZjvSe8NA7iRxDdIN29L/15B62Z\nb11NVowDDxUZhKc/dRBv/bDl2KyoUayQ6DzaIJOFX3LW3YxDTup89GC6i7Hn\nUJeYtx2TrdcJF44qypuESBMdOaXgiVCRmD0jqr4PFWGHilNzBp5rl2ubRdx7\n/t41n3xpstbnm8F7Gc5/XxaZ81zpxJ3S6z7mA5bpAkjOgMBmjuu19DBxUgn2\nj1Bb\r\n=UJkx\r\n-----END PGP SIGNATURE-----\r\n"
       }
+    },
+    "3.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-c",
+      "version": "3.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-d": "3"
+      },
+      "dist": {
+        "integrity": "sha512-79gG69UhEDjuhB4PAgPCwh0iU2qrxIPOO+ZTmJuGZwI9guWkbVFHoS9aLAnXd74EaYSVs8Wp++DmMxglRa63Ag==",
+        "shasum": "bd11ba9616e09de300ae73b40bd64b2e884cd864",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-c/-/testing-peer-dep-conflict-chain-c-3.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 144,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiJ2BCRA9TVsSAnZWagAATQkP/iFdG4Bas6Ks7FfwNMHo\nbPef/1664CKdOnRHnZ6xsCslzJrwcKiLBvxehPBhemod344HGXZfkPmRb3vc\nzxjczDfFBdXwLD3bCrPf/pUQbFfePjZDwrup50S1WCajTgs7QNxwnIMGF7Su\nXiaVGHug9dzDRusnTtmLPjX+mA/PywSK0dQ9TE7ouEuhBiubFsz4U3asA0cw\nVTPLF7sgA3V7oKh+y22BLvl9v0EKR5+95dbi65gAKL2QCSpnbuWfDRLaCku/\nyjEV2OoGFHBBPm192o7VohVGEYnF2Koah4ihs2zY3uSHMxXB8FPcR5Du+P04\n/45qVUUMzNKoCCTHKIGDkg0+/CfvC7UCqK8HNlDH7Raa9L9wyX7Bg3Ys4Byr\neQULGKTAQnzALRadcM4fil8O+4UCBQDHwb+GiTmALhvPDLLF22m3veL+1+9S\nnNqh6mUeEGuk7soMPpWlriITSyl2BKEhxWPwOS4gsEQdt739oL0VizwWD5hq\nCJT8Ng32sqrabnabaN0pM0u6R2i0Z6c7zmZh4J9sLNdUOILh7rcGFJTljVSl\nfVChylkSgbiLUaKqslqm4WsK7Nb2gaM1H3oTU+iiwAS7cSGFGOqyuL9trlBD\nn8e7h2rGgaK5X5/LDIYVXng268pWeMeg/BtU0L4wFOS1aIGxk37bhSQg8FT3\n51NE\r\n=8yn0\r\n-----END PGP SIGNATURE-----\r\n"
+      }
     }
   },
-  "modified": "2020-08-18T23:14:51.550Z"
+  "modified": "2021-04-27T23:25:55.235Z"
 }

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-d.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-d.json
@@ -1,9 +1,9 @@
 {
   "_id": "@isaacs/testing-peer-dep-conflict-chain-d",
-  "_rev": "1-4e9f5a5f36ee57af247791fd55914b15",
+  "_rev": "2-911d03c3d4d903f4f924465aefa24883",
   "name": "@isaacs/testing-peer-dep-conflict-chain-d",
   "dist-tags": {
-    "latest": "2.0.0"
+    "latest": "3.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -75,13 +75,48 @@
         "tmp": "tmp/testing-peer-dep-conflict-chain-d_2.0.0_1597792496005_0.3069298406697263"
       },
       "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-d",
+      "version": "3.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-a": "3"
+      },
+      "_id": "@isaacs/testing-peer-dep-conflict-chain-d@3.0.0",
+      "_nodeVersion": "16.0.0",
+      "_npmVersion": "7.11.1",
+      "dist": {
+        "integrity": "sha512-K0/J7B5vBYXLaFZOEEmfFH195R/rnMKFeIqe2cx0dXAnKkvzCeP7BkqUMvP10N68RyuE1QlPTsEg9pamX7a+ow==",
+        "shasum": "8d58ab5135fab4f57344311794d74b194b33e121",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-d/-/testing-peer-dep-conflict-chain-d-3.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 144,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiJ2ECRA9TVsSAnZWagAAsvUP/Ao33vsdQq3JqySI0tdh\n6MfJG+bYNb2WMmkUWDuoFrwx47F1Xh9zpWsQLKHXE1KXfSmaueJhnJYCavJB\nw5INOFbpplYrfR7jtfAXFMq/x/QQcZNg4tthBfaBHfi+WT3/Ic6bUB8fxm/Z\nEBS6uDjzvlPPpnUskbbzZ2Npo4Cw4sseKjZES9FcwCW8XvOxOnCukTLSDXkY\n8FQ6X7qmkfMr0eEwMN93xjP8CzHix5N1z07Up/nWiOqi5SPaCTlSVcTlZHu3\nWFKePSx6UbSRNTUaXPsjRAvx3Mf+Rr8U7T898OR6C0bVopCugCHRIDAXgDeH\nI/MGBzhomepg9dl/aBzwGvJgk5YhVb/ovSnNY7h0236TVSZUpUjXswRk/i47\nTbkMKHm4cAB6ynOOWwd9iElPadacyiEP4pC/bpgD85mKJIURc8+phuDfJLFk\nyJXqIYgYzcpBKFyBkyKQWwQ9MwWZTl7Fqgt65B2GNUyWEYzr7Pe87nBSz6vl\nLlPp7S92HQ9QcX0U09tlPYQ94GsTX/Mmjz4dYzn4v5648kO7/u8t+gIMM6gW\nCxJTK3lwkJJG6uJHlIC8bnPeEoYqYIe3T6jBMLv6GAKMh7nujfR4UnPhz0vq\nmwAlK3htxsM05AyCI+Nrf8xKqEVRIx1sGCuLLHJbBbOEXwiQ2PKWZNhZv73C\nzNHP\r\n=fZCf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-conflict-chain-d_3.0.0_1619565956272_0.05908717487867432"
+      },
+      "_hasShrinkwrap": false
     }
   },
   "time": {
     "created": "2020-08-18T23:14:52.588Z",
     "1.0.0": "2020-08-18T23:14:52.697Z",
-    "modified": "2020-08-18T23:14:58.503Z",
-    "2.0.0": "2020-08-18T23:14:56.144Z"
+    "modified": "2021-04-27T23:25:58.543Z",
+    "2.0.0": "2020-08-18T23:14:56.144Z",
+    "3.0.0": "2021-04-27T23:25:56.432Z"
   },
   "maintainers": [
     {
@@ -89,7 +124,6 @@
       "email": "i@izs.me"
     }
   ],
-  "description": "A chain of peer deps.  Installing v1 of any of them requires v1 of all of them.  v2 of any requires v2 of all.  No v1 can coexist with any v2.",
-  "readme": "A chain of peer deps.  Installing v1 of any of them requires v1 of all of\nthem.  v2 of any requires v2 of all.  No v1 can coexist with any v2.\n",
-  "readmeFilename": "README.md"
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
 }

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-d.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-d.min.json
@@ -1,7 +1,7 @@
 {
   "name": "@isaacs/testing-peer-dep-conflict-chain-d",
   "dist-tags": {
-    "latest": "2.0.0"
+    "latest": "3.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -33,7 +33,22 @@
         "unpackedSize": 287,
         "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfPGDwCRA9TVsSAnZWagAAKrQP/1U1AN9Z/werAd2FCwQ4\n32rziH7CWkRtT1umJzL4C+s2vtzO458mzS/3zozKH1j2vEC5Beg80URtouFn\nYE3doN34/XJevFDMs0hXijIxxsie+TRjnOCBRoFuh7UkfgmXuniHes4HlnPM\nH0HwcHUrifkUDPWBY7Bg8nY/yCVE00kZHg6c1pTVeuULGqeCH8+fB0SCO70q\no6mJyonKjw8wlcwpKXuFcEB0CtqQM9lrRC/eyE9OldhBGBq2eAV29AGyCyfK\nhOiH+XpmjBCG4CYNdUPLN9CCFA8Oz38qIFyI10qXUXjO7L/BZyz4/6de5yWt\n4GsRGZfZpmCTptfM8h1rGTzgDuIzyO7l0rOTZFsl8FeAt1OHZ1bcVSgJH4UC\n3YvSrHIQWG8XUjM57JzHHhQW+1UDsK+6j2bjlTYffoM1qD9m9TXozTSo21M1\npL+Zy1bY+GaaD10CPhDvnCA9ulyf4ejgVfvCmtw1KaC8JbhwW8k5kiv1187b\n9Yzj+2oVqUPEtd9o6FeOoek5/2cmDbpcHVGBULBWZgku/uX4KATJd5iNHn9w\nk8w1FaQjKmc79raJiy2nGY1BJm6SxA7j6wqwJazHz6wFTWhFAM5iML219xKn\nu7V/vj+2FpAo4AuJs1uab3ushEq95Sjt6wpoR3cyd9ELAo1WOHthuNysaJHf\nhGSK\r\n=T6yc\r\n-----END PGP SIGNATURE-----\r\n"
       }
+    },
+    "3.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-d",
+      "version": "3.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-a": "3"
+      },
+      "dist": {
+        "integrity": "sha512-K0/J7B5vBYXLaFZOEEmfFH195R/rnMKFeIqe2cx0dXAnKkvzCeP7BkqUMvP10N68RyuE1QlPTsEg9pamX7a+ow==",
+        "shasum": "8d58ab5135fab4f57344311794d74b194b33e121",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-d/-/testing-peer-dep-conflict-chain-d-3.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 144,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiJ2ECRA9TVsSAnZWagAAsvUP/Ao33vsdQq3JqySI0tdh\n6MfJG+bYNb2WMmkUWDuoFrwx47F1Xh9zpWsQLKHXE1KXfSmaueJhnJYCavJB\nw5INOFbpplYrfR7jtfAXFMq/x/QQcZNg4tthBfaBHfi+WT3/Ic6bUB8fxm/Z\nEBS6uDjzvlPPpnUskbbzZ2Npo4Cw4sseKjZES9FcwCW8XvOxOnCukTLSDXkY\n8FQ6X7qmkfMr0eEwMN93xjP8CzHix5N1z07Up/nWiOqi5SPaCTlSVcTlZHu3\nWFKePSx6UbSRNTUaXPsjRAvx3Mf+Rr8U7T898OR6C0bVopCugCHRIDAXgDeH\nI/MGBzhomepg9dl/aBzwGvJgk5YhVb/ovSnNY7h0236TVSZUpUjXswRk/i47\nTbkMKHm4cAB6ynOOWwd9iElPadacyiEP4pC/bpgD85mKJIURc8+phuDfJLFk\nyJXqIYgYzcpBKFyBkyKQWwQ9MwWZTl7Fqgt65B2GNUyWEYzr7Pe87nBSz6vl\nLlPp7S92HQ9QcX0U09tlPYQ94GsTX/Mmjz4dYzn4v5648kO7/u8t+gIMM6gW\nCxJTK3lwkJJG6uJHlIC8bnPeEoYqYIe3T6jBMLv6GAKMh7nujfR4UnPhz0vq\nmwAlK3htxsM05AyCI+Nrf8xKqEVRIx1sGCuLLHJbBbOEXwiQ2PKWZNhZv73C\nzNHP\r\n=fZCf\r\n-----END PGP SIGNATURE-----\r\n"
+      }
     }
   },
-  "modified": "2020-08-18T23:14:58.503Z"
+  "modified": "2021-04-27T23:25:58.543Z"
 }

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-v.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-v.json
@@ -1,9 +1,9 @@
 {
   "_id": "@isaacs/testing-peer-dep-conflict-chain-v",
-  "_rev": "2-cac710e9c64a6a6580eae96208559719",
+  "_rev": "3-e3f6c545a01262def38453429825ea93",
   "name": "@isaacs/testing-peer-dep-conflict-chain-v",
   "dist-tags": {
-    "latest": "3.0.0"
+    "latest": "4.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -108,14 +108,49 @@
         "tmp": "tmp/testing-peer-dep-conflict-chain-v_3.0.0_1602528166386_0.10159688426890146"
       },
       "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-v",
+      "version": "4.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-a": "1 || 2"
+      },
+      "_id": "@isaacs/testing-peer-dep-conflict-chain-v@4.0.0",
+      "_nodeVersion": "16.0.0",
+      "_npmVersion": "7.11.1",
+      "dist": {
+        "integrity": "sha512-qCX5A8T2k83L9AhgVUomEx+FFgNslPb+C/OiPaoopAGx0IRVsfCYKG11GUV/+shoikABq2iAckg6FHzmtKuRBQ==",
+        "shasum": "a5b2ac0919defcbe53c58a0bc45a9847af004aa9",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-v/-/testing-peer-dep-conflict-chain-v-4.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 167,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiHP7CRA9TVsSAnZWagAAqsgP/0IGjJEZY+9GGmLIWoFb\nLQoU5SZQIqBEVVBPG7/OXGVr+I9TKd28zGLnwL3cGzvhCqncHZL3OvGo6e80\nva+LDsqkgYYRgcRHB+Eg2PrW9AzSY0XKlCtjMkTtRB907k0j8qlxMSs9mM/x\nTAJdyxIJ+Z1sBbcwOL6F91mxt8t+I/vhxLxMVfSo9AadyNI98Wgk8bVplx4Q\nEjf9c9UknC11K3Upd/wN8CdRHafy3XadOjL1dPsJ6IOFD4GwPtEZoDF20E12\nR+zwx0gfvZR9vu/VNSWZPHX6AVLuwGQPCEmo12lEgbFsUDaKls57ZgPNNGkI\nZQYqWBk9ydCU0I3CpD9wXJotXbxVNhl9DGsSv2eST+Nk5oHrUsTussKhDaqh\n3I8TeGZtcu9u4eCCQJ8Vb6gA/tBRRHciGRgGv31+25qpW6kQcHXLFq325JXw\ntG8TI/1AdSEglit3o1tecd+Eplt4S2FErdJMQLPrMUOs36ezcNwlARg3GqhT\nAWa/47yx421dpmGEGl2loVptu6UeQmJfZHqBqwBAraP2VOw/qKyXGmg9A06E\nOCcxCrCzYzC1C4czO6D7COiOzGwXN1axl4XqgdM0+u3JIh+ZqJxgqenPO9ij\nEk5djkHooSovdEgjOfGFtfj2ew57i4vBtLMn6YhUOtEYB2cC8o+m+LN/sRz0\n+KAQ\r\n=x+GV\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-conflict-chain-v_4.0.0_1619555322392_0.639118234848794"
+      },
+      "_hasShrinkwrap": false
     }
   },
   "time": {
     "created": "2020-08-24T19:54:11.894Z",
     "1.0.0": "2020-08-24T19:54:12.094Z",
-    "modified": "2020-10-12T18:42:48.948Z",
+    "modified": "2021-04-27T20:28:44.942Z",
     "2.0.0": "2020-08-24T19:54:15.529Z",
-    "3.0.0": "2020-10-12T18:42:46.487Z"
+    "3.0.0": "2020-10-12T18:42:46.487Z",
+    "4.0.0": "2021-04-27T20:28:42.738Z"
   },
   "maintainers": [
     {

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-v.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-v.min.json
@@ -1,7 +1,7 @@
 {
   "name": "@isaacs/testing-peer-dep-conflict-chain-v",
   "dist-tags": {
-    "latest": "3.0.0"
+    "latest": "4.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -49,7 +49,22 @@
         "unpackedSize": 216,
         "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfhKOnCRA9TVsSAnZWagAAglkP/j94+tmxvzfcC+ca8WQj\n48CL0ySsCnqh2aEnumkI0g3GVuGV7Xu4U2LNtZ3QlN6CS8TcWLyB7xhDDPwx\n5sgsjtAtKenqyM95ky1lwsk6zClTivErfc1v1zXNayhSjryVx9OtQlegblXa\n63yUh++BOoTwbehIFrERmiaZe52lp+YiB3R9z5Xlf+oKjf98T4JFoD4g7Jmd\nxo2F74Vf9oOnNz5K969Bs2sDp57h4ZIHuDMpStMRV/0UdkHcVJ0LpAZCIoHO\nCMkENZrfON6S3HYaptkE/vxHKFVAok0caDe/Tp/drfHJIkQLGqK487Kxns2M\nc+IyQOffLieAegdRKaVRJ0cCb+In2XBPoQwHB5A+vFkG3+luROr9QE9DU/+0\nGXb7h+2UZ2shFesswRYkIqeXjtHkYP/HpWtZv1fy9qjTwLv3MRqrz1RdHqvj\nLvQfXIjswbq6iLa37y6/DSm6FQOVVWhjXs5NgpPJvuQBUsz8ZWmsWimQlkqf\naZaTrjjzFJSCkMG2ejDj1lqiA89fYXqjH7TNqzDbL8zUa837N9fujgT1l+MT\nOX1MGNtU/scbwqLL90fsZL9Dz0kkpdgs8fHUStfVtAthrU7uXx1dUVczpMXT\ngjB+6wURjh336aeH421Gg+tBMsx36k+x4WGbuKQHlc/IDgDtql3b54fwKudC\n4anD\r\n=P8Eh\r\n-----END PGP SIGNATURE-----\r\n"
       }
+    },
+    "4.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-v",
+      "version": "4.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-a": "1 || 2"
+      },
+      "dist": {
+        "integrity": "sha512-qCX5A8T2k83L9AhgVUomEx+FFgNslPb+C/OiPaoopAGx0IRVsfCYKG11GUV/+shoikABq2iAckg6FHzmtKuRBQ==",
+        "shasum": "a5b2ac0919defcbe53c58a0bc45a9847af004aa9",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-v/-/testing-peer-dep-conflict-chain-v-4.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 167,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiHP7CRA9TVsSAnZWagAAqsgP/0IGjJEZY+9GGmLIWoFb\nLQoU5SZQIqBEVVBPG7/OXGVr+I9TKd28zGLnwL3cGzvhCqncHZL3OvGo6e80\nva+LDsqkgYYRgcRHB+Eg2PrW9AzSY0XKlCtjMkTtRB907k0j8qlxMSs9mM/x\nTAJdyxIJ+Z1sBbcwOL6F91mxt8t+I/vhxLxMVfSo9AadyNI98Wgk8bVplx4Q\nEjf9c9UknC11K3Upd/wN8CdRHafy3XadOjL1dPsJ6IOFD4GwPtEZoDF20E12\nR+zwx0gfvZR9vu/VNSWZPHX6AVLuwGQPCEmo12lEgbFsUDaKls57ZgPNNGkI\nZQYqWBk9ydCU0I3CpD9wXJotXbxVNhl9DGsSv2eST+Nk5oHrUsTussKhDaqh\n3I8TeGZtcu9u4eCCQJ8Vb6gA/tBRRHciGRgGv31+25qpW6kQcHXLFq325JXw\ntG8TI/1AdSEglit3o1tecd+Eplt4S2FErdJMQLPrMUOs36ezcNwlARg3GqhT\nAWa/47yx421dpmGEGl2loVptu6UeQmJfZHqBqwBAraP2VOw/qKyXGmg9A06E\nOCcxCrCzYzC1C4czO6D7COiOzGwXN1axl4XqgdM0+u3JIh+ZqJxgqenPO9ij\nEk5djkHooSovdEgjOfGFtfj2ew57i4vBtLMn6YhUOtEYB2cC8o+m+LN/sRz0\n+KAQ\r\n=x+GV\r\n-----END PGP SIGNATURE-----\r\n"
+      }
     }
   },
-  "modified": "2020-10-12T18:42:48.948Z"
+  "modified": "2021-04-27T20:28:44.942Z"
 }

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-w.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-w.json
@@ -1,9 +1,9 @@
 {
   "_id": "@isaacs/testing-peer-dep-conflict-chain-w",
-  "_rev": "2-fc7b0e345dcf5cd4653e146efe65c4f4",
+  "_rev": "3-1e8e07c2d8622caeb0ccfa5451033598",
   "name": "@isaacs/testing-peer-dep-conflict-chain-w",
   "dist-tags": {
-    "latest": "3.0.0"
+    "latest": "4.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -108,14 +108,49 @@
         "tmp": "tmp/testing-peer-dep-conflict-chain-w_3.0.0_1602528170367_0.09052491752906056"
       },
       "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-w",
+      "version": "4.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-b": "1 || 2"
+      },
+      "_id": "@isaacs/testing-peer-dep-conflict-chain-w@4.0.0",
+      "_nodeVersion": "16.0.0",
+      "_npmVersion": "7.11.1",
+      "dist": {
+        "integrity": "sha512-yuNYgY9jixA+MoykTI9BNrknForYCW/9LxGsIm9Ms55on1vVUPPsnx13YX+ilzpOhH6cOrjXjXUn+BEqU4j5Mg==",
+        "shasum": "98e9895bae42890529b18f899c3173de328e2f93",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-w/-/testing-peer-dep-conflict-chain-w-4.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 167,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiHP+CRA9TVsSAnZWagAA5mgP/2LOeWU2Mw8m6VBawhrc\n4uaIe8z1thHVV7zG5RnfjHZT4n6Ys2gVU7QxQf1Mz/KL8Uj6b6PXRkj/BMoP\nPTNfUP+wBSYNirxP/7U1ffG1TSKcfZo3bZLi2Ru2fO1gqksVlZ6ZeXGqawaX\nvozRm1HNVxsY1lgvfX3QEbMNJWVJmY3EYzJJuI48VWsJJm1HmekznVAhcF1p\nIn7wg6Ndc0kAsIkQDqTwBZzUq29BbPrnBqb94fAYcY5aeEsqUp5CmclqYbxS\na9BvZtiNB40DFvTPkr09QqcPdgZ2RIlKjyRbF66wE/CdTBV2ImpVoUSxJIZv\nE+y/ffPx8XoDwOAyMfZWKnl1D15zAFFxtw4KIv7kN62cFjA7fywD3aqQCKnX\n/3IBL7vO5nDnsdh8+RdS/8Rm0Tl4p7HXL5Wr3/dKbv5GB5ieqdUE7iXL/XwC\nqR1Nga5MYmNzZrWB1znvJj4LdDE8e87jRwRUU903dKQd/U4MejiHb2cYChU7\nsXRsQatub/0A+9qa2D06in2RxetNDkdQ3aU5r+FH8p11fE+YgXt/r5g5yrIQ\nDPFLZMH68nWd/s/GXe0Ww7bXe3Xy7aH4ZkUtaSYh4sV4Glw4pzG1mCsHxqB0\n1qjt+D7SJV31ypPBYjrV/Jo0r8fGXUfJ0XNZveVp6dYjfvqmT+smTma1N3zW\nZBoD\r\n=xYsx\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-conflict-chain-w_4.0.0_1619555325795_0.6802227248043156"
+      },
+      "_hasShrinkwrap": false
     }
   },
   "time": {
     "created": "2020-08-24T19:54:18.749Z",
     "1.0.0": "2020-08-24T19:54:18.887Z",
-    "modified": "2020-10-12T18:42:52.680Z",
+    "modified": "2021-04-27T20:28:48.012Z",
     "2.0.0": "2020-08-24T19:54:22.148Z",
-    "3.0.0": "2020-10-12T18:42:50.460Z"
+    "3.0.0": "2020-10-12T18:42:50.460Z",
+    "4.0.0": "2021-04-27T20:28:45.912Z"
   },
   "maintainers": [
     {

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-w.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-w.min.json
@@ -1,7 +1,7 @@
 {
   "name": "@isaacs/testing-peer-dep-conflict-chain-w",
   "dist-tags": {
-    "latest": "3.0.0"
+    "latest": "4.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -49,7 +49,22 @@
         "unpackedSize": 216,
         "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfhKOqCRA9TVsSAnZWagAAiTUP/0HFpLOBI+eKBCgkIkVS\nBON6xS5tz+8Hl22BBl9/wXSXFScRwXVqJ/a0QE1cOQGQbZnnglnr6LBTbyuG\nJniz9j/04CtPFkU12+uWQdCaKcTc7eVVhRiu7p6BqzLz4oHzNKwhD8ELuCHN\niUPzLJ/L+g1PsqrWWHL2wf5YL576EmZIeMWZj5YELBjk5x8iZNmtz/Clbya9\nU957940P8B+h82NPawVK5LUbOlPaRSvsUU+/OLsLQVNjC53IdPRlmdnMTMJg\ngNDyoErQzrBzigwbOKtXqrkaI0QVCI/hBsqmd5oenkSbyJdpao8ieqhs7pOM\nTiNjX5CFIMUiDULVZDgYS43tZpXV+jJLN5vbjeonyF/IoYVcxrux9pml9EHb\nYPCbIiX0YYAGiYiou2D6h5s0UohOqMy5eN3KjUJlIudeiRZnDHFDaHZnxPh8\nkBtsnfzc9tz0/wNC/D7QyVa+InMBk0lMDvBznR+RZ5BLbZmbEDmxO+TCS7iT\nw0d2hdtWfSTNM+in9UlSPKyp+waqNd7jouznvBuyh0UzlEL6RFYPXkzCgtLk\ne0nos5b+KcrfcN3pF9U32RjM2FwLNh+dsn+8oDlYKqABwo+Xywn55ghRnFiA\nrNh903OBts5iDEKs2TRDcotyyPsf8wWFkZZtBPkn16Djjh9jd3fOGI5PqWi9\nyNuN\r\n=xWxU\r\n-----END PGP SIGNATURE-----\r\n"
       }
+    },
+    "4.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-w",
+      "version": "4.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-b": "1 || 2"
+      },
+      "dist": {
+        "integrity": "sha512-yuNYgY9jixA+MoykTI9BNrknForYCW/9LxGsIm9Ms55on1vVUPPsnx13YX+ilzpOhH6cOrjXjXUn+BEqU4j5Mg==",
+        "shasum": "98e9895bae42890529b18f899c3173de328e2f93",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-w/-/testing-peer-dep-conflict-chain-w-4.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 167,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiHP+CRA9TVsSAnZWagAA5mgP/2LOeWU2Mw8m6VBawhrc\n4uaIe8z1thHVV7zG5RnfjHZT4n6Ys2gVU7QxQf1Mz/KL8Uj6b6PXRkj/BMoP\nPTNfUP+wBSYNirxP/7U1ffG1TSKcfZo3bZLi2Ru2fO1gqksVlZ6ZeXGqawaX\nvozRm1HNVxsY1lgvfX3QEbMNJWVJmY3EYzJJuI48VWsJJm1HmekznVAhcF1p\nIn7wg6Ndc0kAsIkQDqTwBZzUq29BbPrnBqb94fAYcY5aeEsqUp5CmclqYbxS\na9BvZtiNB40DFvTPkr09QqcPdgZ2RIlKjyRbF66wE/CdTBV2ImpVoUSxJIZv\nE+y/ffPx8XoDwOAyMfZWKnl1D15zAFFxtw4KIv7kN62cFjA7fywD3aqQCKnX\n/3IBL7vO5nDnsdh8+RdS/8Rm0Tl4p7HXL5Wr3/dKbv5GB5ieqdUE7iXL/XwC\nqR1Nga5MYmNzZrWB1znvJj4LdDE8e87jRwRUU903dKQd/U4MejiHb2cYChU7\nsXRsQatub/0A+9qa2D06in2RxetNDkdQ3aU5r+FH8p11fE+YgXt/r5g5yrIQ\nDPFLZMH68nWd/s/GXe0Ww7bXe3Xy7aH4ZkUtaSYh4sV4Glw4pzG1mCsHxqB0\n1qjt+D7SJV31ypPBYjrV/Jo0r8fGXUfJ0XNZveVp6dYjfvqmT+smTma1N3zW\nZBoD\r\n=xYsx\r\n-----END PGP SIGNATURE-----\r\n"
+      }
     }
   },
-  "modified": "2020-10-12T18:42:52.680Z"
+  "modified": "2021-04-27T20:28:48.012Z"
 }

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-x.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-x.json
@@ -1,9 +1,9 @@
 {
   "_id": "@isaacs/testing-peer-dep-conflict-chain-x",
-  "_rev": "2-08606d706d871159d2cdf99ee370c77e",
+  "_rev": "3-c6728ccb4ff712aa33cf10de96c8c9c4",
   "name": "@isaacs/testing-peer-dep-conflict-chain-x",
   "dist-tags": {
-    "latest": "3.0.0"
+    "latest": "4.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -108,14 +108,49 @@
         "tmp": "tmp/testing-peer-dep-conflict-chain-x_3.0.0_1602528173569_0.9894386670066546"
       },
       "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-x",
+      "version": "4.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-c": "1 || 2"
+      },
+      "_id": "@isaacs/testing-peer-dep-conflict-chain-x@4.0.0",
+      "_nodeVersion": "16.0.0",
+      "_npmVersion": "7.11.1",
+      "dist": {
+        "integrity": "sha512-lXILPhq2fllEdnc8e1fOYwwG58V7YtNW2njB8d6rLgS+5QxHPzupmAFUsF3TkJLS9nc+7B4x6c+xay7od+IhhQ==",
+        "shasum": "6010b7135ba6649b41bac9624dcb807a76f970aa",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-x/-/testing-peer-dep-conflict-chain-x-4.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 167,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiHQBCRA9TVsSAnZWagAAnysP/AiZo/Y5G3ImuRnWqFCI\nsH2IE/ZVUi6FZvGPAsQ+5f8pdmYO+gtsQxq6nwz+dex/xojKiTyCagrxAwR8\n6pbW86rqlj8RqO+HbDK28dcT9Yr67dAe7apTtVw4sw6o0l433uqTawNqCTE9\nuyIKp2K8i65/PD5PTp7WdHLMoA+d3a5lInJl8aFMkvrxpT/7AaeLEaK8GrDE\n0QBdMAmJuh+xjQQm56tCwxAkyrsTNndQPElhe3OTIIZ/LfKxo4gCKZurawso\nfHxMeume/DigiGklG73FSn1CNadPbovvOLny1D3nrcgiMICbIUfPsmLJ33cR\ny2VfnWnY38gDldTy8ZgKs45eic+ODCTIZRmzgpScj1iuVTtKwVilTMfEx6iw\nDh6BIQaeg8mRQom+9nkqdvH0YNNiqsyPM5SjYPt/TQh7W1HsoUJTjvBa+mUu\nyh8UTkf4t0cqx9W/RDfsqn7H0SIdMb9P9CPn7MLSvK8FbrI1KCGCimNb4Caf\nkugp0s6ipQCIyZaVh7Np41KP8yuHuJxhum/2KcAJhPbcdSIGpMKQ5eVsZ2rK\nSac0o+sSmmBlL9fkhmrMXsJHf/qvYHaSrOmRpzWo9006LZ/mvj3X4D2SbhR7\nr1ZqlM6c17j2bgO5Qz9NcmBJS/GDXedt252jKHYytKaBdyhNuHJg2XmYmO2B\nizCN\r\n=1H5p\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-conflict-chain-x_4.0.0_1619555329309_0.6909439773277466"
+      },
+      "_hasShrinkwrap": false
     }
   },
   "time": {
     "created": "2020-08-24T19:54:25.222Z",
     "1.0.0": "2020-08-24T19:54:25.363Z",
-    "modified": "2020-10-12T18:42:56.804Z",
+    "modified": "2021-04-27T20:28:51.593Z",
     "2.0.0": "2020-08-24T19:54:29.684Z",
-    "3.0.0": "2020-10-12T18:42:53.684Z"
+    "3.0.0": "2020-10-12T18:42:53.684Z",
+    "4.0.0": "2021-04-27T20:28:49.464Z"
   },
   "maintainers": [
     {

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-x.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-x.min.json
@@ -1,7 +1,7 @@
 {
   "name": "@isaacs/testing-peer-dep-conflict-chain-x",
   "dist-tags": {
-    "latest": "3.0.0"
+    "latest": "4.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -49,7 +49,22 @@
         "unpackedSize": 216,
         "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfhKOuCRA9TVsSAnZWagAAX9QQAJgkKMeYJk6kk/6j9HxN\nDi41yUZOWBGeUBlYCFqesY9oBtj5jukGD1GDU66/WJ9Iqd7tzBGgBE+gdRqh\nJ2RnbDe6plj7US0IS/WKa0Ek1uxqv0hbYa0ZYhqYLZtujQXyipcFrVTHD/gt\ngGZY8ndSnlFN29sdCbonkBEa6zbPCC9GH1+l6fXs6/FytVqzDAmvlGX/ZR0q\n9oN+oHG0SBQbXMbbB1ydVP5RDcT3GPRBsfozFytq1zadqdyOTgJ2YJUB8iVm\n1BwgrjBK5hxqPKXFHs6wtavIQQeXIqzAdXL8VVweH6sKftcbcaCJzTNdtKYH\nvyzxg37YmhgIobYhzauXmS262qjKDpJeOZoXBpqRjh4RL1DiErt/kvlYsdK3\nzsLMOg4Hi7js28Xp1cLzj8FjZzJy/AZVhY7/xTS1RrRoS9G6FrlRB/CJCBk9\nVjJ6J8a6XvFUfZ5JDMfpefC9iwdr3hi2/u+n3dKV4YlnlGx8XkOcpUme8Ok/\niom+YBsH6EdgNOJGnvrw74IKv6wY8tJ9Rfkc7x40bK4RHVTrrwYFYLjiUsM0\nEIaC3vZlqTK6wBzTpl59OPl3iAUkEa5p6xnqJk0f+D4oI4nCncrdaxdT4ye4\nHcbzEkrvRNWnWEWxaYcS5RLO4IaA4ZxSMwNsMJDL/pyHCXVk8+Z/mrRH9XTr\nKd8b\r\n=3CH0\r\n-----END PGP SIGNATURE-----\r\n"
       }
+    },
+    "4.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-x",
+      "version": "4.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-c": "1 || 2"
+      },
+      "dist": {
+        "integrity": "sha512-lXILPhq2fllEdnc8e1fOYwwG58V7YtNW2njB8d6rLgS+5QxHPzupmAFUsF3TkJLS9nc+7B4x6c+xay7od+IhhQ==",
+        "shasum": "6010b7135ba6649b41bac9624dcb807a76f970aa",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-x/-/testing-peer-dep-conflict-chain-x-4.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 167,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiHQBCRA9TVsSAnZWagAAnysP/AiZo/Y5G3ImuRnWqFCI\nsH2IE/ZVUi6FZvGPAsQ+5f8pdmYO+gtsQxq6nwz+dex/xojKiTyCagrxAwR8\n6pbW86rqlj8RqO+HbDK28dcT9Yr67dAe7apTtVw4sw6o0l433uqTawNqCTE9\nuyIKp2K8i65/PD5PTp7WdHLMoA+d3a5lInJl8aFMkvrxpT/7AaeLEaK8GrDE\n0QBdMAmJuh+xjQQm56tCwxAkyrsTNndQPElhe3OTIIZ/LfKxo4gCKZurawso\nfHxMeume/DigiGklG73FSn1CNadPbovvOLny1D3nrcgiMICbIUfPsmLJ33cR\ny2VfnWnY38gDldTy8ZgKs45eic+ODCTIZRmzgpScj1iuVTtKwVilTMfEx6iw\nDh6BIQaeg8mRQom+9nkqdvH0YNNiqsyPM5SjYPt/TQh7W1HsoUJTjvBa+mUu\nyh8UTkf4t0cqx9W/RDfsqn7H0SIdMb9P9CPn7MLSvK8FbrI1KCGCimNb4Caf\nkugp0s6ipQCIyZaVh7Np41KP8yuHuJxhum/2KcAJhPbcdSIGpMKQ5eVsZ2rK\nSac0o+sSmmBlL9fkhmrMXsJHf/qvYHaSrOmRpzWo9006LZ/mvj3X4D2SbhR7\nr1ZqlM6c17j2bgO5Qz9NcmBJS/GDXedt252jKHYytKaBdyhNuHJg2XmYmO2B\nizCN\r\n=1H5p\r\n-----END PGP SIGNATURE-----\r\n"
+      }
     }
   },
-  "modified": "2020-10-12T18:42:56.804Z"
+  "modified": "2021-04-27T20:28:51.593Z"
 }

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-y.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-y.json
@@ -1,9 +1,9 @@
 {
   "_id": "@isaacs/testing-peer-dep-conflict-chain-y",
-  "_rev": "2-ca0460807e6f70aa9f837f1edbaf502a",
+  "_rev": "3-5f107ef92ce354722ce661d916f9c1eb",
   "name": "@isaacs/testing-peer-dep-conflict-chain-y",
   "dist-tags": {
-    "latest": "3.0.0"
+    "latest": "4.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -108,14 +108,49 @@
         "tmp": "tmp/testing-peer-dep-conflict-chain-y_3.0.0_1602528177644_0.18581173528368278"
       },
       "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-y",
+      "version": "4.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-d": "1 || 2"
+      },
+      "_id": "@isaacs/testing-peer-dep-conflict-chain-y@4.0.0",
+      "_nodeVersion": "16.0.0",
+      "_npmVersion": "7.11.1",
+      "dist": {
+        "integrity": "sha512-9F5ec1NiDxIRpQdx/Ftffn2H2yfwj4MAFd6FLgvhlPviyevbEOEaD9mLOGGLzLIM7mOUvv4VB3w/rxdXdXJEbA==",
+        "shasum": "1bdbfe315148c5c24bf6fc73a8edb77125b45cf6",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-y/-/testing-peer-dep-conflict-chain-y-4.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 167,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiHQECRA9TVsSAnZWagAAl2EP/1XtaP6SHiZk9RbXwamL\nZcCnKOQiEa8Q9YU5irzWF4gHwx/YMZxpIC9bxENUoFauORZW3crf/kAR1w7E\nYWiALJ46Op0/UoECdPvzlkdcZqwLTLtfAsPrgCw7M7bzeJv3TUIW79UQX9u+\nyGiBx1DuO83Rc9kR/ihvXnSD0re4iF/kyL0XPZQVdSxEXY7yqi5rwWkEw46x\nExKI8Y9cAOgbcRF//aFKtPSPNyAu5wwpC/4FxRDFTF/LG53vmolSFk2V1f6O\njXjs5bV8IDxTYS1j9ElC9Ij/b0NeiYhGXujjOr5FKewphh7lO+L+3RMZCqaU\njdw7nJAiTndTt/u//LBmvFqHXXFCqvqxqGa1nQlfZTdofpJUMp1m+hMhrdG0\nGp1BK5NyqXt3D+4v4jzYdtd6T9tChFrYlBdlB2U2ha3/Hu1Dk7cf6l2qCQQN\n0dU7ktN2abkMAypOwpYGvNosHay9aorHouEito0AYfMnR9r80A7oALAYTuvy\nHfLPfijS3tMZ/Lfl992ZG5zuwooH4Lh+xwDVts6fpQEAgCCsB71r/xfzGch8\nVOBrIffF3eHp7HHRP53xJQdv0IBNwueWaUwaEvc4wOmghIH5TwiuwSlnSYPT\nrdTtdy7NraAGKGiG30rzBPCdDbCXc5U9c7R+Z7cIfrlDlh65S10m8tcH1Glu\n8BMN\r\n=ZWPt\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/testing-peer-dep-conflict-chain-y_4.0.0_1619555332594_0.3208166906545853"
+      },
+      "_hasShrinkwrap": false
     }
   },
   "time": {
     "created": "2020-08-24T19:54:32.850Z",
     "1.0.0": "2020-08-24T19:54:33.045Z",
-    "modified": "2020-10-12T18:42:59.962Z",
+    "modified": "2021-04-27T20:28:54.811Z",
     "2.0.0": "2020-08-24T19:54:36.263Z",
-    "3.0.0": "2020-10-12T18:42:57.748Z"
+    "3.0.0": "2020-10-12T18:42:57.748Z",
+    "4.0.0": "2021-04-27T20:28:52.739Z"
   },
   "maintainers": [
     {

--- a/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-y.min.json
+++ b/test/fixtures/registry-mocks/content/isaacs/testing-peer-dep-conflict-chain-y.min.json
@@ -1,7 +1,7 @@
 {
   "name": "@isaacs/testing-peer-dep-conflict-chain-y",
   "dist-tags": {
-    "latest": "3.0.0"
+    "latest": "4.0.0"
   },
   "versions": {
     "1.0.0": {
@@ -49,7 +49,22 @@
         "unpackedSize": 216,
         "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfhKOyCRA9TVsSAnZWagAArREP/3cuVxs9xAO35KxxbUb1\nang8pBfvf2TNsMX3wm2I2L+/Tp4x+XWdml9rMbXqKwgH++2LkatW5j4FCEE6\nAtmIx7MmfkXvhFjkYWKQSz2hhITjomUIDWiVX9iDu/alwRb+/z1Uw8FK6aqO\ndDnIN0WAjkwawAR8SlQkYxfeq5wBSVIr40BiNMcYmqkles1Mm/cQ1US56Ghm\nXa70D2XNfjHmjnxSAL6HLfYc0ykm8sdUjT+NDtYovn/ryaQeA8AM6po6QXNL\neTB85c/wnWibreNtQ8qzwJxN5JPJZPPCKS2Ce5QVPzRn6DEtpTwNvT/IjNjn\nR41c5e54I/p8tRKuXjzxsY5m/0TGUXmufdeZ68evlVGP7GSXip5r+lCLk2K5\n4Xx/HFExezjDe71l5F7R0/k+zQW7kNJIKhKCIE0ioKHX6ulOazT7WvXwcOO/\npbS2/7v8ZOURQ8xQr8jbzUj7mQxTXLw5idUG7R/p/MKsrWwcDTCovcT9ygYl\n5mZRxXIj59dCzsiszJ/0WK9MQfNjGse0MZpUNOplhdpla5pwZ/Eca8H3lzFB\n0Tvi/uwgtYAp8KlskZY3x5bSqT0xFz/18PA/u5h8IxGgKiIjv98ARoVUouvo\nqE/tC3fOw+a2wPgqLMdqs92KrWM4xrBKJ+TEkDBSWQF1Q3gFesxje/vta223\nEIei\r\n=F9ct\r\n-----END PGP SIGNATURE-----\r\n"
       }
+    },
+    "4.0.0": {
+      "name": "@isaacs/testing-peer-dep-conflict-chain-y",
+      "version": "4.0.0",
+      "peerDependencies": {
+        "@isaacs/testing-peer-dep-conflict-chain-d": "1 || 2"
+      },
+      "dist": {
+        "integrity": "sha512-9F5ec1NiDxIRpQdx/Ftffn2H2yfwj4MAFd6FLgvhlPviyevbEOEaD9mLOGGLzLIM7mOUvv4VB3w/rxdXdXJEbA==",
+        "shasum": "1bdbfe315148c5c24bf6fc73a8edb77125b45cf6",
+        "tarball": "https://registry.npmjs.org/@isaacs/testing-peer-dep-conflict-chain-y/-/testing-peer-dep-conflict-chain-y-4.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 167,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJgiHQECRA9TVsSAnZWagAAl2EP/1XtaP6SHiZk9RbXwamL\nZcCnKOQiEa8Q9YU5irzWF4gHwx/YMZxpIC9bxENUoFauORZW3crf/kAR1w7E\nYWiALJ46Op0/UoECdPvzlkdcZqwLTLtfAsPrgCw7M7bzeJv3TUIW79UQX9u+\nyGiBx1DuO83Rc9kR/ihvXnSD0re4iF/kyL0XPZQVdSxEXY7yqi5rwWkEw46x\nExKI8Y9cAOgbcRF//aFKtPSPNyAu5wwpC/4FxRDFTF/LG53vmolSFk2V1f6O\njXjs5bV8IDxTYS1j9ElC9Ij/b0NeiYhGXujjOr5FKewphh7lO+L+3RMZCqaU\njdw7nJAiTndTt/u//LBmvFqHXXFCqvqxqGa1nQlfZTdofpJUMp1m+hMhrdG0\nGp1BK5NyqXt3D+4v4jzYdtd6T9tChFrYlBdlB2U2ha3/Hu1Dk7cf6l2qCQQN\n0dU7ktN2abkMAypOwpYGvNosHay9aorHouEito0AYfMnR9r80A7oALAYTuvy\nHfLPfijS3tMZ/Lfl992ZG5zuwooH4Lh+xwDVts6fpQEAgCCsB71r/xfzGch8\nVOBrIffF3eHp7HHRP53xJQdv0IBNwueWaUwaEvc4wOmghIH5TwiuwSlnSYPT\nrdTtdy7NraAGKGiG30rzBPCdDbCXc5U9c7R+Z7cIfrlDlh65S10m8tcH1Glu\n8BMN\r\n=ZWPt\r\n-----END PGP SIGNATURE-----\r\n"
+      }
     }
   },
-  "modified": "2020-10-12T18:42:59.962Z"
+  "modified": "2021-04-27T20:28:54.811Z"
 }

--- a/test/fixtures/testing-peer-dep-conflict-chain/README.md
+++ b/test/fixtures/testing-peer-dep-conflict-chain/README.md
@@ -2,7 +2,9 @@ A chain of peer deps.  Installing v1 of any of them requires v1 of all of
 them.  v2 of any requires v2 of all.  No v1 can coexist with any v2.
 
 `a-e`: each has a peerDep on the next one in the loop.  `a -> b`, `b -> c`,
-and so on.
+and so on.  Version 1 depends on version 1 of the next one in line.
+Version 2 depends on version 2 of the next one in line.  Version 3 depends
+on version 3, _but_ `d@3` depends on `a@3` and there is no `e@3`.
 
 `i-m`: each has a regular dep on the corresponding item in the loop.  `i ->
 a`, `j -> b`, and so on.
@@ -16,4 +18,5 @@ peerDep on v2 of the next package in the loop.  So, `p -> PEER(a@1, b@2)`
 `v-z`: each has a peerDep on the corresponding item in the loop.  `v ->
 a`, `w -> b`, and so on.  Version 3 each has a peerDep on the corresponding
 one in the `a-e` version 1 package in the loop loop _and_ the one two steps
-down the chain.  So `v@3 -> a@1,c@1`, etc.
+down the chain.  So `v@3 -> a@1,c@1`, etc.  Version 4 each has a peerDep on
+_either_ version 1 _or_ version 2 of the corresponding item in the loop.

--- a/test/fixtures/testing-peer-dep-conflict-chain/a/3/package.json
+++ b/test/fixtures/testing-peer-dep-conflict-chain/a/3/package.json
@@ -1,0 +1,1 @@
+{"name":"@isaacs/testing-peer-dep-conflict-chain-a", "version": "3.0.0", "peerDependencies":{"@isaacs/testing-peer-dep-conflict-chain-b": "3"}}

--- a/test/fixtures/testing-peer-dep-conflict-chain/b/3/package.json
+++ b/test/fixtures/testing-peer-dep-conflict-chain/b/3/package.json
@@ -1,0 +1,1 @@
+{"name":"@isaacs/testing-peer-dep-conflict-chain-b", "version": "3.0.0", "peerDependencies":{"@isaacs/testing-peer-dep-conflict-chain-c": "3"}}

--- a/test/fixtures/testing-peer-dep-conflict-chain/c/3/package.json
+++ b/test/fixtures/testing-peer-dep-conflict-chain/c/3/package.json
@@ -1,0 +1,1 @@
+{"name":"@isaacs/testing-peer-dep-conflict-chain-c", "version": "3.0.0", "peerDependencies":{"@isaacs/testing-peer-dep-conflict-chain-d": "3"}}

--- a/test/fixtures/testing-peer-dep-conflict-chain/d/3/package.json
+++ b/test/fixtures/testing-peer-dep-conflict-chain/d/3/package.json
@@ -1,0 +1,1 @@
+{"name":"@isaacs/testing-peer-dep-conflict-chain-d", "version": "3.0.0", "peerDependencies":{"@isaacs/testing-peer-dep-conflict-chain-a": "3"}}

--- a/test/fixtures/testing-peer-dep-conflict-chain/v/4/package.json
+++ b/test/fixtures/testing-peer-dep-conflict-chain/v/4/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-dep-conflict-chain-v",
+  "version": "4.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-dep-conflict-chain-a": "1 || 2"
+  }
+}

--- a/test/fixtures/testing-peer-dep-conflict-chain/w/4/package.json
+++ b/test/fixtures/testing-peer-dep-conflict-chain/w/4/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-dep-conflict-chain-w",
+  "version": "4.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-dep-conflict-chain-b": "1 || 2"
+  }
+}

--- a/test/fixtures/testing-peer-dep-conflict-chain/x/4/package.json
+++ b/test/fixtures/testing-peer-dep-conflict-chain/x/4/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-dep-conflict-chain-x",
+  "version": "4.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-dep-conflict-chain-c": "1 || 2"
+  }
+}

--- a/test/fixtures/testing-peer-dep-conflict-chain/y/4/package.json
+++ b/test/fixtures/testing-peer-dep-conflict-chain/y/4/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-dep-conflict-chain-y",
+  "version": "4.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-dep-conflict-chain-d": "1 || 2"
+  }
+}

--- a/test/fixtures/testing-peer-dep-conflict-chain/z/4/package.json
+++ b/test/fixtures/testing-peer-dep-conflict-chain/z/4/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@isaacs/testing-peer-dep-conflict-chain-z",
+  "version": "4.0.0",
+  "peerDependencies": {
+    "@isaacs/testing-peer-dep-conflict-chain-e": "1 || 2"
+  }
+}


### PR DESCRIPTION
Based on https://github.com/npm/arborist/pull/271, land that first

In cases where a peerSet _partially_ overlaps another, we were
previously treating that as a conflict, because not everything in the
peerSet was being replaced.

So for example,

```
root -> (a)
a -> PEER(w@1, x@1, y@1)
b -> PEER(x@1.0, y@1.0, z@1.0)
```

First we install, and get `w@1.1.0`, `x@1.1.0` and `z@1.1.0`.

Then, we try to install `b`, and need to install the `1.0.0` versions of
`x` and `y`.  We could replace `x` and `y`, but then `z` had no
replacement, and was treated as an ERESOLVE mistakenly.

Some work was required to make it still note when a not-replaced member
of the peer set _is_ indicative of a conflict, because it depends on a
version of a dep within the peer set that is not satisfied by the one
being replaced.
