### PR TITLE
fix: ws no longer filter root deps

### DIFF
--- a/lib/arborist/index.js
+++ b/lib/arborist/index.js
@@ -29,6 +29,7 @@
 const {resolve} = require('path')
 const {homedir} = require('os')
 const procLog = require('proc-log')
+const { depth } = require('treeverse')
 const { saveTypeMap } = require('../add-rm-pkg-deps.js')
 
 const mixins = [
@@ -88,6 +89,9 @@ class Arborist extends Base {
     process.emit('timeEnd', 'arborist:ctor')
   }
 
+  // TODO: We should change these to static functions instead
+  //   of methods for the next major version
+
   // returns an array of the actual nodes for all the workspaces
   workspaceNodes (tree, workspaces) {
     return getWorkspaceNodes(tree, workspaces, this.log)
@@ -103,15 +107,15 @@ class Arborist extends Base {
         }
       }
     }
-    const set = new Set(wsNodes)
+    const wsDepSet = new Set(wsNodes)
     const extraneous = new Set()
-    for (const node of set) {
+    for (const node of wsDepSet) {
       for (const edge of node.edgesOut.values()) {
         const dep = edge.to
         if (dep) {
-          set.add(dep)
+          wsDepSet.add(dep)
           if (dep.isLink) {
-            set.add(dep.target)
+            wsDepSet.add(dep.target)
           }
         }
       }
@@ -122,28 +126,40 @@ class Arborist extends Base {
       }
     }
     for (const extra of extraneous) {
-      set.add(extra)
+      wsDepSet.add(extra)
     }
 
-    return set
+    return wsDepSet
+  }
+
+  rootDependencySet (tree) {
+    const rootDepSet = new Set()
+    depth({
+      tree,
+      visit: node => {
+        node.edgesOut.forEach(({ to }) => {
+          if (!to) {
+            return
+          }
+          to.edgesIn.forEach(edgeIn => {
+            if (!to.isWorkspace && (
+              edgeIn.from.isRoot || rootDepSet.has(edgeIn.from))
+            ) {
+              rootDepSet.add(to)
+            }
+          })
+        })
+        return node
+      },
+      filter: node => node,
+      getChildren: (node, tree) =>
+        [...tree.edgesOut.values()].map(edge => edge.to),
+    })
+    return rootDepSet
   }
 
   excludeWorkspacesDependencySet (tree) {
-    const set = new Set()
-    for (const edge of tree.edgesOut.values()) {
-      if (edge.type !== 'workspace' && edge.to) {
-        set.add(edge.to)
-      }
-    }
-    for (const node of set) {
-      for (const edge of node.edgesOut.values()) {
-        if (edge.to) {
-          set.add(edge.to)
-        }
-      }
-    }
-
-    return set
+    return this.rootDependencySet(tree)
   }
 }
 

--- a/lib/arborist/index.js
+++ b/lib/arborist/index.js
@@ -132,23 +132,23 @@ class Arborist extends Base {
     return wsDepSet
   }
 
