### PR TITLE
workspaceEnabled and includeWorkspaceRoot config options to extend workspace filters

### DIFF
--- a/lib/arborist/audit.js
+++ b/lib/arborist/audit.js
@@ -5,6 +5,7 @@ const AuditReport = require('../audit-report.js')
 // shared with reify
 const _global = Symbol.for('global')
 const _workspaces = Symbol.for('workspaces')
+const _includeWorkspaceRoot = Symbol.for('includeWorkspaceRoot')
 
 module.exports = cls => class Auditor extends cls {
   async audit (options = {}) {
@@ -23,7 +24,15 @@ module.exports = cls => class Auditor extends cls {
     process.emit('time', 'audit')
     const tree = await this.loadVirtual()
     if (this[_workspaces] && this[_workspaces].length) {
-      options.filterSet = this.workspaceDependencySet(tree, this[_workspaces])
+      options.filterSet = this.workspaceDependencySet(
+        tree,
+        this[_workspaces],
+        this[_includeWorkspaceRoot]
+      )
+    }
+    if (!options.workspacesEnabled) {
+      options.filterSet =
+        this.excludeWorkspacesDependencySet(tree)
     }
     this.auditReport = await AuditReport.load(tree, options)
     const ret = options.fix ? this.reify(options) : this.auditReport

--- a/lib/arborist/rebuild.js
+++ b/lib/arborist/rebuild.js
@@ -34,6 +34,7 @@ const _addToBuildSet = Symbol('addToBuildSet')
 const _checkBins = Symbol.for('checkBins')
 const _queues = Symbol('queues')
 const _scriptShell = Symbol('scriptShell')
+const _includeWorkspaceRoot = Symbol.for('includeWorkspaceRoot')
 
 const _force = Symbol.for('force')
 
@@ -77,7 +78,11 @@ module.exports = cls => class Builder extends cls {
     if (!nodes) {
       const tree = await this.loadActual()
       if (this[_workspaces] && this[_workspaces].length) {
-        const filterSet = this.workspaceDependencySet(tree, this[_workspaces])
+        const filterSet = this.workspaceDependencySet(
+          tree,
+          this[_workspaces],
+          this[_includeWorkspaceRoot]
+        )
         nodes = tree.inventory.filter(node => filterSet.has(node))
       } else {
         nodes = tree.inventory.values()

--- a/tap-snapshots/test/arborist/load-virtual.js.test.cjs
+++ b/tap-snapshots/test/arborist/load-virtual.js.test.cjs
@@ -16714,6 +16714,29 @@ ArboristNode {
       },
       "version": "1.0.0",
     },
+    "once" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "once",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "wrappy" => EdgeOut {
+          "name": "wrappy",
+          "spec": "1",
+          "to": "node_modules/wrappy",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/once",
+      "name": "once",
+      "path": "{CWD}/test/fixtures/workspaces-shared-deps-virtual/node_modules/once",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "version": "1.4.0",
+    },
     "uuid" => ArboristNode {
       "edgesIn": Set {
         EdgeIn {
@@ -16728,6 +16751,21 @@ ArboristNode {
       "path": "{CWD}/test/fixtures/workspaces-shared-deps-virtual/node_modules/uuid",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "version": "3.3.3",
+    },
+    "wrappy" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "node_modules/once",
+          "name": "wrappy",
+          "spec": "1",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/wrappy",
+      "name": "wrappy",
+      "path": "{CWD}/test/fixtures/workspaces-shared-deps-virtual/node_modules/wrappy",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "1.0.2",
     },
   },
   "edgesOut": Map {
@@ -16748,6 +16786,12 @@ ArboristNode {
       "spec": "file:{CWD}/test/fixtures/workspaces-shared-deps-virtual/packages/c",
       "to": "node_modules/c",
       "type": "workspace",
+    },
+    "once" => EdgeOut {
+      "name": "once",
+      "spec": "*",
+      "to": "node_modules/once",
+      "type": "prod",
     },
   },
   "fsChildren": Set {

--- a/tap-snapshots/test/arborist/reify.js.test.cjs
+++ b/tap-snapshots/test/arborist/reify.js.test.cjs
@@ -4177,6 +4177,132 @@ ArboristNode {
 }
 `
 
+exports[`test/arborist/reify.js TAP includeWorkspaceRoot in addition to workspace > must match snapshot 1`] = `
+ArboristNode {
+  "children": Map {
+    "a" => ArboristLink {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "a",
+          "spec": "file:{CWD}/test/arborist/tap-testdir-reify-includeWorkspaceRoot-in-addition-to-workspace/packages/a",
+          "type": "workspace",
+        },
+      },
+      "isWorkspace": true,
+      "location": "node_modules/a",
+      "name": "a",
+      "path": "{CWD}/test/arborist/tap-testdir-reify-includeWorkspaceRoot-in-addition-to-workspace/node_modules/a",
+      "realpath": "{CWD}/test/arborist/tap-testdir-reify-includeWorkspaceRoot-in-addition-to-workspace/packages/a",
+      "resolved": "file:../packages/a",
+      "target": ArboristNode {
+        "location": "packages/a",
+      },
+      "version": "1.0.1",
+    },
+    "abbrev" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "packages/a",
+          "name": "abbrev",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/abbrev",
+      "name": "abbrev",
+      "path": "{CWD}/test/arborist/tap-testdir-reify-includeWorkspaceRoot-in-addition-to-workspace/node_modules/abbrev",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "version": "1.1.1",
+    },
+    "once" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "once",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "wrappy" => EdgeOut {
+          "name": "wrappy",
+          "spec": "1",
+          "to": "node_modules/wrappy",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/once",
+      "name": "once",
+      "path": "{CWD}/test/arborist/tap-testdir-reify-includeWorkspaceRoot-in-addition-to-workspace/node_modules/once",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "version": "1.4.0",
+    },
+    "wrappy" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "node_modules/once",
+          "name": "wrappy",
+          "spec": "1",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/wrappy",
+      "name": "wrappy",
+      "path": "{CWD}/test/arborist/tap-testdir-reify-includeWorkspaceRoot-in-addition-to-workspace/node_modules/wrappy",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "1.0.2",
+    },
+  },
+  "edgesOut": Map {
+    "a" => EdgeOut {
+      "name": "a",
+      "spec": "file:{CWD}/test/arborist/tap-testdir-reify-includeWorkspaceRoot-in-addition-to-workspace/packages/a",
+      "to": "node_modules/a",
+      "type": "workspace",
+    },
+    "b" => EdgeOut {
+      "error": "MISSING",
+      "name": "b",
+      "spec": "file:{CWD}/test/arborist/tap-testdir-reify-includeWorkspaceRoot-in-addition-to-workspace/packages/b",
+      "to": null,
+      "type": "workspace",
+    },
+    "once" => EdgeOut {
+      "name": "once",
+      "spec": "*",
+      "to": "node_modules/once",
+      "type": "prod",
+    },
+  },
+  "fsChildren": Set {
+    ArboristNode {
+      "edgesOut": Map {
+        "abbrev" => EdgeOut {
+          "name": "abbrev",
+          "spec": "*",
+          "to": "node_modules/abbrev",
+          "type": "prod",
+        },
+      },
+      "isWorkspace": true,
+      "location": "packages/a",
+      "name": "a",
+      "path": "{CWD}/test/arborist/tap-testdir-reify-includeWorkspaceRoot-in-addition-to-workspace/packages/a",
+      "version": "1.0.1",
+    },
+  },
+  "isProjectRoot": true,
+  "location": "",
+  "name": "tap-testdir-reify-includeWorkspaceRoot-in-addition-to-workspace",
+  "path": "{CWD}/test/arborist/tap-testdir-reify-includeWorkspaceRoot-in-addition-to-workspace",
+  "workspaces": Map {
+    "a" => "packages/a",
+    "b" => "packages/b",
+  },
+}
+`
+
 exports[`test/arborist/reify.js TAP just the shrinkwrap cli-750-fresh > must match snapshot 1`] = `
 {
   "name": "monorepo",

--- a/test/arborist/reify.js
+++ b/test/arborist/reify.js
@@ -2324,3 +2324,39 @@ t.test('adding an unresolvable optional dep is OK', async t => {
   t.strictSame([...tree.children.values()], [], 'nothing actually added')
   t.matchSnapshot(printTree(tree))
 })
+
+t.test('includeWorkspaceRoot in addition to workspace', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      dependencies: {
+        once: '',
+      },
+      workspaces: ['packages/*'],
+    }),
+    packages: {
+      a: {
+        'package.json': JSON.stringify({
+          name: 'a',
+          version: '1.0.1',
+          dependencies: {
+            abbrev: '',
+          },
+        }),
+      },
+      b: {
+        'package.json': JSON.stringify({
+          name: 'b',
+          version: '9.8.1',
+          dependencies: {
+            semver: '',
+          },
+        }),
+      },
+    },
+  })
+  const tree = await reify(path, { includeWorkspaceRoot: true, workspaces: ['a'] })
+  t.matchSnapshot(printTree(tree))
+  t.equal(tree.inventory.query('name', 'semver').size, 0)
+  t.equal(tree.inventory.query('name', 'abbrev').size, 1)
+  t.equal(tree.inventory.query('name', 'once').size, 1)
+})

