### PR TITLE
fix: pass integrity to pacote.extract

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -788,7 +788,11 @@ This is a one-time fix-up, please be patient...
       const Arborist = this.constructor
       const opt = { ...this.options }
       await cacache.tmp.withTmp(this.cache, opt, async path => {
-        await pacote.extract(node.resolved, path, opt)
+        await pacote.extract(node.resolved, path, {
+          ...opt,
+          resolved: node.resolved,
+          integrity: node.integrity,
+        })
 
         if (hasShrinkwrap) {
           await new Arborist({ ...this.options, path })


### PR DESCRIPTION
when crackOpen becomes true we were extracting the content through
pacote without providing an integrity, because of this pacote was
creating its own internal ssri IntegrityStream that uses the default
algorithm and piping the response data through that for reasons.
when the default algorithm differs from the current one, which is
often the case with older packages that had sha1 digests, we were
throwing an EINTEGRITY error attempting to compare the old and
correct sha1 to a new and unknown sha512 (the default). by passing
the node's current integrity value we ensure that pacote compares
the sha1 to a sha1 which works as expected.

i poked around in the tests a bit but didn't really see a clear way to test this change. passing the resolved value in the options as well was to follow suit with [how reify does it](https://github.com/npm/arborist/blob/main/lib/arborist/reify.js#L562-L565)

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
