### PR TITLE
deps: @npmcli/map-workspaces@2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.0.1",
         "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/map-workspaces": "^1.0.2",
+        "@npmcli/map-workspaces": "^2.0.0",
         "@npmcli/metavuln-calculator": "^2.0.0",
         "@npmcli/move-file": "^1.1.0",
         "@npmcli/name-from-folder": "^1.0.1",
@@ -727,9 +727,9 @@
       }
     },
     "node_modules/@npmcli/map-workspaces": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-1.0.4.tgz",
-      "integrity": "sha512-wVR8QxhyXsFcD/cORtJwGQodeeaDf0OxcHie8ema4VgFeqwYkFsDPnSrIRSytX8xR6nKPAH89WnwTcaU608b/Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-2.0.0.tgz",
+      "integrity": "sha512-QBJfpCY1NOAkkW3lFfru9VTdqvMB2TN0/vrevl5xBCv5Fi0XDVcA6rqqSau4Ysi4Iw3fBzyXV7hzyTBDfadf7g==",
       "dependencies": {
         "@npmcli/name-from-folder": "^1.0.1",
         "glob": "^7.1.6",
@@ -737,7 +737,7 @@
         "read-package-json-fast": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/@npmcli/metavuln-calculator": {
@@ -8495,9 +8495,9 @@
       }
     },
     "@npmcli/map-workspaces": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-1.0.4.tgz",
-      "integrity": "sha512-wVR8QxhyXsFcD/cORtJwGQodeeaDf0OxcHie8ema4VgFeqwYkFsDPnSrIRSytX8xR6nKPAH89WnwTcaU608b/Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-2.0.0.tgz",
+      "integrity": "sha512-QBJfpCY1NOAkkW3lFfru9VTdqvMB2TN0/vrevl5xBCv5Fi0XDVcA6rqqSau4Ysi4Iw3fBzyXV7hzyTBDfadf7g==",
       "requires": {
         "@npmcli/name-from-folder": "^1.0.1",
         "glob": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@isaacs/string-locale-compare": "^1.0.1",
     "@npmcli/installed-package-contents": "^1.0.7",
-    "@npmcli/map-workspaces": "^1.0.2",
+    "@npmcli/map-workspaces": "^2.0.0",
     "@npmcli/metavuln-calculator": "^2.0.0",
     "@npmcli/move-file": "^1.1.0",
     "@npmcli/name-from-folder": "^1.0.1",


### PR DESCRIPTION
The breaking change is bringing `engines` in sync w/ npm@8, arborist is
already on the same level