--- a/test/fixtures/workspaces-shared-deps-virtual/package-lock.json
+++ b/test/fixtures/workspaces-shared-deps-virtual/package-lock.json
@@ -7,10 +7,11 @@
     "": {
       "name": "workspaces-shared-deps",
       "version": "1.0.0",
-      "workspaces": {
-        "packages": [
-          "packages/*"
-        ]
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "once": ""
       }
     },
     "node_modules/a": {
@@ -18,7 +19,6 @@
       "link": true
     },
     "node_modules/abbrev": {
-      "name": "abbrev",
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
@@ -31,31 +31,41 @@
       "resolved": "packages/c",
       "link": true
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/uuid": {
-      "name": "uuid",
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
     "packages/a": {
-      "name": "a",
       "version": "1.0.0",
       "dependencies": {
         "abbrev": "^1.1.1"
       }
     },
     "packages/b": {
-      "name": "b",
       "version": "1.0.0",
       "dependencies": {
         "abbrev": "^1.1.1"
       }
     },
     "packages/c": {
-      "name": "c",
       "version": "1.0.0",
       "dependencies": {
         "uuid": "=3.3.3"
@@ -64,7 +74,10 @@
   },
   "dependencies": {
     "a": {
-      "version": "file:packages/a"
+      "version": "file:packages/a",
+      "requires": {
+        "abbrev": "^1.1.1"
+      }
     },
     "abbrev": {
       "version": "1.1.1",
@@ -72,15 +85,34 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "b": {
-      "version": "file:packages/b"
+      "version": "file:packages/b",
+      "requires": {
+        "abbrev": "^1.1.1"
+      }
     },
     "c": {
-      "version": "file:packages/c"
+      "version": "file:packages/c",
+      "requires": {
+        "uuid": "=3.3.3"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
     },
     "uuid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }

--- a/test/fixtures/workspaces-shared-deps-virtual/package.json
+++ b/test/fixtures/workspaces-shared-deps-virtual/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "dependencies": {
+    "once": ""
+  }
 }


### PR DESCRIPTION
Added the ability to include workspace root or to filter out workspaces entirely `--enableWorkspaces` `--includeWorkspaceRoot` for arborist commands.

When `enableWorkspaces` is false, commands that would normally dive into workspaces do not.

When workspaces are specified, using `includeWorkspaceRoot` includes the root package in the context of those commands.
