### PR TITLE
fix extraneous deps on load-actual

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -547,6 +547,8 @@ class Node {
 
       // try to find our parent/fsParent in the new root inventory
       for (const p of walkUp(dirname(this.path))) {
+        if (p === this.path)
+          continue
         const ploc = relpath(root.realpath, p)
         const parent = root.inventory.get(ploc)
         if (parent) {
@@ -783,7 +785,13 @@ class Node {
   }
 
   get fsParent () {
-    return this[_fsParent]
+    const parent = this[_fsParent]
+    /* istanbul ignore next - should be impossible */
+    debug(() => {
+      if (parent === this)
+        throw new Error('node set to its own fsParent')
+    })
+    return parent
   }
 
   set fsParent (fsParent) {
@@ -1009,7 +1017,13 @@ class Node {
   }
 
   get parent () {
-    return this[_parent]
+    const parent = this[_parent]
+    /* istanbul ignore next - should be impossible */
+    debug(() => {
+      if (parent === this)
+        throw new Error('node set to its own parent')
+    })
+    return parent
   }
 
   // This setter keeps everything in order when we move a node from

--- a/tap-snapshots/test/calc-dep-flags.js.test.cjs
+++ b/tap-snapshots/test/calc-dep-flags.js.test.cjs
@@ -421,3 +421,213 @@ ArboristNode {
   "peer": true,
 }
 `
+
+exports[`test/calc-dep-flags.js TAP set parents to not extraneous when visiting > after 1`] = `
+ArboristNode {
+  "children": Map {
+    "asdf" => ArboristNode {
+      "children": Map {
+        "baz" => ArboristNode {
+          "location": "node_modules/asdf/node_modules/baz",
+          "name": "baz",
+          "path": "/some/path/node_modules/asdf/node_modules/baz",
+          "version": "1.2.3",
+        },
+      },
+      "location": "node_modules/asdf",
+      "name": "asdf",
+      "path": "/some/path/node_modules/asdf",
+      "version": "1.2.3",
+    },
+    "baz" => ArboristLink {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "baz",
+          "spec": "file:node_modules/asdf/node_modules/baz",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/baz",
+      "name": "baz",
+      "path": "/some/path/node_modules/baz",
+      "realpath": "/some/path/node_modules/asdf/node_modules/baz",
+      "resolved": "file:asdf/node_modules/baz",
+      "target": ArboristNode {
+        "location": "node_modules/asdf/node_modules/baz",
+      },
+      "version": "1.2.3",
+    },
+    "foo" => ArboristLink {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "foo",
+          "spec": "file:bar/foo",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/foo",
+      "name": "foo",
+      "path": "/some/path/node_modules/foo",
+      "realpath": "/some/path/bar/foo",
+      "resolved": "file:../bar/foo",
+      "target": ArboristNode {
+        "location": "bar/foo",
+      },
+      "version": "1.2.3",
+    },
+  },
+  "edgesOut": Map {
+    "baz" => EdgeOut {
+      "name": "baz",
+      "spec": "file:node_modules/asdf/node_modules/baz",
+      "to": "node_modules/baz",
+      "type": "prod",
+    },
+    "foo" => EdgeOut {
+      "name": "foo",
+      "spec": "file:bar/foo",
+      "to": "node_modules/foo",
+      "type": "prod",
+    },
+  },
+  "fsChildren": Set {
+    ArboristNode {
+      "fsChildren": Set {
+        ArboristNode {
+          "location": "bar/foo",
+          "name": "foo",
+          "path": "/some/path/bar/foo",
+          "version": "1.2.3",
+        },
+      },
+      "location": "bar",
+      "name": "bar",
+      "path": "/some/path/bar",
+    },
+  },
+  "location": "",
+  "name": "path",
+  "path": "/some/path",
+}
+`
+
+exports[`test/calc-dep-flags.js TAP set parents to not extraneous when visiting > before 1`] = `
+ArboristNode {
+  "children": Map {
+    "asdf" => ArboristNode {
+      "children": Map {
+        "baz" => ArboristNode {
+          "dev": true,
+          "extraneous": true,
+          "location": "node_modules/asdf/node_modules/baz",
+          "name": "baz",
+          "optional": true,
+          "path": "/some/path/node_modules/asdf/node_modules/baz",
+          "peer": true,
+          "version": "1.2.3",
+        },
+      },
+      "dev": true,
+      "extraneous": true,
+      "location": "node_modules/asdf",
+      "name": "asdf",
+      "optional": true,
+      "path": "/some/path/node_modules/asdf",
+      "peer": true,
+      "version": "1.2.3",
+    },
+    "baz" => ArboristLink {
+      "dev": true,
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "baz",
+          "spec": "file:node_modules/asdf/node_modules/baz",
+          "type": "prod",
+        },
+      },
+      "extraneous": true,
+      "location": "node_modules/baz",
+      "name": "baz",
+      "optional": true,
+      "path": "/some/path/node_modules/baz",
+      "peer": true,
+      "realpath": "/some/path/node_modules/asdf/node_modules/baz",
+      "resolved": "file:asdf/node_modules/baz",
+      "target": ArboristNode {
+        "location": "node_modules/asdf/node_modules/baz",
+      },
+      "version": "1.2.3",
+    },
+    "foo" => ArboristLink {
+      "dev": true,
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "foo",
+          "spec": "file:bar/foo",
+          "type": "prod",
+        },
+      },
+      "extraneous": true,
+      "location": "node_modules/foo",
+      "name": "foo",
+      "optional": true,
+      "path": "/some/path/node_modules/foo",
+      "peer": true,
+      "realpath": "/some/path/bar/foo",
+      "resolved": "file:../bar/foo",
+      "target": ArboristNode {
+        "location": "bar/foo",
+      },
+      "version": "1.2.3",
+    },
+  },
+  "dev": true,
+  "edgesOut": Map {
+    "baz" => EdgeOut {
+      "name": "baz",
+      "spec": "file:node_modules/asdf/node_modules/baz",
+      "to": "node_modules/baz",
+      "type": "prod",
+    },
+    "foo" => EdgeOut {
+      "name": "foo",
+      "spec": "file:bar/foo",
+      "to": "node_modules/foo",
+      "type": "prod",
+    },
+  },
+  "extraneous": true,
+  "fsChildren": Set {
+    ArboristNode {
+      "dev": true,
+      "extraneous": true,
+      "fsChildren": Set {
+        ArboristNode {
+          "dev": true,
+          "extraneous": true,
+          "location": "bar/foo",
+          "name": "foo",
+          "optional": true,
+          "path": "/some/path/bar/foo",
+          "peer": true,
+          "version": "1.2.3",
+        },
+      },
+      "location": "bar",
+      "name": "bar",
+      "optional": true,
+      "path": "/some/path/bar",
+      "peer": true,
+    },
+  },
+  "location": "",
+  "name": "path",
+  "optional": true,
+  "path": "/some/path",
+  "peer": true,
+}
+`

--- a/test/arborist/load-actual.js
+++ b/test/arborist/load-actual.js
@@ -358,3 +358,35 @@ t.test('load workspaces when loading from hidding lockfile', async t => {
   t.equal(aTarget.version, '1.2.3', 'updated a target version')
   t.matchSnapshot(tree, 'actual tree')
 })
+
+t.test('recalc dep flags for virtual load actual', async t => {
+  const path = t.testdir({
+    node_modules: {
+      abbrev: {
+        'package.json': JSON.stringify({
+          name: 'abbrev',
+          version: '1.1.1',
+        }),
+      },
+      '.package-lock.json': JSON.stringify({
+        lockfileVersion: 2,
+        requires: true,
+        packages: {
+          'node_modules/abbrev': {
+            version: '1.1.1',
+            resolved: 'https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz',
+            integrity: 'sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==',
+          },
+        },
+      }),
+    },
+    'package.json': JSON.stringify({}),
+  })
+
+  const hidden = resolve(path, 'node_modules/.package-lock.json')
+  const then = Date.now() + 10000
+  fs.utimesSync(hidden, new Date(then), new Date(then))
+  const tree = await loadActual(path)
+  const abbrev = tree.children.get('abbrev')
+  t.equal(abbrev.extraneous, true, 'abbrev is extraneous')
+})

--- a/test/node.js
+++ b/test/node.js
@@ -2508,3 +2508,14 @@ t.test('packageName getter', t => {
   t.equal(node.packageName, 'foo')
   t.end()
 })
+
+t.test('node at / should not have fsParent', t => {
+  const root = new Node({ path: '/some/path' })
+  const link = new Link({
+    parent: root,
+    name: 'link',
+    realpath: '/',
+  })
+  t.equal(link.target.fsParent, null)
+  t.end()
+})


### PR DESCRIPTION
When loading an actual tree sometimes extraneous deps were not being
properly marked as so, since they were not really marked as extraneous
at the moment of reify, so in order to be strictly correct we need to
recalculate deps at load-actual in order to make sure extraneous deps
are properly marked as such.

## References
Related to: https://github.com/npm/cli/issues/2554

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
