### PR TITLE
fix: stop pruning peerSets when entryEdge is from a workspace

### DIFF
--- a/lib/place-dep.js
+++ b/lib/place-dep.js
@@ -407,11 +407,12 @@ class PlaceDep {
       for (const entryEdge of peerEntrySets(edge.from).keys()) {
         // either this one needs to be pruned and re-evaluated, or marked
         // as peerConflicted and warned about.  If the entryEdge comes in from
-        // the root, then we have to leave it alone, and in that case, it
-        // will have already warned or crashed by getting to this point.
+        // the root or a workspace, then we have to leave it alone, and in that
+        // case, it will have already warned or crashed by getting to this point
         const entryNode = entryEdge.to
         const deepestTarget = deepestNestingTarget(entryNode)
-        if (deepestTarget !== target && !entryEdge.from.isRoot) {
+        if (deepestTarget !== target &&
+            !(entryEdge.from.isProjectRoot || entryEdge.from.isWorkspace)) {
           prunePeerSets.push(...gatherDepSet([entryNode], e => {
             return e.to !== entryNode && !e.peerConflicted
           }))

--- a/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-a.json
+++ b/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-a.json
@@ -1,0 +1,101 @@
+{
+  "_id": "@lukekarrys/workspace-peer-dep-infinite-loop-a",
+  "_rev": "3-833cea8f3e355af4796771e09a08b140",
+  "name": "@lukekarrys/workspace-peer-dep-infinite-loop-a",
+  "dist-tags": {
+    "latest": "2.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-a",
+      "version": "1.0.0",
+      "dependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-b": "1.0.0"
+      },
+      "peerDependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-c": "1.0.0 || 2.0.0",
+        "@lukekarrys/workspace-peer-dep-infinite-loop-d": "1.0.0 || 2.0.0"
+      },
+      "gitHead": "bbc444f368656f5d297159648f9b73ce8a3a50a7",
+      "_id": "@lukekarrys/workspace-peer-dep-infinite-loop-a@1.0.0",
+      "_nodeVersion": "14.17.6",
+      "_npmVersion": "8.1.0",
+      "dist": {
+        "integrity": "sha512-C/BEzjHrHlxpJ9K0h71a6lIzgzVSPJ7hV7os+332Hm4kwHhmRbF1kTt8sy9KZnZm03J3pOTzh4NPPHNiCNz7bw==",
+        "shasum": "abc8cc877853adf93680f07dacbc1158ea641fed",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-a/-/workspace-peer-dep-infinite-loop-a-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 359
+      },
+      "_npmUser": {
+        "name": "lukekarrys",
+        "email": "luke@lukekarrys.com"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "lukekarrys",
+          "email": "luke@lukekarrys.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/workspace-peer-dep-infinite-loop-a_1.0.0_1634941282442_0.9874777418548006"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.1": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-a",
+      "version": "2.0.1",
+      "dependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-b": "1.0.0"
+      },
+      "peerDependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-c": "2.0.0",
+        "@lukekarrys/workspace-peer-dep-infinite-loop-d": "2.0.0"
+      },
+      "gitHead": "bbc444f368656f5d297159648f9b73ce8a3a50a7",
+      "_id": "@lukekarrys/workspace-peer-dep-infinite-loop-a@2.0.1",
+      "_nodeVersion": "14.17.6",
+      "_npmVersion": "8.1.0",
+      "dist": {
+        "integrity": "sha512-giB57Db/oYd7/McsynhxFS+76F7Th9QStIBdgicVhITDJ9czIBbcfYKoLGOvmexfHfdkRirXTBs418tvwir8Ag==",
+        "shasum": "58fcad108de00091e398697cbe3fef9c983e7be7",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-a/-/workspace-peer-dep-infinite-loop-a-2.0.1.tgz",
+        "fileCount": 1,
+        "unpackedSize": 341
+      },
+      "_npmUser": {
+        "name": "lukekarrys",
+        "email": "luke@lukekarrys.com"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "lukekarrys",
+          "email": "luke@lukekarrys.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/workspace-peer-dep-infinite-loop-a_2.0.1_1634971981358_0.562420315902278"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-10-22T22:21:22.379Z",
+    "1.0.0": "2021-10-22T22:21:22.558Z",
+    "modified": "2021-10-23T06:53:01.554Z",
+    "2.0.0": "2021-10-23T05:51:31.763Z",
+    "2.0.1": "2021-10-23T06:53:01.527Z"
+  },
+  "maintainers": [
+    {
+      "name": "lukekarrys",
+      "email": "luke@lukekarrys.com"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-a.min.json
+++ b/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-a.min.json
@@ -1,0 +1,45 @@
+{
+  "name": "@lukekarrys/workspace-peer-dep-infinite-loop-a",
+  "dist-tags": {
+    "latest": "2.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-a",
+      "version": "1.0.0",
+      "dependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-b": "1.0.0"
+      },
+      "peerDependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-c": "1.0.0 || 2.0.0",
+        "@lukekarrys/workspace-peer-dep-infinite-loop-d": "1.0.0 || 2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-C/BEzjHrHlxpJ9K0h71a6lIzgzVSPJ7hV7os+332Hm4kwHhmRbF1kTt8sy9KZnZm03J3pOTzh4NPPHNiCNz7bw==",
+        "shasum": "abc8cc877853adf93680f07dacbc1158ea641fed",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-a/-/workspace-peer-dep-infinite-loop-a-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 359
+      }
+    },
+    "2.0.1": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-a",
+      "version": "2.0.1",
+      "dependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-b": "1.0.0"
+      },
+      "peerDependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-c": "2.0.0",
+        "@lukekarrys/workspace-peer-dep-infinite-loop-d": "2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-giB57Db/oYd7/McsynhxFS+76F7Th9QStIBdgicVhITDJ9czIBbcfYKoLGOvmexfHfdkRirXTBs418tvwir8Ag==",
+        "shasum": "58fcad108de00091e398697cbe3fef9c983e7be7",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-a/-/workspace-peer-dep-infinite-loop-a-2.0.1.tgz",
+        "fileCount": 1,
+        "unpackedSize": 341
+      }
+    }
+  },
+  "modified": "2021-10-23T06:53:01.554Z"
+}