-  rootDependencySet (tree) {
+  // returns a set of root dependencies, excluding depdencies that are
+  // exclusively workspace dependencies
+  excludeWorkspacesDependencySet (tree) {
     const rootDepSet = new Set()
     depth({
       tree,
       visit: node => {
-        node.edgesOut.forEach(({ to }) => {
-          if (!to) {
-            return
+        for (const { to } of node.edgesOut.values()) {
+          if (!to || to.isWorkspace) {
+            continue
           }
-          to.edgesIn.forEach(edgeIn => {
-            if (!to.isWorkspace && (
-              edgeIn.from.isRoot || rootDepSet.has(edgeIn.from))
-            ) {
+          for (const edgeIn of to.edgesIn.values()) {
+            if (edgeIn.from.isRoot || rootDepSet.has(edgeIn.from)) {
               rootDepSet.add(to)
             }
-          })
-        })
+          }
+        }
         return node
       },
       filter: node => node,
@@ -156,10 +156,6 @@ class Arborist extends Base {
         [...tree.edgesOut.values()].map(edge => edge.to),
     })
     return rootDepSet
-  }
-
-  excludeWorkspacesDependencySet (tree) {
-    return this.rootDependencySet(tree)
   }
 }
 

--- a/tap-snapshots/test/arborist/pruner.js.test.cjs
+++ b/tap-snapshots/test/arborist/pruner.js.test.cjs
@@ -180,6 +180,26 @@ ArboristNode {
       "path": "{CWD}/test/arborist/tap-testdir-pruner-prune-workspaces/node_modules/b",
       "version": "1.2.3",
     },
+    "derp" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "derp",
+          "spec": "*",
+          "type": "prod",
+        },
+        EdgeIn {
+          "from": "node_modules/once",
+          "name": "derp",
+          "spec": "*",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/derp",
+      "name": "derp",
+      "path": "{CWD}/test/arborist/tap-testdir-pruner-prune-workspaces/node_modules/derp",
+      "version": "90.2.11",
+    },
     "once" => ArboristNode {
       "edgesIn": Set {
         EdgeIn {
@@ -190,6 +210,12 @@ ArboristNode {
         },
       },
       "edgesOut": Map {
+        "derp" => EdgeOut {
+          "name": "derp",
+          "spec": "*",
+          "to": "node_modules/derp",
+          "type": "prod",
+        },
         "wrappy" => EdgeOut {
           "name": "wrappy",
           "spec": "*",
@@ -245,6 +271,12 @@ ArboristNode {
       "spec": "file:{CWD}/test/arborist/tap-testdir-pruner-prune-workspaces/packages/b",
       "to": "node_modules/b",
       "type": "workspace",
+    },
+    "derp" => EdgeOut {
+      "name": "derp",
+      "spec": "*",
+      "to": "node_modules/derp",
+      "type": "prod",
     },
     "qs" => EdgeOut {
       "name": "qs",

--- a/test/arborist/index.js
+++ b/test/arborist/index.js
@@ -131,6 +131,7 @@ t.test('excludeSet includes nonworkspace metadeps', async t => {
       workspaces: ['pkgs/*'],
       dependencies: {
         foo: '',
+        fritzy: '',
       },
     },
     children: [
@@ -215,9 +216,11 @@ t.test('excludeSet includes nonworkspace metadeps', async t => {
   const arb = new Arborist()
   const filter = arb.excludeWorkspacesDependencySet(tree)
 
-  t.equal(filter.size, 2)
+  t.equal(filter.size, 3)
   t.equal(filter.has(tree.children.get('foo')), true)
   t.equal(filter.has(tree.children.get('bar')), true)
+  t.equal(filter.has(tree.children.get('baz')), false)
+  t.equal(filter.has(tree.children.get('fritzy')), true)
 })
 
 t.test('lockfileVersion config validation', async t => {

--- a/test/arborist/pruner.js
+++ b/test/arborist/pruner.js
@@ -124,6 +124,7 @@ t.test('prune workspaces', async t => {
       main: 'index.js',
       dependencies: {
         qs: '',
+        derp: '',
       },
       scripts: {
         test: 'echo "Error: no test specified" && exit 1',
@@ -171,6 +172,7 @@ t.test('prune workspaces', async t => {
           version: '1.2.3',
           dependencies: {
             wrappy: '',
+            derp: '',
           },
         }),
       },
@@ -186,6 +188,12 @@ t.test('prune workspaces', async t => {
           version: '1.2.3',
         }),
       },
+      derp: {
+        'package.json': JSON.stringify({
+          name: 'derp',
+          version: '90.2.11',
+        }),
+      },
     },
   })
   const tree = await pruneTree(path, { workspacesEnabled: false })
@@ -194,5 +202,6 @@ t.test('prune workspaces', async t => {
   t.notOk(fs.existsSync(join(path, 'node_modules', 'wrappy')), 'wrappy was pruned from tree')
   t.notOk(fs.existsSync(join(path, 'node_modules', 'a')), 'a was pruned from tree')
   t.notOk(fs.existsSync(join(path, 'node_modules', 'b')), 'b was pruned from tree')
+  t.ok(fs.existsSync(join(path, 'node_modules', 'derp')), 'derp was not pruned from tree')
   t.matchSnapshot(printTree(tree))
 })


### PR DESCRIPTION
`arborist.excludeWorkspaceDependencySet` properly handles dependencies that
are both root and workspace deps for commands like prune, npm ls, etc.

Previously, commands like `arborist prune --workspacesEnabled=false` would prune packages erroneously if they were both a workspace and a root dependency.

