### PR TITLE
Trying to fix Bug #321

### DIFF
--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -1148,6 +1148,10 @@ module.exports = cls => class Reifier extends cls {
         }
 
         let newSpec
+        // True if the dependency is getting installed from a lcoal file path
+        // In this case it is not possible to do the normal version comparisons
+        // as the new version will be a file path
+        const isLocalDep = req.type === 'directory' || req.type === 'file'
         if (req.registry) {
           const version = child.version
           const prefixRange = version ? this[_savePrefix] + version : '*'
@@ -1179,7 +1183,7 @@ module.exports = cls => class Reifier extends cls {
           } else {
             newSpec = h.shortcut(opt)
           }
-        } else if (req.type === 'directory' || req.type === 'file') {
+        } else if (isLocalDep) {
           // save the relative path in package.json
           // Normally saveSpec is updated with the proper relative
           // path already, but it's possible to specify a full absolute
@@ -1208,11 +1212,11 @@ module.exports = cls => class Reifier extends cls {
           if (hasSubKey(pkg, 'devDependencies', name)) {
             pkg.devDependencies[name] = newSpec
             // don't update peer or optional if we don't have to
-            if (hasSubKey(pkg, 'peerDependencies', name) && !intersects(newSpec, pkg.peerDependencies[name])) {
+            if (hasSubKey(pkg, 'peerDependencies', name) && (isLocalDep || !intersects(newSpec, pkg.peerDependencies[name]))) {
               pkg.peerDependencies[name] = newSpec
             }
 
-            if (hasSubKey(pkg, 'optionalDependencies', name) && !intersects(newSpec, pkg.optionalDependencies[name])) {
+            if (hasSubKey(pkg, 'optionalDependencies', name) && (isLocalDep || !intersects(newSpec, pkg.optionalDependencies[name]))) {
               pkg.optionalDependencies[name] = newSpec
             }
           } else {


### PR DESCRIPTION
<!-- What / Why -->
Trying to fix Issue #321
To prevent the comparison of the relative file path to an actual version number I added a new variable which tracks if the current install is a local one.

If so no version comparisons are done


## References
Fixes #321