--- a/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-b.json
+++ b/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-b.json
@@ -1,0 +1,94 @@
+{
+  "_id": "@lukekarrys/workspace-peer-dep-infinite-loop-b",
+  "_rev": "1-4a3d3b25c000b5775f766c8e659bc2e1",
+  "name": "@lukekarrys/workspace-peer-dep-infinite-loop-b",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-b",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-c": "1.0.0",
+        "@lukekarrys/workspace-peer-dep-infinite-loop-d": "1.0.0"
+      },
+      "gitHead": "bbc444f368656f5d297159648f9b73ce8a3a50a7",
+      "_id": "@lukekarrys/workspace-peer-dep-infinite-loop-b@1.0.0",
+      "_nodeVersion": "14.17.6",
+      "_npmVersion": "8.1.0",
+      "dist": {
+        "integrity": "sha512-+GvjbbvuGzZvsjQxKTjQkbIJrtNt56Gv6vSrARlORG8zV9hmKq42nLzs+WxtnK660GLAdEDfX9I6hgBNbS7/mA==",
+        "shasum": "522b8d76088df12851dc32f85776e82d864d14cb",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-b/-/workspace-peer-dep-infinite-loop-b-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 254
+      },
+      "_npmUser": {
+        "name": "lukekarrys",
+        "email": "luke@lukekarrys.com"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "lukekarrys",
+          "email": "luke@lukekarrys.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/workspace-peer-dep-infinite-loop-b_1.0.0_1634941296191_0.2369251217358015"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-b",
+      "version": "2.0.0",
+      "peerDependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-c": "1.0.0",
+        "@lukekarrys/workspace-peer-dep-infinite-loop-d": "1.0.0"
+      },
+      "gitHead": "bbc444f368656f5d297159648f9b73ce8a3a50a7",
+      "_id": "@lukekarrys/workspace-peer-dep-infinite-loop-b@2.0.0",
+      "_nodeVersion": "14.17.6",
+      "_npmVersion": "8.1.0",
+      "dist": {
+        "integrity": "sha512-oR7ANLAxFCdudMyKIC+tTar+z1tXbuuPorTa34MIIBH/adruSEfIOB3PcpyW+K1VrpEBVuCYLwHbAicKHCHhrw==",
+        "shasum": "48905853b45ab91ba0bafe6403d3ca5dfa887af1",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-b/-/workspace-peer-dep-infinite-loop-b-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 254
+      },
+      "_npmUser": {
+        "name": "lukekarrys",
+        "email": "luke@lukekarrys.com"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "lukekarrys",
+          "email": "luke@lukekarrys.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/workspace-peer-dep-infinite-loop-b_2.0.0_1634968303287_0.1382056167069008"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-10-22T22:21:36.156Z",
+    "1.0.0": "2021-10-22T22:21:36.308Z",
+    "modified": "2021-10-23T05:51:43.444Z",
+    "2.0.0": "2021-10-23T05:51:43.411Z"
+  },
+  "maintainers": [
+    {
+      "name": "lukekarrys",
+      "email": "luke@lukekarrys.com"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-b.min.json
+++ b/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-b.min.json
@@ -1,0 +1,39 @@
+{
+  "name": "@lukekarrys/workspace-peer-dep-infinite-loop-b",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-b",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-c": "1.0.0",
+        "@lukekarrys/workspace-peer-dep-infinite-loop-d": "1.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-+GvjbbvuGzZvsjQxKTjQkbIJrtNt56Gv6vSrARlORG8zV9hmKq42nLzs+WxtnK660GLAdEDfX9I6hgBNbS7/mA==",
+        "shasum": "522b8d76088df12851dc32f85776e82d864d14cb",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-b/-/workspace-peer-dep-infinite-loop-b-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 254
+      }
+    },
+    "2.0.0": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-b",
+      "version": "2.0.0",
+      "peerDependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-c": "1.0.0",
+        "@lukekarrys/workspace-peer-dep-infinite-loop-d": "1.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-oR7ANLAxFCdudMyKIC+tTar+z1tXbuuPorTa34MIIBH/adruSEfIOB3PcpyW+K1VrpEBVuCYLwHbAicKHCHhrw==",
+        "shasum": "48905853b45ab91ba0bafe6403d3ca5dfa887af1",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-b/-/workspace-peer-dep-infinite-loop-b-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 254
+      }
+    }
+  },
+  "modified": "2021-10-23T05:51:43.444Z"
+}

