### PR TITLE
reify and prune respects workspaceEnabled=false

### DIFF
--- a/lib/arborist/index.js
+++ b/lib/arborist/index.js
@@ -44,6 +44,7 @@ const mixins = [
   require('./reify.js'),
 ]
 
+const _workspacesEnabled = Symbol.for('workspacesEnabled')
 const Base = mixins.reduce((a, b) => b(a), require('events'))
 const getWorkspaceNodes = require('../get-workspace-nodes.js')
 
@@ -60,6 +61,9 @@ class Arborist extends Base {
       log: options.log || procLog,
       workspacesEnabled: options.workspacesEnabled !== false,
     }
+
+    this[_workspacesEnabled] = this.options.workspacesEnabled
+
     if (options.saveType && !saveTypeMap.get(options.saveType)) {
       throw new Error(`Invalid saveType ${options.saveType}`)
     }

--- a/lib/arborist/pruner.js
+++ b/lib/arborist/pruner.js
@@ -1,4 +1,6 @@
 const _idealTreePrune = Symbol.for('idealTreePrune')
+const _workspacesEnabled = Symbol.for('workspacesEnabled')
+const _addNodeToTrashList = Symbol.for('addNodeToTrashList')
 
 module.exports = cls => class Pruner extends cls {
   async prune (options = {}) {
@@ -9,6 +11,19 @@ module.exports = cls => class Pruner extends cls {
     await this.buildIdealTree(options)
 
     this[_idealTreePrune]()
+
+    if (!this[_workspacesEnabled]) {
+      const excludeNodes = this.excludeWorkspacesDependencySet(this.idealTree)
+      for (const node of this.idealTree.inventory.values()) {
+        if (
+          node.parent !== null
+          && !node.isProjectRoot
+          && !excludeNodes.has(node)
+        ) {
+          this[_addNodeToTrashList](node)
+        }
+      }
+    }
 
     return this.reify(options)
   }

--- a/lib/arborist/rebuild.js
+++ b/lib/arborist/rebuild.js
@@ -35,6 +35,7 @@ const _checkBins = Symbol.for('checkBins')
 const _queues = Symbol('queues')
 const _scriptShell = Symbol('scriptShell')
 const _includeWorkspaceRoot = Symbol.for('includeWorkspaceRoot')
+const _workspacesEnabled = Symbol.for('workspacesEnabled')
 
 const _force = Symbol.for('force')
 
@@ -77,8 +78,14 @@ module.exports = cls => class Builder extends cls {
     // the actual tree on disk.
     if (!nodes) {
       const tree = await this.loadActual()
-      if (this[_workspaces] && this[_workspaces].length) {
-        const filterSet = this.workspaceDependencySet(
+      let filterSet
+      if (!this[_workspacesEnabled]) {
+        filterSet = this.excludeWorkspacesDependencySet(tree)
+        nodes = tree.inventory.filter(node =>
+          filterSet.has(node) || node.isProjectRoot
+        )
+      } else if (this[_workspaces] && this[_workspaces].length) {
+        filterSet = this.workspaceDependencySet(
           tree,
           this[_workspaces],
           this[_includeWorkspaceRoot]

--- a/tap-snapshots/test/arborist/pruner.js.test.cjs
+++ b/tap-snapshots/test/arborist/pruner.js.test.cjs
@@ -138,3 +138,132 @@ ArboristNode {
   "version": "1.0.0",
 }
 `
+
+exports[`test/arborist/pruner.js TAP prune workspaces > must match snapshot 1`] = `
+ArboristNode {
+  "children": Map {
+    "a" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "error": "INVALID",
+          "from": "",
+          "name": "a",
+          "spec": "file:{CWD}/test/arborist/tap-testdir-pruner-prune-workspaces/packages/a",
+          "type": "workspace",
+        },
+      },
+      "edgesOut": Map {
+        "once" => EdgeOut {
+          "name": "once",
+          "spec": "*",
+          "to": "node_modules/once",
+          "type": "prod",
+        },
+      },
+      "isWorkspace": true,
+      "location": "node_modules/a",
+      "name": "a",
+      "path": "{CWD}/test/arborist/tap-testdir-pruner-prune-workspaces/node_modules/a",
+      "version": "1.2.3",
+    },
+    "b" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "error": "INVALID",
+          "from": "",
+          "name": "b",
+          "spec": "file:{CWD}/test/arborist/tap-testdir-pruner-prune-workspaces/packages/b",
+          "type": "workspace",
+        },
+      },
+      "isWorkspace": true,
+      "location": "node_modules/b",
+      "name": "b",
+      "path": "{CWD}/test/arborist/tap-testdir-pruner-prune-workspaces/node_modules/b",
+      "version": "1.2.3",
+    },
+    "once" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "node_modules/a",
+          "name": "once",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "wrappy" => EdgeOut {
+          "name": "wrappy",
+          "spec": "*",
+          "to": "node_modules/wrappy",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/once",
+      "name": "once",
+      "path": "{CWD}/test/arborist/tap-testdir-pruner-prune-workspaces/node_modules/once",
+      "version": "1.2.3",
+    },
+    "qs" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "qs",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/qs",
+      "name": "qs",
+      "path": "{CWD}/test/arborist/tap-testdir-pruner-prune-workspaces/node_modules/qs",
+      "version": "1.2.3",
+    },
+    "wrappy" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "node_modules/once",
+          "name": "wrappy",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/wrappy",
+      "name": "wrappy",
+      "path": "{CWD}/test/arborist/tap-testdir-pruner-prune-workspaces/node_modules/wrappy",
+      "version": "1.2.3",
+    },
+  },
+  "edgesOut": Map {
+    "a" => EdgeOut {
+      "error": "INVALID",
+      "name": "a",
+      "spec": "file:{CWD}/test/arborist/tap-testdir-pruner-prune-workspaces/packages/a",
+      "to": "node_modules/a",
+      "type": "workspace",
+    },
+    "b" => EdgeOut {
+      "error": "INVALID",
+      "name": "b",
+      "spec": "file:{CWD}/test/arborist/tap-testdir-pruner-prune-workspaces/packages/b",
+      "to": "node_modules/b",
+      "type": "workspace",
+    },
+    "qs" => EdgeOut {
+      "name": "qs",
+      "spec": "*",
+      "to": "node_modules/qs",
+      "type": "prod",
+    },
+  },
+  "isProjectRoot": true,
+  "location": "",
+  "name": "tap-testdir-pruner-prune-workspaces",
+  "packageName": "prune-workspaces",
+  "path": "{CWD}/test/arborist/tap-testdir-pruner-prune-workspaces",
+  "version": "1.0.0",
+  "workspaces": Map {
+    "a" => "packages/a",
+    "b" => "packages/b",
+  },
+}
+`

--- a/tap-snapshots/test/arborist/reify.js.test.cjs
+++ b/tap-snapshots/test/arborist/reify.js.test.cjs
@@ -16842,6 +16842,81 @@ exports[`test/arborist/reify.js TAP no saveType: prod w/ peer > must match snaps
 {"dependencies":{"abbrev":"^1.1.1"}}
 `
 
+exports[`test/arborist/reify.js TAP no workspace > must match snapshot 1`] = `
+ArboristNode {
+  "children": Map {
+    "once" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "once",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "edgesOut": Map {
+        "wrappy" => EdgeOut {
+          "name": "wrappy",
+          "spec": "1",
+          "to": "node_modules/wrappy",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/once",
+      "name": "once",
+      "path": "{CWD}/test/arborist/tap-testdir-reify-no-workspace/node_modules/once",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "version": "1.4.0",
+    },
+    "wrappy" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "node_modules/once",
+          "name": "wrappy",
+          "spec": "1",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/wrappy",
+      "name": "wrappy",
+      "path": "{CWD}/test/arborist/tap-testdir-reify-no-workspace/node_modules/wrappy",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "1.0.2",
+    },
+  },
+  "edgesOut": Map {
+    "a" => EdgeOut {
+      "error": "MISSING",
+      "name": "a",
+      "spec": "file:{CWD}/test/arborist/tap-testdir-reify-no-workspace/packages/a",
+      "to": null,
+      "type": "workspace",
+    },
+    "b" => EdgeOut {
+      "error": "MISSING",
+      "name": "b",
+      "spec": "file:{CWD}/test/arborist/tap-testdir-reify-no-workspace/packages/b",
+      "to": null,
+      "type": "workspace",
+    },
+    "once" => EdgeOut {
+      "name": "once",
+      "spec": "*",
+      "to": "node_modules/once",
+      "type": "prod",
+    },
+  },
+  "isProjectRoot": true,
+  "location": "",
+  "name": "tap-testdir-reify-no-workspace",
+  "path": "{CWD}/test/arborist/tap-testdir-reify-no-workspace",
+  "workspaces": Map {
+    "a" => "packages/a",
+    "b" => "packages/b",
+  },
+}
+`
+
 exports[`test/arborist/reify.js TAP node_modules may not be a symlink > must match snapshot 1`] = `
 ArboristNode {
   "children": Map {

--- a/test/arborist/reify.js
+++ b/test/arborist/reify.js
@@ -2360,3 +2360,39 @@ t.test('includeWorkspaceRoot in addition to workspace', async t => {
   t.equal(tree.inventory.query('name', 'abbrev').size, 1)
   t.equal(tree.inventory.query('name', 'once').size, 1)
 })
+
+t.test('no workspace', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      dependencies: {
+        once: '',
+      },
+      workspaces: ['packages/*'],
+    }),
+    packages: {
+      a: {
+        'package.json': JSON.stringify({
+          name: 'a',
+          version: '1.0.1',
+          dependencies: {
+            abbrev: '',
+          },
+        }),
+      },
+      b: {
+        'package.json': JSON.stringify({
+          name: 'b',
+          version: '9.8.1',
+          dependencies: {
+            semver: '',
+          },
+        }),
+      },
+    },
+  })
+  const tree = await reify(path, { workspacesEnabled: false, workspaces: ['a', 'b'] })
+  t.matchSnapshot(printTree(tree))
+  t.equal(tree.inventory.query('name', 'semver').size, 0)
+  t.equal(tree.inventory.query('name', 'abbrev').size, 0)
+  t.equal(tree.inventory.query('name', 'once').size, 1)
+})

