### PR TITLE
chore: normalize ci workflow, raise tap timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,5 @@ jobs:
           cache: npm
       - run: npm i --prefer-online -g npm@latest
       - run: npm ci
-        # TODO -t0 will need to go into npm test when we standardize on template-oss
-      - run: npm test --ignore-scripts -t0
+      - run: npm test --ignore-scripts
       - run: npm ls -a
-        # TODO these will need to go into npm test when we standardize on template-oss
-        env:
-          ARBORIST_DEBUG: '0'
-          NODE_OPTIONS: --no-warnings

--- a/package.json
+++ b/package.json
@@ -45,11 +45,10 @@
     "tcompare": "^5.0.6"
   },
   "scripts": {
-    "test": "npm run test-only --",
-    "test-only": "tap",
-    "posttest": "npm run lint --",
+    "test": "tap",
+    "posttest": "npm run lint",
     "snap": "tap",
-    "postsnap": "npm run lintfix --",
+    "postsnap": "npm run lintfix",
     "test-proxy": "ARBORIST_TEST_PROXY=1 tap --snapshot",
     "preversion": "npm test",
     "postversion": "npm publish",
@@ -88,7 +87,7 @@
       "--no-warnings",
       "--no-deprecation"
     ],
-    "timeout": "240"
+    "timeout": "360"
   },
   "engines": {
     "node": "^12.13.0 || ^14.15.0 || >=16"


### PR DESCRIPTION
does what it says in the title, i want to see if these non-standard things that were present are actually necessary