--- a/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-c.json
+++ b/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-c.json
@@ -1,0 +1,86 @@
+{
+  "_id": "@lukekarrys/workspace-peer-dep-infinite-loop-c",
+  "_rev": "1-688f6a1b5a2ad585ee1f10ddb651927f",
+  "name": "@lukekarrys/workspace-peer-dep-infinite-loop-c",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-c",
+      "version": "1.0.0",
+      "gitHead": "bbc444f368656f5d297159648f9b73ce8a3a50a7",
+      "_id": "@lukekarrys/workspace-peer-dep-infinite-loop-c@1.0.0",
+      "_nodeVersion": "14.17.6",
+      "_npmVersion": "8.1.0",
+      "dist": {
+        "integrity": "sha512-Mo0OMqE85adQNUae/K1SR8aCtOAv0GQ6vZ4vZ3NdB+J+J1sJ2mffliJeGbzHgN9Le9Njc8sVZ114GpU/pdddEA==",
+        "shasum": "bb06793078a1a552597d416b32d6db53dc78c5be",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-c/-/workspace-peer-dep-infinite-loop-c-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 100
+      },
+      "_npmUser": {
+        "name": "lukekarrys",
+        "email": "luke@lukekarrys.com"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "lukekarrys",
+          "email": "luke@lukekarrys.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/workspace-peer-dep-infinite-loop-c_1.0.0_1634941304372_0.9920503488288135"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-c",
+      "version": "2.0.0",
+      "gitHead": "bbc444f368656f5d297159648f9b73ce8a3a50a7",
+      "_id": "@lukekarrys/workspace-peer-dep-infinite-loop-c@2.0.0",
+      "_nodeVersion": "14.17.6",
+      "_npmVersion": "8.1.0",
+      "dist": {
+        "integrity": "sha512-V97f4sg8/qDVsneWvvxRolgQHlo4d1fywWYT0T1O9fo9c5WInL74CZ+RmHgaKIBVWXUdQpGRMf7K98TVT8J16A==",
+        "shasum": "d837970ae4f694e8968f334642eddc5f76e31a16",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-c/-/workspace-peer-dep-infinite-loop-c-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 100
+      },
+      "_npmUser": {
+        "name": "lukekarrys",
+        "email": "luke@lukekarrys.com"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "lukekarrys",
+          "email": "luke@lukekarrys.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/workspace-peer-dep-infinite-loop-c_2.0.0_1634941360008_0.992974788749321"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-10-22T22:21:44.335Z",
+    "1.0.0": "2021-10-22T22:21:44.485Z",
+    "modified": "2021-10-22T22:22:40.230Z",
+    "2.0.0": "2021-10-22T22:22:40.196Z"
+  },
+  "maintainers": [
+    {
+      "name": "lukekarrys",
+      "email": "luke@lukekarrys.com"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-c.min.json
+++ b/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-c.min.json
@@ -1,0 +1,31 @@
+{
+  "name": "@lukekarrys/workspace-peer-dep-infinite-loop-c",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-c",
+      "version": "1.0.0",
+      "dist": {
+        "integrity": "sha512-Mo0OMqE85adQNUae/K1SR8aCtOAv0GQ6vZ4vZ3NdB+J+J1sJ2mffliJeGbzHgN9Le9Njc8sVZ114GpU/pdddEA==",
+        "shasum": "bb06793078a1a552597d416b32d6db53dc78c5be",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-c/-/workspace-peer-dep-infinite-loop-c-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 100
+      }
+    },
+    "2.0.0": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-c",
+      "version": "2.0.0",
+      "dist": {
+        "integrity": "sha512-V97f4sg8/qDVsneWvvxRolgQHlo4d1fywWYT0T1O9fo9c5WInL74CZ+RmHgaKIBVWXUdQpGRMf7K98TVT8J16A==",
+        "shasum": "d837970ae4f694e8968f334642eddc5f76e31a16",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-c/-/workspace-peer-dep-infinite-loop-c-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 100
+      }
+    }
+  },
+  "modified": "2021-10-22T22:22:40.230Z"
+}

--- a/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-d.json
+++ b/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-d.json
@@ -1,0 +1,94 @@
+{
+  "_id": "@lukekarrys/workspace-peer-dep-infinite-loop-d",
+  "_rev": "1-785e52ba6ea133d21a10fdd7b0b84c45",
+  "name": "@lukekarrys/workspace-peer-dep-infinite-loop-d",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-d",
+      "version": "1.0.0",
+      "dependencies": {},
+      "peerDependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-c": "1.0.0"
+      },
+      "gitHead": "bbc444f368656f5d297159648f9b73ce8a3a50a7",
+      "_id": "@lukekarrys/workspace-peer-dep-infinite-loop-d@1.0.0",
+      "_nodeVersion": "14.17.6",
+      "_npmVersion": "8.1.0",
+      "dist": {
+        "integrity": "sha512-TjMnL1cPV0UcpbU+NyCKQrXQN3lI7Ksz3zn6drJg3KL+6AxDFit/Aw6BtCL6tHmm5G+U7eIzjLPAHqlXIFrSVw==",
+        "shasum": "a3251551cab8e45de1b800a2b32a314c2c8142c3",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-d/-/workspace-peer-dep-infinite-loop-d-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 213
+      },
+      "_npmUser": {
+        "name": "lukekarrys",
+        "email": "luke@lukekarrys.com"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "lukekarrys",
+          "email": "luke@lukekarrys.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/workspace-peer-dep-infinite-loop-d_1.0.0_1634941316373_0.43979451381454204"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-d",
+      "version": "2.0.0",
+      "dependencies": {},
+      "peerDependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-c": "2.0.0"
+      },
+      "gitHead": "bbc444f368656f5d297159648f9b73ce8a3a50a7",
+      "_id": "@lukekarrys/workspace-peer-dep-infinite-loop-d@2.0.0",
+      "_nodeVersion": "14.17.6",
+      "_npmVersion": "8.1.0",
+      "dist": {
+        "integrity": "sha512-aJXF9gmAN0dAJZGQ5Midr18ufPU9uGB7ce7LjwF0+tqTwxQroHlqBo/WID51ERBOHRldZfdsKrxJd7O3EKj8kg==",
+        "shasum": "2a896e17ace2d74d002b084a1d77dff9bdbe1dff",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-d/-/workspace-peer-dep-infinite-loop-d-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 213
+      },
+      "_npmUser": {
+        "name": "lukekarrys",
+        "email": "luke@lukekarrys.com"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "lukekarrys",
+          "email": "luke@lukekarrys.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/workspace-peer-dep-infinite-loop-d_2.0.0_1634941352176_0.7382597483667386"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2021-10-22T22:21:56.323Z",
+    "1.0.0": "2021-10-22T22:21:56.483Z",
+    "modified": "2021-10-22T22:22:32.558Z",
+    "2.0.0": "2021-10-22T22:22:32.526Z"
+  },
+  "maintainers": [
+    {
+      "name": "lukekarrys",
+      "email": "luke@lukekarrys.com"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-d.min.json
+++ b/test/fixtures/registry-mocks/content/lukekarrys/workspace-peer-dep-infinite-loop-d.min.json
@@ -1,0 +1,37 @@
+{
+  "name": "@lukekarrys/workspace-peer-dep-infinite-loop-d",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-d",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-c": "1.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-TjMnL1cPV0UcpbU+NyCKQrXQN3lI7Ksz3zn6drJg3KL+6AxDFit/Aw6BtCL6tHmm5G+U7eIzjLPAHqlXIFrSVw==",
+        "shasum": "a3251551cab8e45de1b800a2b32a314c2c8142c3",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-d/-/workspace-peer-dep-infinite-loop-d-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 213
+      }
+    },
+    "2.0.0": {
+      "name": "@lukekarrys/workspace-peer-dep-infinite-loop-d",
+      "version": "2.0.0",
+      "peerDependencies": {
+        "@lukekarrys/workspace-peer-dep-infinite-loop-c": "2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-aJXF9gmAN0dAJZGQ5Midr18ufPU9uGB7ce7LjwF0+tqTwxQroHlqBo/WID51ERBOHRldZfdsKrxJd7O3EKj8kg==",
+        "shasum": "2a896e17ace2d74d002b084a1d77dff9bdbe1dff",
+        "tarball": "https://registry.npmjs.org/@lukekarrys/workspace-peer-dep-infinite-loop-d/-/workspace-peer-dep-infinite-loop-d-2.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 213
+      }
+    }
+  },
+  "modified": "2021-10-22T22:22:32.558Z"
+}