--- a/test/fixtures/workspaces-not-root/package-lock.json
+++ b/test/fixtures/workspaces-not-root/package-lock.json
@@ -1,0 +1,80 @@
+{
+  "name": "workspaces-not-root",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "abbrev": "",
+        "wrappy": "1.0.0"
+      }
+    },
+    "node_modules/a": {
+      "resolved": "packages/a",
+      "link": true
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "node_modules/b": {
+      "resolved": "packages/b",
+      "link": true
+    },
+    "node_modules/c": {
+      "resolved": "packages/c",
+      "link": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.0.tgz",
+      "integrity": "sha1-iq5PxrTNa+MqRVOYW88ys+4THk4="
+    },
+    "packages/a": {
+      "version": "1.2.3"
+    },
+    "packages/b": {
+      "version": "1.2.3",
+      "dependencies": {
+        "abbrev": ""
+      }
+    },
+    "packages/c": {
+      "version": "1.2.3",
+      "dependencies": {
+        "abbrev": ""
+      }
+    }
+  },
+  "dependencies": {
+    "a": {
+      "version": "file:packages/a"
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "b": {
+      "version": "file:packages/b",
+      "requires": {
+        "abbrev": ""
+      }
+    },
+    "c": {
+      "version": "file:packages/c",
+      "requires": {
+        "abbrev": ""
+      }
+    },
+    "wrappy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.0.tgz",
+      "integrity": "sha1-iq5PxrTNa+MqRVOYW88ys+4THk4="
+    }
+  }
+}


### PR DESCRIPTION
When `reify`ing, if `workspacesEnabled` is set to false, do not include workspaces or their dependencies in the diffTree, resulting in no changes for those packages. Whatever state those workspaces and packages are in, they're not messed with. A clean `reify` will install everything other than workspaces and their dependencies.

When `prune`ing if `workspacesEnabled` is set to `false`, remove all package installs that are workspaces or exclusive dependencies of those workspaces.

When `rebuild`ing, ingore workspace and workspaces dependency scripts if `workspacesEnabled` is `false`.
