### PR TITLE
Isaacs/metadata making reify not good

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -110,16 +110,33 @@ const getAction = ({actual, ideal}) => {
   if (ideal.isRoot && actual.isRoot)
     return null
 
+  // if the versions don't match, it's a change no matter what
+  if (ideal.version !== actual.version)
+    return 'CHANGE'
+
   const binsExist = ideal.binPaths.every((path) => existsSync(path))
 
   // top nodes, links, and git deps won't have integrity, but do have resolved
-  if (!ideal.integrity && !actual.integrity && ideal.resolved === actual.resolved && binsExist)
+  // However! if *neither* has a resolved value, then we need to refetch
+  // to figure out what it even is, so we mark as CHANGE.
+  const noIntegrity = !ideal.integrity && !actual.integrity
+  const resolvedMatch = ideal.resolved && ideal.resolved === actual.resolved
+  if (noIntegrity && resolvedMatch && binsExist)
+    return null
+
+  // If NEITHER has resolved OR integrity, but the versions match
+  // (which we know because of the check above), and we don't have
+  // to find bins, then we should just leave it as-is.
+  const noResolved = !ideal.resolved && !actual.resolved
+  if (noIntegrity && noResolved && binsExist)
     return null
 
   // otherwise, verify that it's the same bits
   // note that if ideal has integrity, and resolved doesn't, we treat
   // that as a 'change', so that it gets re-fetched and locked down.
-  if (!ideal.integrity || !actual.integrity || !ssri.parse(ideal.integrity).match(actual.integrity) || !binsExist)
+  const integrityMismatch = !ideal.integrity || !actual.integrity ||
+    !ssri.parse(ideal.integrity).match(actual.integrity)
+  if (integrityMismatch || !binsExist)
     return 'CHANGE'
 
   return null

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -714,6 +714,7 @@ class Shrinkwrap {
         resolved,
         integrity,
         hasShrinkwrap,
+        version,
       } = this.get(node.path)
 
       const pathFixed = !resolved ? null
@@ -727,8 +728,12 @@ class Shrinkwrap {
         node.resolved === pathFixed
       const integrityOk = !integrity || !node.integrity ||
         node.integrity === integrity
+      const versionOk = !version || !node.version || version === node.version
 
-      if ((resolved || integrity) && resolvedOk && integrityOk) {
+      const allOk = (resolved || integrity || version) &&
+        resolvedOk && integrityOk && versionOk
+
+      if (allOk) {
         node.resolved = node.resolved || pathFixed || null
         node.integrity = node.integrity || integrity || null
         node.hasShrinkwrap = node.hasShrinkwrap || hasShrinkwrap || false

--- a/test/arborist/reify.js
+++ b/test/arborist/reify.js
@@ -2066,3 +2066,30 @@ t.test('update a dep when the lockfile is lying about it', async t => {
   t.equal(abbrev.version, '1.1.1')
   t.equal(require(abbrev.path + '/package.json').version, '1.1.1')
 })
+
+t.test('shrinkwrap which lacks metadata updates deps', async t => {
+  const path = t.testdir({
+    'package.json': '{}',
+  })
+
+  const first = await reify(path, {
+    add: ['@isaacs/testing-shrinkwrap-abbrev@1.2.0'],
+  })
+  const firstAbbrev = first.children.get('@isaacs/testing-shrinkwrap-abbrev')
+    .children.get('abbrev')
+  t.equal(firstAbbrev.version, '1.1.0')
+
+  const abbrevPath = firstAbbrev.path
+  const abbrevpj = () =>
+    JSON.parse(fs.readFileSync(abbrevPath + '/package.json', 'utf8'))
+
+  t.equal(abbrevpj().version, firstAbbrev.version)
+
+  const second = await reify(path, {
+    add: ['@isaacs/testing-shrinkwrap-abbrev@1.2.1'],
+  })
+  const secondAbbrev = second.children.get('@isaacs/testing-shrinkwrap-abbrev')
+    .children.get('abbrev')
+  t.equal(secondAbbrev.version, '1.1.1')
+  t.equal(abbrevpj().version, secondAbbrev.version)
+})

--- a/test/diff.js
+++ b/test/diff.js
@@ -487,3 +487,49 @@ t.test('extraneous pruning in workspaces', async t => {
   const pruneWsB = Diff.calculate({actual, ideal, filterNodes: [idealB, actualB]})
   t.matchSnapshot(pruneWsB, 'prune in workspace B')
 })
+
+t.test('check versions (even if all other metadata is missing)', t => {
+  const actual = new Node({
+    path: '/some/path',
+    pkg: {
+      dependencies: {
+        foo: '',
+      },
+    },
+    children: [
+      { name: 'foo', pkg: { name: 'foo', version: '1.0.0' }},
+    ],
+  })
+
+  const ideal = new Node({
+    path: '/some/path',
+    pkg: {
+      dependencies: {
+        foo: '',
+      },
+    },
+    children: [
+      { name: 'foo', pkg: { name: 'foo', version: '1.2.3' }},
+    ],
+  })
+
+  const diff = Diff.calculate({actual, ideal})
+  t.match(diff.children, [
+    {
+      actual: actual.children.get('foo'),
+      ideal: ideal.children.get('foo'),
+      action: 'CHANGE',
+    },
+  ])
+  t.equal(diff.children.length, 1)
+
+  t.match(diff.leaves, [
+    {
+      actual: actual.children.get('foo'),
+      ideal: ideal.children.get('foo'),
+      action: 'CHANGE',
+    },
+  ])
+  t.equal(diff.leaves.length, 1)
+  t.end()
+})


### PR DESCRIPTION
Two commits to make Arborist properly handle some pretty interesting shrinkwrap/metadata handling errors.