### PR DESCRIPTION
While fixing npm/cli#3933 I wrote tests to confirm the behavior and noticed that a case with an overlapping peerSet was warning when it shouldn't be.

This tree should be able to be built with `c@1` and `d@1`, which it does, but with a warning. In `2.8.3` it correctly doesn't give an `ERESOLVE` warning, so I think it's a regression in `2.8.4`.

 ```
// overlapping peerSet
 project -> (a@1)
 a@1 -> (b), PEER(c@1||2), PEER(d@1||2)
 b -> PEER(c@1), PEER(d@1)
 c -> ()
 d@1 -> PEER(c@1)
 d@2 -> PEER(c@2)
 ```

I also found that a similar tree with a conflicting peerSet was also causing the infinite loop when installed in a workspace. When testing that case I found that building this tree in a root vs a workspace ended up with different versions of `c` and `d`.

```
// conflicting peerSet
project -> (a@2)
a@2 -> (b), PEER(c@2), PEER(d@2)
b -> PEER(c@1), PEER(d@1)
c -> ()
d@1 -> PEER(c@1)
d@2 -> PEER(c@2)
```

Here's a table to compare the behavior across `2.8.3`, `2.8.4`, and what it should be after this PR (❌ means the test is currently failing).

|version|location|add|peers|`c`|`d`|warns|
|-------|--------|------------|--------|------|---|---|
|2.8.3|root|a@1|overlapping| 1|1|no|
|2.8.3|workspace|a@1|overlapping| 1|1|no|
|2.8.3|root | a@2|conflicting| 2|2|yes|
|2.8.3|workspace | a@2 | conflicting| 🔁|🔁|🔁|
|2.8.4|root|a@1|overlapping| 1|1|yes|
|2.8.4|workspace|a@1|overlapping| 🔁|🔁|🔁|
|2.8.4|root | a@2|conflicting| 2|2|yes|
|2.8.4|workspace | a@2 | conflicting| 🔁|🔁|🔁|
|goal|root|a@1|overlapping| 1|1| no (❌) |
| goal |workspace|a@1|overlapping| 1|1|no (❌) |
| goal |root | a@2|conflicting| 2|2|yes|
| goal |workspace | a@2 | conflicting|2 (❌)|2 (❌)|yes|

