### PR TITLE
feat(rebuild): add lifecycle scripts dependencies

### DIFF
--- a/lib/arborist/rebuild.js
+++ b/lib/arborist/rebuild.js
@@ -249,73 +249,162 @@ module.exports = cls => class Builder extends cls {
     if (!queue.length)
       return
 
+    // helper class to manage script execution
+    class Script {
+      constructor (opts) {
+        const {
+          node,
+          timer,
+          ...runScriptOpts
+        } = opts
+        this.node = node
+        this.timer = timer
+        this.opts = runScriptOpts
+        this.pkg = opts.pkg
+        this.path = opts.path
+        this.env = opts.env
+        this.ref = this.node.target.path
+
+        if (!Script.runPromises)
+          Script.runPromises = new Map()
+      }
+
+      // when the script to be run belongs to a link node, this method
+      // retrieves a list of all other link nodes that are direct dependencies
+      // of the current node, their scripts also have to be part of the current
+      // queue, otherwise it just returns an empty list
+      // this is necessary in order to enable workspaces lifecycle scripts
+      // that depend on each other
+      linkLinkedDeps () {
+        const res = []
+
+        if (!this.node.isLink)
+          return res
+
+        for (const edge of this.node.target.edgesOut.values()) {
+          if (edge.to.isLink &&
+            queue.some(node => node.isLink && node.target.name === edge.name))
+            res.push(edge.to.target.path)
+        }
+
+        return res
+      }
+
+      // use the list of depended scripts from linkLinkedDeps()
+      // and returns a Promise that resolves once all scripts
+      // this current script depends are resolved
+      async linkLinkedDepsResolved () {
+        const resolved = (ref) => {
+          const p = Script.runPromises.get(ref)
+          // polling mechanism used in case the depended script is not
+          // yet set in Script.runPromises, this allow us to keep the
+          // alphabetical order of execution at first and the dependency
+          // mechanism for linked deps is only used when necessary
+          if (!p) {
+            return new Promise(res =>
+              setTimeout(() => res(resolved(ref)), 10))
+          }
+          return p
+        }
+
+        return await Promise.all(
+          this.linkLinkedDeps().map(ref => resolved(ref)))
+      }
+
+      async run () {
+        // in case the current script belongs to a link node that also has
+        // linked nodes dependencies (e.g: workspaces that depend on each other)
+        // then we await for that dependency script to be resolved before
+        // executing the current script
+        await this.linkLinkedDepsResolved()
+
+        // executes the current script using @npmcli/run-script
+        const p = runScript(this.opts)
+
+        // keeps a pool of executing scripts in order to track
+        // inter-dependencies between these scripts
+        Script.runPromises.set(this.ref, p)
+        return p
+      }
+    }
+
     process.emit('time', `build:run:${event}`)
     const stdio = this.options.foregroundScripts ? 'inherit' : 'pipe'
     const limit = this.options.foregroundScripts ? 1 : undefined
-    await promiseCallLimit(queue.map(node => async () => {
-      const {
-        path,
-        integrity,
-        resolved,
-        optional,
-        peer,
-        dev,
-        devOptional,
-        package: pkg,
-        location,
-      } = node.target
-
-      // skip any that we know we'll be deleting
-      if (this[_trashList].has(path))
-        return
-
-      const timer = `build:run:${event}:${location}`
-      process.emit('time', timer)
-      this.log.info('run', pkg._id, event, location, pkg.scripts[event])
-      const env = {
-        npm_package_resolved: resolved,
-        npm_package_integrity: integrity,
-        npm_package_json: resolve(path, 'package.json'),
-        npm_package_optional: boolEnv(optional),
-        npm_package_dev: boolEnv(dev),
-        npm_package_peer: boolEnv(peer),
-        npm_package_dev_optional:
-          boolEnv(devOptional && !dev && !optional),
-      }
-      const runOpts = {
-        event,
-        path,
-        pkg,
-        stdioString: true,
-        stdio,
-        env,
-        scriptShell: this[_scriptShell],
-      }
-      const p = runScript(runOpts).catch(er => {
-        const { code, signal } = er
-        this.log.info('run', pkg._id, event, {code, signal})
-        throw er
-      }).then(({args, code, signal, stdout, stderr}) => {
-        this.scriptsRun.add({
-          pkg,
+    await promiseCallLimit(queue
+      .map(node => {
+        const {
           path,
+          integrity,
+          resolved,
+          optional,
+          peer,
+          dev,
+          devOptional,
+          package: pkg,
+          location,
+        } = node.target
+
+        // skip any that we know we'll be deleting
+        if (this[_trashList].has(path))
+          return
+
+        const timer = `build:run:${event}:${location}`
+        process.emit('time', timer)
+        this.log.info('run', pkg._id, event, location, pkg.scripts[event])
+        const env = {
+          npm_package_resolved: resolved,
+          npm_package_integrity: integrity,
+          npm_package_json: resolve(path, 'package.json'),
+          npm_package_optional: boolEnv(optional),
+          npm_package_dev: boolEnv(dev),
+          npm_package_peer: boolEnv(peer),
+          npm_package_dev_optional:
+            boolEnv(devOptional && !dev && !optional),
+        }
+        return new Script({
+          node,
+          timer,
           event,
-          cmd: args && args[args.length - 1],
+          path,
+          pkg,
+          stdioString: true,
+          stdio,
           env,
-          code,
-          signal,
-          stdout,
-          stderr,
+          scriptShell: this[_scriptShell],
         })
-        this.log.info('run', pkg._id, event, {code, signal})
       })
+      .filter(Boolean)
+      .map(script => async () => {
+        const p = script.run().catch(er => {
+          const { code, signal } = er
+          this.log.info('run', script.pkg._id, event, {code, signal})
+          throw er
+        }).then(({args, code, signal, stdout, stderr}) => {
+          this.scriptsRun.add({
+            pkg: script.pkg,
+            path: script.path,
+            event,
+            cmd: args && args[args.length - 1],
+            env: script.env,
+            code,
+            signal,
+            stdout,
+            stderr,
+          })
+          this.log.info('run', script.pkg._id, event, {code, signal})
+        })
 
-      await (this[_doHandleOptionalFailure]
-        ? this[_handleOptionalFailure](node, p)
-        : p)
+        await (this[_doHandleOptionalFailure]
+          ? this[_handleOptionalFailure](script.node, p)
+          : p)
 
-      process.emit('timeEnd', timer)
-    }), limit)
+        process.emit('timeEnd', script.timer)
+      }), limit)
+
+    // release pool refs to scripts promises
+    delete Script.runPromises
+
     process.emit('timeEnd', `build:run:${event}`)
   }
 

--- a/lib/arborist/rebuild.js
+++ b/lib/arborist/rebuild.js
@@ -269,6 +269,56 @@ module.exports = cls => class Builder extends cls {
           Script.runPromises = new Map()
       }
 
+      // releases any refs used in the pool and polling systems
+      static end () {
+        if (Script.runPromises)
+          Script.runPromises.clear()
+
+        if (Script.pollRefs)
+          Script.pollRefs.clear()
+      }
+
+      // make sure there's always just a single, polling system running
+      // at a given time, this method will return a promise that resolves
+      // once the original promise tracked in Script.runPromises is available
+      static waitRunPromise (ref) {
+        if (!Script.pollRefs)
+          Script.pollRefs = new Map()
+
+        const pollAgain = () => setTimeout(poll, 10)
+        const poll = () => {
+          // check if the run-script promise is available for each entry
+          // in the polling queue, if so take it out of the queue
+          // and resolve its pending promise
+          for (const [pollRef, resolve] of Script.pollRefs.entries()) {
+            const p = Script.runPromises.get(pollRef)
+            if (p) {
+              Script.pollRefs.delete(pollRef)
+              resolve(p)
+            }
+          }
+
+          // only poll again if there are still refs left in the queue
+          if (Script.pollRefs.size)
+            pollAgain()
+        }
+
+        // starts the polling system for the first time, given that this
+        // part of the code is still synchronous, it's going to only start
+        // it once the poll refs are empty
+        if (!Script.pollRefs.size)
+          pollAgain()
+
+        // creates a new promise that is going to be returned by this fuction
+        // and also be tracked in the polling system along with its queue ref
+        let resolve
+        const p = new Promise((res) => {
+          resolve = res
+        })
+        Script.pollRefs.set(ref, resolve)
+        return p
+      }
+
       // when the script to be run belongs to a link node, this method
       // retrieves a list of all other link nodes that are direct dependencies
       // of the current node, their scripts also have to be part of the current
@@ -294,21 +344,8 @@ module.exports = cls => class Builder extends cls {
       // and returns a Promise that resolves once all scripts
       // this current script depends are resolved
       async linkLinkedDepsResolved () {
-        const resolved = (ref) => {
-          const p = Script.runPromises.get(ref)
-          // polling mechanism used in case the depended script is not
-          // yet set in Script.runPromises, this allow us to keep the
-          // alphabetical order of execution at first and the dependency
-          // mechanism for linked deps is only used when necessary
-          if (!p) {
-            return new Promise(res =>
-              setTimeout(() => res(resolved(ref)), 10))
-          }
-          return p
-        }
-
         return await Promise.all(
-          this.linkLinkedDeps().map(ref => resolved(ref)))
+          this.linkLinkedDeps().map(ref => Script.waitRunPromise(ref)))
       }
 
       async run () {
@@ -402,8 +439,8 @@ module.exports = cls => class Builder extends cls {
         process.emit('timeEnd', script.timer)
       }), limit)
 
-    // release pool refs to scripts promises
-    delete Script.runPromises
+    // releases pool refs
+    Script.end()
 
     process.emit('timeEnd', `build:run:${event}`)
   }

--- a/lib/arborist/rebuild.js
+++ b/lib/arborist/rebuild.js
@@ -267,6 +267,9 @@ module.exports = cls => class Builder extends cls {
 
         if (!Script.runPromises)
           Script.runPromises = new Map()
+
+        if (!Script.pollRefs)
+          Script.pollRefs = new Map()
       }
 
       // releases any refs used in the pool and polling systems
@@ -276,15 +279,15 @@ module.exports = cls => class Builder extends cls {
 
         if (Script.pollRefs)
           Script.pollRefs.clear()
+
+        delete Script.runPromises
+        delete Script.pollRefs
       }
 
       // make sure there's always just a single, polling system running
       // at a given time, this method will return a promise that resolves
       // once the original promise tracked in Script.runPromises is available
       static waitRunPromise (ref) {
-        if (!Script.pollRefs)
-          Script.pollRefs = new Map()
-
         const pollAgain = () => setTimeout(poll, 10)
         const poll = () => {
           // check if the run-script promise is available for each entry
@@ -343,9 +346,10 @@ module.exports = cls => class Builder extends cls {
       // use the list of depended scripts from linkLinkedDeps()
       // and returns a Promise that resolves once all scripts
       // this current script depends are resolved
-      async linkLinkedDepsResolved () {
-        return await Promise.all(
-          this.linkLinkedDeps().map(ref => Script.waitRunPromise(ref)))
+      linkLinkedDepsResolved () {
+        return Promise.all(
+          this.linkLinkedDeps()
+            .map(ref => Script.waitRunPromise(ref)))
       }
 
       async run () {
@@ -362,6 +366,16 @@ module.exports = cls => class Builder extends cls {
         // inter-dependencies between these scripts
         Script.runPromises.set(this.ref, p)
         return p
+      }
+
+      end () {
+        delete this.node
+        delete this.timer
+        delete this.opts
+        delete this.pkg
+        delete this.path
+        delete this.env
+        delete this.ref
       }
     }
 
@@ -436,6 +450,7 @@ module.exports = cls => class Builder extends cls {
           ? this[_handleOptionalFailure](script.node, p)
           : p)
 
+        script.end()
         process.emit('timeEnd', script.timer)
       }), limit)
 


### PR DESCRIPTION
Adds the ability for lifecycle scripts of Link nodes to depend
on each other, such that a `prepare` script of linked module **A**
can make use of files that are a result of a `prepare` script of
a linked package **B**.

This is important in order to unlock workflows in which a workspace
needs to make use of another workspace but they all have transpilation
steps (very common in Typescript projects) so tracking the order
(and completion) in which the dependencies lifecycle scripts runs
becomes necessary.

## References
Fixes: https://github.com/npm/cli/issues/3034

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
