### PR TITLE
feat: make node.target return this for non-links

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -324,7 +324,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
       .then(async root => {
         if (!this[_updateAll] && !this[_global] && !root.meta.loadedFromDisk) {
           await new this.constructor(this.options).loadActual({ root })
-          const tree = root.target || root
+          const tree = root.target
           // even though we didn't load it from a package-lock.json FILE,
           // we still loaded it "from disk", meaning we have to reset
           // dep flags before assuming that any mutations were reflected.
@@ -396,7 +396,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
   // update.names request by queueing nodes dependent on those named.
   async [_applyUserRequests] (options) {
     process.emit('time', 'idealTree:userRequests')
-    const tree = this.idealTree.target || this.idealTree
+    const tree = this.idealTree.target
 
     if (!this[_workspaces].length)
       await this[_applyUserRequestsToNode](tree, options)
@@ -532,7 +532,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
     /* istanbul ignore else - should also be covered by realpath failure */
     if (filepath) {
       const { name } = spec
-      const tree = this.idealTree.target || this.idealTree
+      const tree = this.idealTree.target
       spec = npa(`file:${relpath(tree.path, filepath)}`, tree.path)
       spec.name = name
     }
@@ -730,7 +730,7 @@ This is a one-time fix-up, please be patient...
   // or extraneous.
   [_buildDeps] () {
     process.emit('time', 'idealTree:buildDeps')
-    const tree = this.idealTree.target || this.idealTree
+    const tree = this.idealTree.target
     this[_depsQueue].push(tree)
     this.log.silly('idealTree', 'buildDeps')
     this.addTracker('idealTree', tree.name, '')
@@ -1293,7 +1293,7 @@ This is a one-time fix-up, please be patient...
 
       // when installing globally, or just in global style, we never place
       // deps above the first level.
-      const tree = this.idealTree && this.idealTree.target || this.idealTree
+      const tree = this.idealTree && this.idealTree.target
       if (this[_globalStyle] && check.resolveParent === tree)
         break
     }
@@ -1362,7 +1362,7 @@ This is a one-time fix-up, please be patient...
       integrity: dep.integrity,
       legacyPeerDeps: this.legacyPeerDeps,
       error: dep.errors[0],
-      ...(dep.target ? { target: dep.target, realpath: dep.target.path } : {}),
+      ...(dep.isLink ? { target: dep.target, realpath: dep.target.path } : {}),
     })
     if (this[_loadFailures].has(dep))
       this[_loadFailures].add(newDep)

--- a/lib/arborist/index.js
+++ b/lib/arborist/index.js
@@ -81,7 +81,7 @@ class Arborist extends Base {
         const dep = edge.to
         if (dep) {
           set.add(dep)
-          if (dep.target)
+          if (dep.isLink)
             set.add(dep.target)
         }
       }

--- a/lib/arborist/load-actual.js
+++ b/lib/arborist/load-actual.js
@@ -315,7 +315,7 @@ module.exports = cls => class ActualLoader extends cls {
 
   [_loadFSTree] (node) {
     const did = this[_actualTreeLoaded]
-    node = node.target || node
+    node = node.target
 
     // if a Link target has started, but not completed, then
     // a Promise will be in the cache to indicate this.

--- a/lib/arborist/load-virtual.js
+++ b/lib/arborist/load-virtual.js
@@ -221,7 +221,7 @@ module.exports = cls => class VirtualLoader extends cls {
   [assignBundles] (nodes) {
     for (const [location, node] of nodes) {
       // Skip assignment of parentage for the root package
-      if (!location || node.target && !node.target.location)
+      if (!location || node.isLink && !node.target.location)
         continue
       const { name, parent, package: { inBundle }} = node
 

--- a/lib/arborist/rebuild.js
+++ b/lib/arborist/rebuild.js
@@ -263,7 +263,7 @@ module.exports = cls => class Builder extends cls {
         devOptional,
         package: pkg,
         location,
-      } = node.target || node
+      } = node.target
 
       // skip any that we know we'll be deleting
       if (this[_trashList].has(path))

--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -289,8 +289,8 @@ module.exports = cls => class Reifier extends cls {
 
     const filterNodes = []
     if (this[_global] && this.explicitRequests.size) {
-      const idealTree = this.idealTree.target || this.idealTree
-      const actualTree = this.actualTree.target || this.actualTree
+      const idealTree = this.idealTree.target
+      const actualTree = this.actualTree.target
       // we ONLY are allowed to make changes in the global top-level
       // children where there's an explicit request.
       for (const { name } of this.explicitRequests) {
@@ -664,7 +664,7 @@ module.exports = cls => class Reifier extends cls {
         const node = diff.ideal
         if (!node)
           return
-        if (node.isProjectRoot || (node.target && node.target.isProjectRoot))
+        if (node.isProjectRoot)
           return
 
         const { bundleDependencies } = node.package

--- a/lib/calc-dep-flags.js
+++ b/lib/calc-dep-flags.js
@@ -29,7 +29,7 @@ const calcDepFlagsStep = (node) => {
   resetParents(node, 'optional')
 
   // for links, map their hierarchy appropriately
-  if (node.target) {
+  if (node.isLink) {
     node.target.dev = node.dev
     node.target.optional = node.optional
     node.target.devOptional = node.devOptional
@@ -92,10 +92,10 @@ const unsetFlag = (node, flag) => {
       tree: node,
       visit: node => {
         node.extraneous = node[flag] = false
-        if (node.target)
+        if (node.isLink)
           node.target.extraneous = node.target[flag] = false
       },
-      getChildren: node => [...(node.target || node).edgesOut.values()]
+      getChildren: node => [...node.target.edgesOut.values()]
         .filter(edge => edge.to && edge.to[flag] &&
           (flag !== 'peer' && edge.type === 'peer' || edge.type === 'prod'))
         .map(edge => edge.to),

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -45,8 +45,7 @@ class Diff {
       const { root } = filterNode
       if (root !== ideal && root !== actual)
         throw new Error('invalid filterNode: outside idealTree/actualTree')
-      const { target } = root
-      const rootTarget = target || root
+      const rootTarget = root.target
       const edge = [...rootTarget.edgesOut.values()].filter(e => {
         return e.to && (e.to === filterNode || e.to.target === filterNode)
       })[0]
@@ -56,8 +55,7 @@ class Diff {
       filterSet.add(actual)
       if (edge && edge.to) {
         filterSet.add(edge.to)
-        if (edge.to.target)
-          filterSet.add(edge.to.target)
+        filterSet.add(edge.to.target)
       }
       filterSet.add(filterNode)
 
@@ -65,7 +63,7 @@ class Diff {
         tree: filterNode,
         visit: node => filterSet.add(node),
         getChildren: node => {
-          node = node.target || node
+          node = node.target
           const loc = node.location
           const idealNode = ideal.inventory.get(loc)
           const ideals = !idealNode ? []

--- a/lib/node.js
+++ b/lib/node.js
@@ -649,7 +649,7 @@ class Node {
         })
 
         if (this.isLink) {
-          const target = node.target || node
+          const target = node.target
           this[_target] = target
           this[_package] = target.package
           target.linksIn.add(this)
@@ -1174,7 +1174,7 @@ class Node {
   }
 
   get target () {
-    return null
+    return this
   }
 
   set target (n) {

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -802,7 +802,7 @@ class Shrinkwrap {
     if (this.tree) {
       if (this.yarnLock)
         this.yarnLock.fromTree(this.tree)
-      const root = Shrinkwrap.metaFromNode(this.tree.target || this.tree, this.path)
+      const root = Shrinkwrap.metaFromNode(this.tree.target, this.path)
       this.data.packages = {}
       if (Object.keys(root).length)
         this.data.packages[''] = root
@@ -864,7 +864,7 @@ class Shrinkwrap {
     const spec = !edge ? rSpec
       : npa.resolve(node.name, edge.spec, edge.from.realpath)
 
-    if (node.target)
+    if (node.isLink)
       lock.version = `file:${relpath(this.path, node.realpath)}`
     else if (spec && (spec.type === 'file' || spec.type === 'remote'))
       lock.version = spec.saveSpec
@@ -888,7 +888,7 @@ class Shrinkwrap {
     // when we didn't resolve to git, file, or dir, and didn't request
     // git, file, dir, or remote, then the resolved value is necessary.
     if (node.resolved &&
-        !node.target &&
+        !node.isLink &&
         rSpec.type !== 'git' &&
         rSpec.type !== 'file' &&
         rSpec.type !== 'directory' &&
@@ -917,7 +917,7 @@ class Shrinkwrap {
         lock.optional = true
     }
 
-    const depender = node.target || node
+    const depender = node.target
     if (depender.edgesOut.size > 0) {
       if (node !== this.tree) {
         lock.requires = [...depender.edgesOut.entries()].reduce((set, [k, v]) => {
@@ -942,7 +942,7 @@ class Shrinkwrap {
     }
 
     // now we walk the children, putting them in the 'dependencies' object
-    const {children} = node.target || node
+    const {children} = node.target
     if (!children.size)
       delete lock.dependencies
     else {


### PR DESCRIPTION
This gets rid of a lot of `tree = node.target || node` everywhere, by
making `node.target` return `node` when `node` is not a Link.

Caveat is that `if (node.target)` is no longer a thing we can do to test
for link-ness, but it's more clear in those cases to use `if
(node.isLink)` if we want to know if the node is a Link.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
