### PR TITLE
feat: use Intl.Collator to compare string

### DIFF
--- a/lib/place-dep.js
+++ b/lib/place-dep.js
@@ -19,6 +19,7 @@ const debug = require('./debug.js')
 const Link = require('./link.js')
 const gatherDepSet = require('./gather-dep-set.js')
 const peerEntrySets = require('./peer-entry-sets.js')
+const collator = new Intl.Collator('en');
 
 class PlaceDep {
   constructor (options) {
@@ -430,7 +431,7 @@ class PlaceDep {
       // sort these so that they're deterministically ordered
       // otherwise, resulting tree shape is dependent on the order
       // in which they happened to be resolved.
-      const nodeSort = (a, b) => a.location.localeCompare(b.location, 'en')
+      const nodeSort = (a, b) => collator.compare(a.location, b.location)
 
       const children = [...node.children.values()].sort(nodeSort)
       for (const child of children) {


### PR DESCRIPTION
Refs:
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#performance

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

`Collator#compare` is 100x faster than `String#localeCompare`. And mdn also recommond to use it.

> When comparing large numbers of strings, such as in sorting large arrays, it is better to create an Intl.Collator object and use the function provided by its compare property.

It's the benchmark code and the result.

```
String#localeCompare x 1.50 ops/sec ±2.78% (8 runs sampled)
Collator#compare x 165 ops/sec ±1.00% (83 runs sampled)
Fastest is Collator#compare
```

```js
'use strict';

const Benchmark = require('benchmark');
const cryprto = require('crypto');
const suite = new Benchmark.Suite();

const strCount = 1e5;
const strList1 = [];
const strList2 = [];
for (let i = 0; i < strCount; i++) {
  strList1.push(cryprto.randomBytes(5).toString('hex'));
  strList2.push(cryprto.randomBytes(5).toString('hex'));
}

function useStr() {
  for (let i = 0; i < strCount; i++) {
    strList1[i].localeCompare(strList2[i], 'en');
  }
}

const collator = Intl.Collator('en');
function useIntr() {
  for (let i = 0; i < strCount; i++) {
    collator.compare(strList1[i], strList2[i]);
  }
}

// add tests
suite.add('String#localeCompare', function() {
  useStr();
})
  .add('Collator#compare', function() {
    useIntr();
  })
  // add listeners
  .on('cycle', function(event) {
    console.log(String(event.target));
  })
  .on('complete', function() {
    console.log('Fastest is ' + this.filter('fastest')
      .map('name'));
  })
  // run async
  .run({ 'async': true });
```

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
