### PR TITLE
Make dependencies' sort locale independent

### DIFF
--- a/lib/dep-spec.js
+++ b/lib/dep-spec.js
@@ -27,7 +27,7 @@ const orderDeps = (pkg) => {
   for (const type of types) {
     if (pkg && pkg[type]) {
       pkg[type] = Object.keys(pkg[type])
-        .sort((a, b) => a.localeCompare(b))
+        .sort()
         .reduce((res, key) => {
           res[key] = pkg[type][key]
           return res


### PR DESCRIPTION
this will fix npm's sorting of dependencies in `package.json` https://github.com/npm/cli/issues/2829

now dependencies in `package.json` are sorted locale dependent, which makes npm unusable on non-english systems

same problem was fixed in 2017 https://github.com/npm/npm/pull/17844/files but now sorting package.json and package-lock.json are again locale independend in npm 7

for me this is a big issue, because some of us in our company is working with english OS, some in slovak and both package.json and package-lock files are changing with every npm install

if you are on *nix system, you can test `LC_ALL=sk npm i` and `LC_ALL=en-US npm i` (as described in issue above). but on windows there is no way to change sort language.

npm 6 from 2017 fix use native `.sort()`, which use `C.UTF-8` sort, now npm 7 use localeCompare, which changed sorting even on English systems: `-` is now after `_`.
so fixing this by forcing sorting to `en-US` locale makes npm 6 and npm 7 dependencies sorted different