### PR TITLE
Arborist.workspaceNodes and .workspaceDependencySet methods

### DIFF
--- a/lib/arborist/index.js
+++ b/lib/arborist/index.js
@@ -45,6 +45,7 @@ const mixins = [
 ]
 
 const Base = mixins.reduce((a, b) => b(a), require('events'))
+const getWorkspaceNodes = require('../get-workspace-nodes.js')
 
 class Arborist extends Base {
   constructor (options = {}) {
@@ -63,6 +64,28 @@ class Arborist extends Base {
     this.cache = resolve(this.options.cache)
     this.path = resolve(this.options.path)
     process.emit('timeEnd', 'arborist:ctor')
+  }
+
+  // returns an array of the actual nodes for all the workspaces
+  workspaceNodes (tree, workspaces) {
+    return getWorkspaceNodes(tree, workspaces, this.log)
+  }
+
+  // returns a set of workspace nodes and all their deps
+  workspaceDependencySet (tree, workspaces) {
+    const wsNodes = this.workspaceNodes(tree, workspaces)
+    const set = new Set(wsNodes)
+    for (const node of set) {
+      for (const edge of node.edgesOut.values()) {
+        const dep = edge.to
+        if (dep) {
+          set.add(dep)
+          if (dep.target)
+            set.add(dep.target)
+        }
+      }
+    }
+    return set
   }
 }
 

--- a/lib/get-workspace-nodes.js
+++ b/lib/get-workspace-nodes.js
@@ -1,0 +1,33 @@
+// Get the actual nodes corresponding to a root node's child workspaces,
+// given a list of workspace names.
+const relpath = require('./relpath.js')
+const getWorkspaceNodes = (tree, workspaces, log) => {
+  const wsMap = tree.workspaces
+  if (!wsMap) {
+    log.warn('workspaces', 'filter set, but no workspaces present')
+    return []
+  }
+
+  const nodes = []
+  for (const name of workspaces) {
+    const path = wsMap.get(name)
+    if (!path) {
+      log.warn('workspaces', `${name} in filter set, but not in workspaces`)
+      continue
+    }
+
+    const loc = relpath(tree.realpath, path)
+    const node = tree.inventory.get(loc)
+
+    if (!node) {
+      log.warn('workspaces', `${name} in filter set, but no workspace folder present`)
+      continue
+    }
+
+    nodes.push(node)
+  }
+
+  return nodes
+}
+
+module.exports = getWorkspaceNodes

--- a/test/arborist/index.js
+++ b/test/arborist/index.js
@@ -1,4 +1,8 @@
 const t = require('tap')
+
+const Edge = require('../../lib/edge.js')
+const Link = require('../../lib/link.js')
+
 const Arborist = require('../../lib/arborist/index.js')
 const normalizePath = path => path.replace(/[A-Z]:/, '').replace(/\\/g, '/')
 
@@ -20,3 +24,44 @@ t.equal(c.options.packumentCache, packumentCache, 'passed in a packument cache')
 t.throws(() => {
   new Arborist({ saveType: 'something' })
 }, /saveType/, 'rejects invalid saveType')
+
+t.test('workspace nodes and deps', async t => {
+  const { resolve } = require('path')
+  const fixture = resolve(__dirname, '../fixtures/workspaces-shared-deps-virtual')
+  const arb = new Arborist({ path: fixture })
+  const tree = await arb.loadVirtual()
+  const wsNodes = arb.workspaceNodes(tree, ['b'])
+  t.equal(wsNodes.length, 1, 'got one node')
+  t.equal(wsNodes[0], tree.children.get('b').target, 'got the right node')
+
+  {
+    const wsDepSet = arb.workspaceDependencySet(tree, ['b'])
+    t.equal(wsDepSet.size, 2)
+    t.equal(wsDepSet.has(tree.children.get('b').target), true)
+    t.equal(wsDepSet.has(tree.children.get('abbrev')), true)
+  }
+
+  const wsNode = wsNodes[0]
+  new Edge({
+    from: wsNode,
+    type: 'prod',
+    name: 'xyz',
+    spec: '1.2.3',
+  })
+
+  // move abbrev under the 'a' workspace, and make a link to it
+  tree.children.get('abbrev').parent = tree.children.get('a').target
+  new Link({
+    parent: tree,
+    target: tree.children.get('a').target.children.get('abbrev'),
+  })
+
+  {
+    // verify that xyz is not in the set, but abbrev AND its link both are
+    const wsDepSet = arb.workspaceDependencySet(tree, ['b'])
+    t.equal(wsDepSet.size, 3)
+    t.equal(wsDepSet.has(tree.children.get('b').target), true)
+    t.equal(wsDepSet.has(tree.children.get('abbrev')), true)
+    t.equal(wsDepSet.has(tree.children.get('abbrev').target), true)
+  }
+})

--- a/test/get-workspace-nodes.js
+++ b/test/get-workspace-nodes.js
@@ -1,0 +1,66 @@
+const t = require('tap')
+const getWorkspaceNodes = require('../lib/get-workspace-nodes.js')
+const Arborist = require('../lib/arborist/index.js')
+const { resolve } = require('path')
+const path = resolve(__dirname, './fixtures/workspaces-shared-deps-virtual')
+
+const log = require('../lib/proc-log.js')
+
+const warningTracker = () => {
+  const list = []
+  const onlog = (...msg) => msg[0] === 'warn' && list.push(msg)
+  process.on('log', onlog)
+  return () => {
+    process.removeListener('log', onlog)
+    return list
+  }
+}
+
+let tree
+t.before(async () => {
+  tree = await new Arborist({ path }).loadVirtual()
+})
+
+t.test('basic behavior', t => {
+  const getLogs = warningTracker()
+  const wsNodes = getWorkspaceNodes(tree, ['a'], log)
+  t.equal(wsNodes.length, 1)
+  t.equal(wsNodes[0], tree.children.get('a').target)
+  t.same(getLogs(), [])
+  t.end()
+})
+
+t.test('filter set, but no workspaces present', t => {
+  const getLogs = warningTracker()
+  const wsNodes = getWorkspaceNodes(tree.children.get('b').target, ['xyz'], log)
+  t.same(wsNodes, [])
+  t.same(getLogs(), [
+    ['warn', 'workspaces', 'filter set, but no workspaces present'],
+  ])
+  t.end()
+})
+
+t.test('name in filter set, but not in workspaces', t => {
+  const getLogs = warningTracker()
+  const wsNodes = getWorkspaceNodes(tree, ['xyz'], log)
+  t.same(wsNodes, [])
+  t.same(getLogs(), [
+    ['warn', 'workspaces', 'xyz in filter set, but not in workspaces'],
+  ])
+  t.end()
+})
+
+t.test('name in filter set, but no workspace folder present', t => {
+  const getLogs = warningTracker()
+  // damage the tree somehow.  Note that the getWorkspaces() function
+  // that returns the map already *should* prevent this from happening,
+  // but if we start moving things around and make a mistake, it's
+  // possible to get there.
+  tree.children.get('c').target.root = null
+  const wsNodes = getWorkspaceNodes(tree, ['c'], log)
+  t.same(wsNodes, [])
+  t.same(getLogs(), [
+    ['warn', 'workspaces', 'c in filter set, but no workspace folder present'],
+  ])
+  t.end()
+})


### PR DESCRIPTION
This adds a simple way for an Arborist instance to turn a list of
workspace names into a list of nodes, or a set of all deps (direct and
transitive) that are relied upon by those workspace nodes.

Note that this returns the *target* of the workspace, not the link in
the root node_modules folder.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
