### PR TITLE
fix: do not try to inflate a fresh lockfile

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -349,6 +349,7 @@ class Shrinkwrap {
   reset () {
     this.tree = null
     this[_awaitingUpdate] = new Map()
+    this.originalLockfileVersion = lockfileVersion
     this.data = {
       lockfileVersion,
       requires: true,

--- a/test/arborist/reify.js
+++ b/test/arborist/reify.js
@@ -547,7 +547,6 @@ t.test('warn on reifying deprecated dependency', t => {
   })
   const check = warningTracker()
   return a.reify({ update: true }).then(() => t.match(check(), [
-    oldLockfileWarning,
     [
       'warn',
       'deprecated',


### PR DESCRIPTION
when running an updateAll, we use Shrinkwrap.reset() to empty and reset
the lockfile metadata. however, due to _inflateAncientLockfile having a
check on meta.originalLockfileVersion, we need that property to be set
on a freshly reset lock so that _inflateAncientLockfile knows it has no
work to be done.