### PR TITLE
fix: always set originalLockfileVersion when doing shrinkwrap reset

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -380,9 +380,10 @@ class Shrinkwrap {
   reset () {
     this.tree = null
     this[_awaitingUpdate] = new Map()
-    this.originalLockfileVersion = this.lockfileVersion
+    const lockfileVersion = this.lockfileVersion || defaultLockfileVersion
+    this.originalLockfileVersion = lockfileVersion
     this.data = {
-      lockfileVersion: this.lockfileVersion || defaultLockfileVersion,
+      lockfileVersion,
       requires: true,
       packages: {},
       dependencies: {},

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -611,6 +611,33 @@ t.test('force a new mkdirp (but not semver major)', async t => {
   t.equal(arb.idealTree.children.get('minimist').package.version, '1.2.5')
 })
 
+t.test('empty update should not trigger old lockfile', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'empty-update',
+      version: '1.0.0',
+    }),
+    'package-lock.json': JSON.stringify({
+      name: 'empty-update',
+      version: '1.0.0',
+      lockfileVersion: 2,
+      requires: true,
+      packages: {
+        '': {
+          name: 'empty-update',
+          version: '1.0.0',
+        },
+      },
+    }),
+  })
+  const checkLogs = warningTracker()
+
+  const arb = newArb(path)
+  await arb.reify({ update: true })
+
+  t.strictSame(checkLogs(), [])
+})
+
 t.test('no fix available', async t => {
   const path = resolve(fixtures, 'audit-mkdirp/mkdirp-unfixable')
   const checkLogs = warningTracker()

--- a/test/shrinkwrap.js
+++ b/test/shrinkwrap.js
@@ -75,6 +75,7 @@ t.test('starting out with a reset lockfile is an empty lockfile', t =>
       dependencies: {},
       packages: {},
     })
+    t.equal(sw.originalLockfileVersion, 2)
     t.equal(sw.loadedFromDisk, true)
     t.equal(sw.filename, resolve(fixture, 'package-lock.json'))
   }))


### PR DESCRIPTION
Fix: npm/cli#3899

A shrinkwrap reset without specifying a lockfile version was triggering
an old lockfile warning due to the originalLockfileVersion not being set
prior to checking whether the lockfile was old.
