### PR TITLE
chore: add regression tests for old lockfile warning

### DIFF
--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -978,6 +978,53 @@ t.test('complete build for project with old lockfile', async t => {
   ])
 })
 
+t.test('no old lockfile warning with no package-lock', async t => {
+  const fixt = t.testdir({
+    node_modules: {
+      abbrev: {
+        'package.json': JSON.stringify({
+          name: 'abbrev',
+          version: '1.1.1',
+        }),
+      },
+    },
+    'package.json': JSON.stringify({
+      name: 'no-package-lock',
+      dependencies: {
+        abbrev: '1',
+      },
+    }),
+  })
+  const checkLogs = warningTracker()
+  await newArb(fixt).reify()
+  t.strictSame(checkLogs(), [])
+})
+
+t.test('no old lockfile warning with a conflict package-lock', async t => {
+  const fixt = t.testdir({
+    node_modules: {
+      abbrev: {
+        'package.json': JSON.stringify({
+          name: 'abbrev',
+          version: '1.1.1',
+        }),
+      },
+    },
+    'package.json': JSON.stringify({
+      name: 'conflict-package-lock',
+      dependencies: {
+        abbrev: '1',
+      },
+    }),
+    'package-lock.json': fs.readFileSync(
+      resolve(fixtures, 'conflict-package-lock/package-lock.json')
+    ),
+  })
+  const checkLogs = warningTracker()
+  await newArb(fixt).reify()
+  t.strictSame(checkLogs(), [])
+})
+
 t.test('override a conflict with the root dep (with force)', async t => {
   const path = resolve(fixtures, 'testing-peer-dep-conflict-chain/override')
   // note: fails because this is the root dep, unless --force used

--- a/test/fixtures/conflict-package-lock/package-lock.json
+++ b/test/fixtures/conflict-package-lock/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "conflict-package-lock",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "conflict-package-lock",
+      "dependencies": {
+        "abbrev": "1"
+      }
+    },
+    "node_modules/abbrev": {
+<<<<<<< HEAD
+      "version": "1.1.1",
+=======
+      "version": "1.1.2",
+>>>>>>> conflict
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    }
+  },
+  "dependencies": {
+    "abbrev": {
+<<<<<<< HEAD
+      "version": "1.1.1",
+=======
+      "version": "1.1.2",
+>>>>>>> conflict
+    }
+  }
+}


### PR DESCRIPTION
Ref: npm/cli#3721

Prior to this change[^1] reifying with no package-lock or a package-lock
with a merge conflict would result in an old lockfile warning. This adds
regression tests to explicitly test both those scenarios.

[^1]: https://github.com/npm/arborist/commit/c7f2370b3fa9111944b916871c281efba507732d#diff-a22bf0383032b8f318ebe49a4e41b34bcc98e2c10d18322f619edcd041a27483R333-R334