I also went back to cb623a27fd327b63cd21a4cf96f892d39d1dd308 and noticed that some of the `test/place-dep.js` snapshots added warnings. I suspect that whatever fix gets the tests in this PR passing will affect those snapshots, so I should go through these and confirm they are correct after the fix.

These might all be different fixes, but I've got tests for all of them in this PR, so I'll probably fix them all in here.

TODOS:
- [x] Resolving peerSets in a workspace does not loop
- [x] ~~Don't warn for overlapping peer sets~~
- [x] ~~Install the same peerSet in a root and workspace~~
- [x] ~~[`test/place-dep.js TAP placement tests prod dep directly on conflicted peer, newer, force > warnings 1`](https://github.com/npm/arborist/commit/cb623a27fd327b63cd21a4cf96f892d39d1dd308#diff-e68bb1c8f7773a0dc0af8a23874f57d40e04ef0bf11585f9d139efc3c5211413L6237)~~
- [x] ~~[`test/place-dep.js TAP placement tests prod dep directly on conflicted peer, older, force > warnings 1`](https://github.com/npm/arborist/commit/cb623a27fd327b63cd21a4cf96f892d39d1dd308#diff-e68bb1c8f7773a0dc0af8a23874f57d40e04ef0bf11585f9d139efc3c5211413L6836)~~
- [x] ~~[`test/place-dep.js TAP placement tests replacing existing peer set > warnings 1`](https://github.com/npm/arborist/commit/cb623a27fd327b63cd21a4cf96f892d39d1dd308#diff-e68bb1c8f7773a0dc0af8a23874f57d40e04ef0bf11585f9d139efc3c5211413L7459)~~
- [x] ~~[`test/place-dep.js TAP placement tests replacing overlapping peer sets > warnings 1`](https://github.com/npm/arborist/commit/cb623a27fd327b63cd21a4cf96f892d39d1dd308#diff-e68bb1c8f7773a0dc0af8a23874f57d40e04ef0bf11585f9d139efc3c5211413L7743)~~
- [x] ~~[`test/place-dep.js TAP placement tests replacing partially overlapping peer sets, superset > warnings 1`](https://github.com/npm/arborist/commit/cb623a27fd327b63cd21a4cf96f892d39d1dd308#diff-e68bb1c8f7773a0dc0af8a23874f57d40e04ef0bf11585f9d139efc3c5211413L8391)~~
- [x] Write real commit message explaining all this