### PR TITLE
feat(reify): add the ability to add a hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ arb.reify({
   // write the lockfile(s) back to disk, and package.json with any updates
   // defaults to 'true'
   save: true,
+
+  // experimental hooks
+  hooks: {
+    // hook that runs after building the idealTree but before saving it
+    [Symbol.for('beforeReify')]: Arborist => ...
+  }
 }).then(() => {
   // node modules has been written to match the idealTree
 })

--- a/lib/arborist/reify.js
+++ b/lib/arborist/reify.js
@@ -99,6 +99,9 @@ const _resolvedAdd = Symbol.for('resolvedAdd')
 const _usePackageLock = Symbol.for('usePackageLock')
 const _formatPackageLock = Symbol.for('formatPackageLock')
 
+// hooks
+const _beforeReify = Symbol.for('beforeReify')
+
 module.exports = cls => class Reifier extends cls {
   constructor (options) {
     super(options)
@@ -147,6 +150,10 @@ module.exports = cls => class Reifier extends cls {
     process.emit('time', 'reify')
     await this[_validatePath]()
     await this[_loadTrees](options)
+    if (options.hooks
+        && typeof options.hooks[_beforeReify] === 'function') {
+      options.hooks[_beforeReify](this)
+    }
     await this[_diffTrees]()
     await this[_reifyPackages]()
     await this[_saveIdealTree](options)

--- a/tap-snapshots/test/arborist/reify.js.test.cjs
+++ b/tap-snapshots/test/arborist/reify.js.test.cjs
@@ -32358,6 +32358,16 @@ ArboristNode {
 }
 `
 
+exports[`test/arborist/reify.js TAP run hooks > must match snapshot 1`] = `
+ArboristNode {
+  "isProjectRoot": true,
+  "location": "",
+  "name": "tap-testdir-reify-run-hooks",
+  "packageName": "hook-test-modified",
+  "path": "{CWD}/test/arborist/tap-testdir-reify-run-hooks",
+}
+`
+
 exports[`test/arborist/reify.js TAP running lifecycle scripts of unchanged link nodes on reify > result 1`] = `
 ArboristNode {
   "children": Map {

--- a/test/arborist/reify.js
+++ b/test/arborist/reify.js
@@ -2432,3 +2432,16 @@ t.test('add local dep with existing dev + peer/optional', async t => {
   t.equal(tree.children.get('abbrev').resolved, 'file:../../dep', 'resolved')
   t.equal(tree.children.size, 1, 'children')
 })
+
+t.test('run hooks', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'hook-test',
+    }),
+  })
+  const tree = await reify(path, { hooks: {
+    [Symbol.for('beforeReify')]: (arborist) => {
+      arborist.idealTree.package.name = 'hook-test-modified'
+    } } })
+  t.matchSnapshot(printTree(tree))
+})


### PR DESCRIPTION
This PR adds the ability to add a hook via `options.hook`. It adds a single hook `options.hook[Symbol.for('beforeReify')](Arborist)`, that runs after `this[_loadTrees]()` but before `this[_reifyPackages](options)`. Other hook can be added later, with backward compatability.

Sometimes in a project, there is a need to enforce some policies on dependencies used in the project or mutate the tree. However, npm or Arborist doesn't provide a way to hook into its process.

## References
Related to https://github.com/npm/rfcs/issues/460

#### Other package managers

- Yarn 1: undocumented hooks can wrap each step (https://github.com/yarnpkg/yarn/pull/7557)
- Yarn 2: hooks can be added via a plugin (https://yarnpkg.com/advanced/plugin-tutorial#using-hooks)
- pnpm: hooks can be added via configuration (https://pnpm.io/pnpmfile)