### PR TITLE
fix running unchanged links lifecycle scripts

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -1421,7 +1421,7 @@ This is a one-time fix-up, please be patient...
     // prune anything deeper in the tree that can be replaced by this
     if (this.idealTree) {
       for (const node of this.idealTree.inventory.query('name', newDep.name)) {
-        if (node.isDescendantOf(target))
+        if (!node.isTop && node.isDescendantOf(target))
           this[_pruneDedupable](node, false)
       }
     }
@@ -1819,7 +1819,7 @@ This is a one-time fix-up, please be patient...
     const current = target !== entryEdge.from && target.resolve(dep.name)
     if (current) {
       for (const edge of current.edgesIn.values()) {
-        if (edge.from.isDescendantOf(target) && edge.valid) {
+        if (!edge.from.isTop && edge.from.isDescendantOf(target) && edge.valid) {
           if (!edge.satisfiedBy(dep))
             return CONFLICT
         }
@@ -1876,7 +1876,8 @@ This is a one-time fix-up, please be patient...
       if (link.root !== this.idealTree)
         continue
 
-      const external = /^\.\.(\/|$)/.test(relpath(this.path, link.realpath))
+      const tree = this.idealTree.target || this.idealTree
+      const external = !link.target.isDescendantOf(tree)
 
       // outside the root, somebody else's problem, ignore it
       if (external && !this[_follow])

--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -914,7 +914,7 @@ This is a one-time fix-up, please be patient...
     await Promise.all(promises)
 
     for (const { to } of node.edgesOut.values()) {
-      if (to && to.isLink)
+      if (to && to.isLink && to.target)
         this[_linkNodes].add(to)
     }
 

--- a/lib/arborist/rebuild.js
+++ b/lib/arborist/rebuild.js
@@ -169,7 +169,7 @@ module.exports = cls => class Builder extends cls {
     const queue = [...set].sort(sortNodes)
 
     for (const node of queue) {
-      const { package: { bin, scripts = {} } } = node
+      const { package: { bin, scripts = {} } } = node.target || node
       const { preinstall, install, postinstall, prepare } = scripts
       const tests = { bin, preinstall, install, postinstall, prepare }
       for (const [key, has] of Object.entries(tests)) {
@@ -202,7 +202,7 @@ module.exports = cls => class Builder extends cls {
         !(meta.originalLockfileVersion >= 2)
     }
 
-    const { package: pkg, hasInstallScript } = node
+    const { package: pkg, hasInstallScript } = node.target || node
     const { gypfile, bin, scripts = {} } = pkg
 
     const { preinstall, install, postinstall, prepare } = scripts

--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -407,7 +407,7 @@ module.exports = cls => class Reifier extends cls {
     // node.parent is checked to make sure this is a node that's in the tree, and
     // not the parent-less top level nodes
     const filter = node =>
-      node.isDescendantOf(this.idealTree) &&
+      node.top.isProjectRoot &&
         (node.peer && this[_omitPeer] ||
           node.dev && this[_omitDev] ||
           node.optional && this[_omitOptional] ||

--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -404,8 +404,7 @@ module.exports = cls => class Reifier extends cls {
       return
 
     process.emit('time', 'reify:trashOmits')
-    // node.parent is checked to make sure this is a node that's in the tree, and
-    // not the parent-less top level nodes
+
     const filter = node =>
       node.top.isProjectRoot &&
         (node.peer && this[_omitPeer] ||
@@ -886,6 +885,18 @@ module.exports = cls => class Reifier extends cls {
       getChildren: diff => diff && diff.children,
       filter: diff => diff.action === 'ADD' || diff.action === 'CHANGE',
     })
+
+    // pick up link nodes from the unchanged list as we want to run their
+    // scripts in every install despite of having a diff status change
+    for (const node of this.diff.unchanged) {
+      const tree = node.root.target || node.root
+
+      // skip links that only live within node_modules as they are most
+      // likely managed by packages we installed, we only want to rebuild
+      // unchanged links we directly manage
+      if (node.isLink && node.target.fsTop === tree)
+        nodes.push(node)
+    }
 
     return this.rebuild({ nodes, handleOptionalFailure: true })
       .then(() => process.emit('timeEnd', 'reify:build'))

--- a/lib/node.js
+++ b/lib/node.js
@@ -409,7 +409,7 @@ class Node {
   }
 
   isDescendantOf (node) {
-    for (let p = this; p; p = p.parent) {
+    for (let p = this; p; p = p.resolveParent) {
       if (p === node)
         return true
     }
@@ -1195,6 +1195,14 @@ class Node {
 
   get top () {
     return this.isTop ? this : this.parent.top
+  }
+
+  get isFsTop () {
+    return !this.fsParent
+  }
+
+  get fsTop () {
+    return this.isFsTop ? this : this.fsParent.fsTop
   }
 
   get resolveParent () {

--- a/tap-snapshots/test/arborist/reify.js.test.cjs
+++ b/tap-snapshots/test/arborist/reify.js.test.cjs
@@ -31821,6 +31821,53 @@ ArboristNode {
 }
 `
 
+exports[`test/arborist/reify.js TAP running lifecycle scripts of unchanged link nodes on reify > result 1`] = `
+ArboristNode {
+  "children": Map {
+    "a" => ArboristLink {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "a",
+          "spec": "file:./a",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/a",
+      "name": "a",
+      "path": "{CWD}/test/arborist/tap-testdir-reify-running-lifecycle-scripts-of-unchanged-link-nodes-on-reify/node_modules/a",
+      "realpath": "{CWD}/test/arborist/tap-testdir-reify-running-lifecycle-scripts-of-unchanged-link-nodes-on-reify/a",
+      "resolved": "file:../a",
+      "target": ArboristNode {
+        "location": "a",
+      },
+      "version": "1.0.0",
+    },
+  },
+  "edgesOut": Map {
+    "a" => EdgeOut {
+      "name": "a",
+      "spec": "file:./a",
+      "to": "node_modules/a",
+      "type": "prod",
+    },
+  },
+  "fsChildren": Set {
+    ArboristNode {
+      "location": "a",
+      "name": "a",
+      "path": "{CWD}/test/arborist/tap-testdir-reify-running-lifecycle-scripts-of-unchanged-link-nodes-on-reify/a",
+      "version": "1.0.0",
+    },
+  },
+  "location": "",
+  "name": "tap-testdir-reify-running-lifecycle-scripts-of-unchanged-link-nodes-on-reify",
+  "packageName": "link-dep-lifecycle-scripts",
+  "path": "{CWD}/test/arborist/tap-testdir-reify-running-lifecycle-scripts-of-unchanged-link-nodes-on-reify",
+  "version": "1.0.0",
+}
+`
+
 exports[`test/arborist/reify.js TAP save complete lockfile on update-all > should have abbrev 1.0.4 1`] = `
 {
   "name": "save-package-lock-after-update-test",

--- a/test/arborist/audit.js
+++ b/test/arborist/audit.js
@@ -101,7 +101,7 @@ t.test('audit in a workspace', async t => {
   t.equal(auditReport.get('mkdirp').nodes.size, 1)
   t.strictSame(auditReport.toJSON().vulnerabilities.mkdirp.nodes, ['packages/a/node_modules/mkdirp'])
   t.equal(auditReport.get('minimist').nodes.size, 1)
-  t.strictSame(auditReport.toJSON().vulnerabilities.minimist.nodes, ['packages/a/node_modules/minimist'])
+  t.strictSame(auditReport.toJSON().vulnerabilities.minimist.nodes, ['node_modules/minimist'])
 
   const fixed = await newArb(path, { workspaces: ['b'] }).audit({ fix: true })
   t.equal(fixed.children.get('a').target.children.get('mkdirp').version, '0.5.0', 'did not fix a')

--- a/test/arborist/reify.js
+++ b/test/arborist/reify.js
@@ -1723,6 +1723,14 @@ console.log('ok 1 - this is fine')
   }), 'test result')
 })
 
+t.test('running lifecycle scripts of unchanged link nodes on reify', async t => {
+  const path = fixture(t, 'link-dep-lifecycle-scripts')
+  t.matchSnapshot(await printReified(path), 'result')
+
+  t.ok(fs.lstatSync(resolve(path, 'a/a-prepare')).isFile(),
+    'should run prepare lifecycle scripts for links directly linked to the tree')
+})
+
 t.test('save-prod, with optional', async t => {
   const path = t.testdir({
     'package.json': JSON.stringify({

--- a/test/fixtures/link-dep-lifecycle-scripts/a/package.json
+++ b/test/fixtures/link-dep-lifecycle-scripts/a/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "a",
+  "version": "1.0.0",
+  "scripts": {
+    "prepare": "node -e \"require('fs').writeFileSync(require('path').resolve('a-prepare'), '')\""
+  }
+}

--- a/test/fixtures/link-dep-lifecycle-scripts/package-lock.json
+++ b/test/fixtures/link-dep-lifecycle-scripts/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "link-dep-lifecycle-scripts",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "dependencies": {
+        "a": "file:./a"
+      }
+    },
+    "a": {
+      "version": "1.0.0"
+    },
+    "node_modules/a": {
+      "resolved": "a",
+      "link": true
+    }
+  },
+  "dependencies": {
+    "a": {
+      "version": "file:a"
+    }
+  }
+}

--- a/test/fixtures/link-dep-lifecycle-scripts/package.json
+++ b/test/fixtures/link-dep-lifecycle-scripts/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "link-dep-lifecycle-scripts",
+  "version": "1.0.0",
+  "dependencies": {
+    "a": "file:./a"
+  }
+}

--- a/test/fixtures/reify-cases/link-dep-lifecycle-scripts.js
+++ b/test/fixtures/reify-cases/link-dep-lifecycle-scripts.js
@@ -1,0 +1,71 @@
+// generated from test/fixtures/link-dep-lifecycle-scripts
+module.exports = t => {
+  const path = t.testdir({
+  "a": {
+    "package.json": JSON.stringify({
+      "name": "a",
+      "version": "1.0.0",
+      "scripts": {
+        "prepare": "node -e \"require('fs').writeFileSync(require('path').resolve('a-prepare'), '')\""
+      }
+    })
+  },
+  "node_modules": {
+    ".package-lock.json": JSON.stringify({
+      "name": "link-dep-lifecycle-scripts",
+      "version": "1.0.0",
+      "lockfileVersion": 2,
+      "requires": true,
+      "packages": {
+        "a": {
+          "version": "1.0.0"
+        },
+        "node_modules/a": {
+          "resolved": "a",
+          "link": true
+        }
+      }
+    }),
+    "a": t.fixture('symlink', "../a")
+  },
+  "package-lock.json": JSON.stringify({
+    "name": "link-dep-lifecycle-scripts",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+      "": {
+        "version": "1.0.0",
+        "dependencies": {
+          "a": "file:./a"
+        }
+      },
+      "a": {
+        "version": "1.0.0"
+      },
+      "node_modules/a": {
+        "resolved": "a",
+        "link": true
+      }
+    },
+    "dependencies": {
+      "a": {
+        "version": "file:a"
+      }
+    }
+  }),
+  "package.json": JSON.stringify({
+    "name": "link-dep-lifecycle-scripts",
+    "version": "1.0.0",
+    "dependencies": {
+      "a": "file:./a"
+    }
+  })
+})
+  const {utimesSync} = require('fs')
+  const n = Date.now() + 10000
+  const {resolve} = require('path')
+  
+  utimesSync(resolve(path, "node_modules/.package-lock.json"), new Date(n), new Date(n))
+  return path
+}

--- a/test/node.js
+++ b/test/node.js
@@ -2496,6 +2496,12 @@ t.test('canDedupe()', t => {
 
   t.equal(top.children.get('a').canDedupe(), true)
 
+  // check fsTop and isDescendantOf
+  t.equal(top.isDescendantOf(root), true)
+  t.equal(top.isFsTop, false)
+  t.equal(top.fsTop, root)
+  t.equal(top.children.get('a').isFsTop, true)
+
   t.end()
 })
 


### PR DESCRIPTION
Users expect workspaces (or regular linked deps) to run their prepare
lifecycle script on every reify, since it's often used as some form of
compilation step and should run even though that node hasn't changed.

## References
Fixes: https://github.com/npm/cli/issues/2900

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
