### PR TITLE
add extra info to node.explain

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -354,7 +354,7 @@ class Node {
     }
 
     const why = {
-      name: this.isProjectRoot ? this.packageName : this.name,
+      name: this.isProjectRoot || this.isTop ? this.packageName : this.name,
       version: this.package.version,
     }
     if (this.errors.length || !this.packageName || !this.package.version) {
@@ -380,6 +380,7 @@ class Node {
       return why
 
     why.location = this.location
+    why.isWorkspace = this.isWorkspace
 
     // make a new list each time.  we can revisit, but not loop.
     seen = seen.concat(this)
@@ -400,6 +401,10 @@ class Node {
       for (const edge of edges)
         why.dependents.push(edge.explain(seen))
     }
+
+    if (this.linksIn.size)
+      why.linksIn = [...this.linksIn].map(link => link[_explain](edge, seen))
+
     return why
   }
 

--- a/test/node.js
+++ b/test/node.js
@@ -1601,6 +1601,7 @@ t.test('explain yourself', t => {
     name: 'x',
     version: '1.2.3',
     location: 'node_modules/x',
+    isWorkspace: false,
     dependents: [{ name: 'x', type: 'prod', spec: '1', from: n.explain() }],
   })
 
@@ -1629,6 +1630,7 @@ t.test('explain yourself', t => {
     name: 'y',
     version: '2.3.4',
     location: 'node_modules/y',
+    isWorkspace: false,
     dependents: [
       {
         type: 'prod',
@@ -1643,6 +1645,7 @@ t.test('explain yourself', t => {
     name: 'z',
     version: '3.4.5',
     location: 'node_modules/y/node_modules/z',
+    isWorkspace: false,
     dependents: [
       {
         type: 'prod',
@@ -1657,6 +1660,7 @@ t.test('explain yourself', t => {
     name: 'a',
     version: '4.5.6',
     location: 'node_modules/y/node_modules/z/node_modules/a',
+    isWorkspace: false,
     dependents: [
       {
         type: 'prod',
@@ -1690,6 +1694,7 @@ t.test('explain yourself', t => {
     name: 'b',
     version: '9.9.9',
     location: 'node_modules/b',
+    isWorkspace: false,
     dependents: [],
   })
   b.package = { ...b.package }
@@ -1704,6 +1709,7 @@ t.test('explain yourself', t => {
     name: 'b',
     version: '9.9.9',
     location: 'node_modules/b',
+    isWorkspace: false,
     dependents: [{ type: 'prod', name: 'b', spec: '1.2.3', error: 'INVALID', from: n.explain() }],
   })
 
@@ -1726,6 +1732,7 @@ t.test('explain yourself', t => {
     name: 'b',
     version: '9.9.9',
     location: 'node_modules/b',
+    isWorkspace: false,
     dependents: [
       {
         type: 'prod',
@@ -1751,6 +1758,7 @@ t.test('explain yourself', t => {
     name: 'b',
     version: '1.1.1',
     location: 'node_modules/b',
+    isWorkspace: false,
     dependents: [
       {
         type: 'prod',
@@ -1760,6 +1768,7 @@ t.test('explain yourself', t => {
           name: 'a',
           version: '1.1.1',
           location: 'node_modules/a',
+          isWorkspace: false,
           dependents: [
             {
               type: 'prod',
@@ -1779,6 +1788,7 @@ t.test('explain yourself', t => {
                 name: 'c',
                 version: '1.1.1',
                 location: 'node_modules/c',
+                isWorkspace: false,
                 dependents: [
                   {
                     type: 'prod',
@@ -1827,6 +1837,7 @@ t.test('explain yourself', t => {
         path: '/project/node_modules/b',
       },
       location: 'node_modules/d',
+      isWorkspace: false,
       dependents: [
         {
           type: 'prod',
@@ -1841,6 +1852,7 @@ t.test('explain yourself', t => {
               path: '/project/node_modules/b',
             },
             location: 'node_modules/c',
+            isWorkspace: false,
             dependents: [
               {
                 type: 'prod',
@@ -1850,6 +1862,7 @@ t.test('explain yourself', t => {
                   name: 'b',
                   version: '1.2.3',
                   location: 'node_modules/b',
+                  isWorkspace: false,
                   dependents: [
                     {
                       type: 'prod',
@@ -1859,6 +1872,7 @@ t.test('explain yourself', t => {
                         name: 'a',
                         version: '1.2.3',
                         location: 'node_modules/a',
+                        isWorkspace: false,
                         dependents: [
                           {
                             type: 'prod',
@@ -1904,6 +1918,56 @@ t.test('explain yourself', t => {
     package: { noname: 'bad', noversion: 'node' },
   })
 
+  // workspaces
+  const workspacesRoot = new Node({
+    path: '/some/path',
+    pkg: {
+      name: 'project-root',
+      version: '1.0.0',
+      workspaces: ['a'],
+    },
+  })
+  const workspacesMap = new Map(
+    [['a', '/some/path/a']]
+  )
+  const ws = new Node({
+    root: workspacesRoot,
+    path: '/some/path/a',
+    pkg: { name: 'a', version: '1.0.0' },
+  })
+  new Link({
+    name: 'a',
+    parent: workspacesRoot,
+    target: ws,
+  })
+  workspacesRoot.workspaces = workspacesMap
+  t.strictSame(
+    normalizePaths(ws.explain()),
+    {
+      name: 'a',
+      version: '1.0.0',
+      location: 'a',
+      isWorkspace: true,
+      dependents: [],
+      linksIn: [
+        {
+          name: 'a',
+          version: '1.0.0',
+          location: 'node_modules/a',
+          isWorkspace: true,
+          dependents: [
+            {
+              type: 'workspace',
+              name: 'a',
+              spec: 'file:/some/path/a',
+              from: { location: '/some/path' },
+            },
+          ],
+        },
+      ],
+    },
+    'should have workspaces properly set up'
+  )
   t.end()
 })
 


### PR DESCRIPTION
Added to the result object of node.explain():
- `isWorkspace`, boolean value, true when a node is a workspace
- `linksIn`, array containing all links to a target

This is going to be useful in the **cli** in order to identify a workspace node at the end of the dependency chain.