### PR TITLE
[Not ready] Introduce tests for isolated mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "ssri": "^8.0.1",
+        "tar-stream": "^2.2.0",
         "treeverse": "^1.0.4",
         "walk-up-path": "^1.0.0"
       },
@@ -976,6 +977,25 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "dev": true,
@@ -1025,6 +1045,29 @@
         "node": ">=10"
       }
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "license": "MIT",
@@ -1064,6 +1107,29 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -1485,6 +1551,14 @@
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enquirer": {
@@ -2014,6 +2088,11 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "node_modules/fs-exists-cached": {
       "version": "1.0.0",
       "dev": true,
@@ -2314,6 +2393,25 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "4.0.6",
@@ -6126,6 +6224,34 @@
         "node": ">= 10"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/tcompare": {
       "version": "5.0.6",
       "dev": true,
@@ -7213,6 +7339,11 @@
     "balanced-match": {
       "version": "1.0.2"
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "dev": true,
@@ -7249,6 +7380,28 @@
       "integrity": "sha512-nLEaaz3/sEzNSyPWRsN9HNsqwk1AUyECtGj+XwGdIi3xABnEqecvXtIJ0wehQXuuER5uZ/5fTs2usONgYjG+iw==",
       "dev": true
     },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "requires": {
@@ -7272,6 +7425,15 @@
         "electron-to-chromium": "^1.3.830",
         "escalade": "^3.1.1",
         "node-releases": "^1.1.75"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
@@ -7555,6 +7717,14 @@
       "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
       }
     },
     "enquirer": {
@@ -7893,6 +8063,11 @@
       "version": "1.3.2",
       "dev": true
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "fs-exists-cached": {
       "version": "1.0.0",
       "dev": true
@@ -8089,6 +8264,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -10611,6 +10791,30 @@
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "tcompare": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "ssri": "^8.0.1",
-        "tar-stream": "^2.2.0",
         "treeverse": "^1.0.4",
         "walk-up-path": "^1.0.0"
       },
@@ -53,6 +52,7 @@
         "minify-registry-metadata": "^2.1.0",
         "nock": "^13.2.0",
         "tap": "^15.1.2",
+        "tar-stream": "^2.2.0",
         "tcompare": "^5.0.6"
       },
       "engines": {
@@ -981,6 +981,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1049,6 +1050,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1059,6 +1061,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -1113,6 +1116,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1557,6 +1561,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -2091,7 +2096,8 @@
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
     },
     "node_modules/fs-exists-cached": {
       "version": "1.0.0",
@@ -2398,6 +2404,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6228,6 +6235,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -6243,6 +6251,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -7342,7 +7351,8 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -7384,6 +7394,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -7394,6 +7405,7 @@
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -7431,6 +7443,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -7723,6 +7736,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -8066,7 +8080,8 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
     },
     "fs-exists-cached": {
       "version": "1.0.0",
@@ -8268,7 +8283,8 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "ignore": {
       "version": "4.0.6",
@@ -10797,6 +10813,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
       "requires": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -10809,6 +10826,7 @@
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "minify-registry-metadata": "^2.1.0",
     "nock": "^13.2.0",
     "tap": "^15.1.2",
+    "tar-stream": "^2.2.0",
     "tcompare": "^5.0.6"
   },
   "scripts": {

--- a/test/isolated-mode.js
+++ b/test/isolated-mode.js
@@ -1,0 +1,24 @@
+const tap = require('tap')
+const fs = require('fs')
+const path = require('path')
+const Arborist = require('../lib/arborist')
+
+tap.test('most simple happy scenario', async t => {
+  const package = { name: 'foo', dependencies: { 'which': '*' } }
+
+  const cwd = t.testdir({
+    'package.json': JSON.stringify(package)
+  })
+
+  const arborist = new Arborist({ path: cwd })
+  await arborist.reify({ isolated: true })
+
+  // Only direct dependencies are accessible by the node-module resolution algorithm
+  t.throws(() => require.resolve('isexe', { paths: [ cwd ] }), 'repo should be able to require direct dependencies')
+  t.doesNotThrow(() => require.resolve('which', { paths: [ cwd ] }), 'repo should not be able to require transitive dependencies')
+
+  // Transitive dependencies are accessible from their parents
+  const whichPath = path.dirname(require.resolve("which", { paths: [ cwd ] }))
+  t.doesNotThrow(() => require.resolve('isexe', { paths: [ whichPath ] }), 'external dependencies should be able to require their own dependencies')
+
+})

--- a/test/isolated-mode.js
+++ b/test/isolated-mode.js
@@ -21,31 +21,33 @@ tap.test('most simple happy scenario', async t => {
   const arborist = new Arborist({ path: cwd })
   await arborist.reify({ isolated: true })
 
+  const requireChain = setupRequire(cwd)
+
   // Only direct dependencies are accessible by the node-module resolution algorithm
-  t.throws(() => require.resolve('isexe', { paths: [ cwd ] }), 'repo should be able to require direct dependencies')
-  t.doesNotThrow(() => require.resolve('which', { paths: [ cwd ] }), 'repo should not be able to require transitive dependencies')
+  t.ok(requireChain('which'), 'repo should be able to require direct dependencies')
+  t.notOk(requireChain('isexe'), 'repo should not be able to require transitive dependencies')
 
   // Transitive dependencies are accessible from their parents
-  const whichPath = path.dirname(require.resolve("which", { paths: [ cwd ] }))
-  t.doesNotThrow(() => require.resolve('isexe', { paths: [ whichPath ] }), 'external dependencies should be able to require their own dependencies')
+  t.ok(requireChain('which', 'isexe'), 'external dependencies should be able to require their own dependencies')
 
-  const isexePath = require.resolve('isexe', { paths: [ whichPath ] })
-  t.throws(() => require.resolve('which', { paths: [ isexePath ] }), 'dependencies are not able to require their parents')
+  // Dependencies cannot require their parents
+  t.notOk(requireChain('which', 'isexe', 'which'), 'dependencies are not able to require their parents')
+
+  // Depencies can require themselves
+  t.ok(requireChain('which', 'which'), 'which can require itself')
+  t.ok(requireChain('which', 'isexe', 'isexe'), 'isexe can require itself')
 })
 
 tap.test('simple peer dependencies scenarios', async t => {
-  const package = { name: 'foo', dependencies: { 'ws': '7.5.2', 'bufferutil': '4.0.1' } }
+  const package = { name: 'foo', dependencies: { 'tsutils': '3.21.0', 'typescript': '4.4.4' } }
 
   /*
     * Dependencies:
     *
-    * foo -> ws
-    *        ws -> bufferutil (peer dep)
-    *              bufferutil -> node-gyp-build
-    *        ws -> utf-8-validate (peer dep)
-    *              utf8-validate -> node-gyp-build
-    * foo -> bufferutil
-    *        bufferutil -> node-gyp-build
+    * foo -> tsutils
+    *        tsutils -> typescript (peer dep)
+    *        tsutils -> tslib
+    * foo -> typescript
     *
     */
 
@@ -56,35 +58,30 @@ tap.test('simple peer dependencies scenarios', async t => {
   const arborist = new Arborist({ path: cwd })
   await arborist.reify({ isolated: true })
 
+  const requireChain = setupRequire(cwd)
+
   // Only direct dependencies are accessible by the node-module resolution algorithm
-  t.doesNotThrow(() => require.resolve('ws', { paths: [ cwd ] }), 'repo should be able to require direct dependency to ws')
-  t.doesNotThrow(() => require.resolve('bufferutil', { paths: [ cwd ] }), 'repo should be able to require direct dependency to bufferutil')
-  t.throws(() => require.resolve('node-gyp-build', { paths: [ cwd ] }), 'repo should not be able to require transitive dependency to node-gyp-build')
-  t.throws(() => require.resolve('utf-8-validate', { paths: [ cwd ] }), 'repo should not be able to require transitive dependency to utf-8-validate')
+  t.ok(requireChain('typescript'), 'repo should be able to require direct dependency to typescript')
+  t.ok(requireChain('tsutils'), 'repo should be able to require direct dependency to tsutils')
+  t.notOk(requireChain('tslib'), 'repo should not be able to require transitive dependency to tslib')
 
-  // ws can only require its direct dependencies
-  const wsPath = path.dirname(require.resolve('ws', { paths: [ cwd ] }))
-  t.doesNotThrow(() => require.resolve('bufferutil', { paths: [ wsPath ] }), 'ws should be able to require its own peer dependency to bufferutil')
-  t.doesNotThrow(() => require.resolve('utf-8-validate', { paths: [ wsPath ] }), 'ws should be able to require its own peer dependency to utf-8-validate')
-  t.doesNotThrow(() => require.resolve('ws', { paths: [ wsPath ] }), 'ws should be able to require itself')
-  t.throws(() => require.resolve('node-gyp-build', { paths: [ wsPath ] }), 'ws should not be able to require transitive dependency to node-gyp-build')
+  // typescript can only require its direct dependencies and root dependencies
+  t.ok(requireChain('typescript', 'typescript'), 'typescript can require itself')
+  t.ok(requireChain('typescript', 'tsutils'), 'typescript should be able to require tsutils because it is a root dependency')
+  t.notOk(requireChain('typescript', 'tslib'), 'typescript should not be able to require tslib because it is neither a dependency of itself or of the root')
 
-  // bufferutil can resolve its deps and dependencies of the root
-  const bufferutilPath = path.dirname(require.resolve('bufferutil', { paths: [ wsPath ] }))
-  t.doesNotThrow(() => require.resolve('node-gyp-build', { paths: [ bufferutilPath ] }), 'bufferutil should be able to require its own dependency to node-gyp-build')
-  t.doesNotThrow(() => require.resolve('bufferutil', { paths: [ bufferutilPath ] }), 'bufferutil should be able to require itself')
-  t.doesNotThrow(() => require.resolve('ws', { paths: [ bufferutilPath ] }), 'bufferutil should be able to require its parent because it is a root dependency')
-  t.throws(() => require.resolve('utf-8-validate', { paths: [ bufferutilPath ] }), 'bufferutil should not be able to require its sibling')
+  // tsutils can resolve its deps and dependencies of the root
+  t.ok(requireChain('tsutils', 'typescript'), 'tsutils should be able to resolve its peer dependency to typescript')
+  t.ok(requireChain('tsutils', 'tslib'), 'tsutils should be able to resolve its dependency to tslib')
+  t.ok(requireChain('tsutils', 'tsutils'), 'tsutils should be able to resolve itself')
 
-  // utf-8-validate can resolve its deps and dependencies of the root
-  const utf8validatePaty = path.dirname(require.resolve('utf-8-validate', { paths: [ wsPath ] }))
-  t.doesNotThrow(() => require.resolve('node-gyp-build', { paths: [ utf8validatePaty ] }), 'utf-8-validate should be able to require its own dependency to node-gyp-build')
-  t.doesNotThrow(() => require.resolve('utf-8-validate', { paths: [ utf8validatePaty ] }), 'utf-8-validate should be able to require itself')
-  t.doesNotThrow(() => require.resolve('ws', { paths: [ utf8validatePaty ] }), 'utf-8-validate should be able to require ws because it is a root dependency')
-  t.doesNotThrow(() => require.resolve('bufferutil', { paths: [ utf8validatePaty ] }), 'utf-8-validate should be able to require bufferutil because it is a root dependency')
+  // tslib can resolve its deps and dependencies of the root
+  t.ok(requireChain('tsutils', 'tslib', 'tslib'), 'tslib can require itself')
+  t.ok(requireChain('tsutils', 'tslib', 'typescript'), 'tslib can resolve typescript because it is a root dependency')
+  t.ok(requireChain('tsutils', 'tslib', 'tsutils'), 'tslib should be able to resolve tsutils because it is a root dependency')
 
-  // foo and ws share the same instance of bufferutil (due to it being a peer dependency)
-  t.same(require.resolve('bufferutil', { paths: [ cwd ] }), require.resolve('bufferutil', { paths: [ wsPath ] }), 'peer dependencies are correctly shared with the parents')
+  // The typescript used by the root and by tsutils is the same because it is a peer dependency
+  t.same(requireChain('typescript'), requireChain('tsutils', 'typescript'), 'typescript used by the root and by tsutils should be the same because it is a peer dependency')
 })
 
 
@@ -113,12 +110,159 @@ tap.test('lock file is same in hoisted and in isolatedMode', async t => {
   t.same(hoistedModeLockFile, isolatedModeLockFile, 'hoited mode and isolated mode produce the same lockfile')
 })
 
+tap.test('basic workspaces setup', async t => {
+  const projectDir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'foo',
+      workspaces: ['bar', 'baz', 'cat', 'fish', 'catfish'],
+      dependencies: {
+        'bar': '*'
+      }
+    }),
+    bar: {
+      'package.json': JSON.stringify({
+        name: 'bar',
+        dependencies: {
+          which: '2.0.2'
+        }
+      })
+    },
+    baz: {
+      'package.json': JSON.stringify({
+        name: 'baz',
+        dependencies: {
+          bar: '*',
+          which: '2.0.2'
+        }
+      }),
+    },
+    cat: {
+      'package.json': JSON.stringify({
+        name: 'cat',
+        dependencies: {
+          which: '2.0.1'
+        }
+      })
+    },
+    fish: {
+      'package.json': JSON.stringify({
+        name: 'fish',
+        dependencies: {
+          cat: '*',
+          which: '2.0.1'
+        }
+      })
+    },
+    catfish: {
+      'package.json': JSON.stringify({
+        name: 'catfish'
+      })
+    }
+  })
+
+  const arborist = new Arborist({ path: projectDir })
+  await arborist.reify({ isolated: true })
+
+  const requireChain = setupRequire(projectDir)
+
+  // TODO: maybe come up with a less verbose / more generic way to specific the assert matrix
+
+  // Only the declared workspace relationships are resolvable
+  // TODO: are workspaces considered declared dependencies of the root? For now we will assume that the answser is no.
+  t.ok(requireChain('bar'), 'repo should be able to require direct dependency to workspace bar')
+  t.notOk(requireChain('baz'), 'repo should not be able to require workspace baz because it has no declared dependency on it')
+  t.notOk(requireChain('cat'), 'repo should not be able to require workspace cat because it has no declared dependency on it')
+  t.notOk(requireChain('fish'), 'repo should not be able to require workspace fish because it has no declared dependency on it')
+  t.notOk(requireChain('catfish'), 'repo should not be able to require workspace catfish because it has no declared dependency on it')
+  t.notOk(requireChain('which'), 'repo should not be able to require which because it has no declared dependency on it')
+  t.notOk(requireChain('isexe'), 'repo should not be able to require isexe because it has no declared dependency on it')
+
+  // workspace bar dependencies
+  // TODO: should workspaces always be able to resolve themselves or only when they are dependencies of the root? For now will will assume that the answer is the latter.
+  t.ok(requireChain('bar', 'bar'), 'workspace bar can require itself because it is a root dependency')
+  t.ok(requireChain('bar', 'baz'), 'workspace bar can require workspace baz because it has a dependency on it')
+  t.notOk(requireChain('bar', 'cat'), 'workspace bar cannot require workspace cat because neither bar nor the root has a dependency on it')
+  t.notOk(requireChain('bar', 'fish'), 'workspace bar cannot require workspace fish because neither bar nor the root has a dependency on it')
+  t.notOk(requireChain('bar', 'catfish'), 'workspace bar cannot require workspace fish because neither bar nor the root has a dependency on it')
+  t.ok(requireChain('bar', 'which'), 'workspace bar can require which because it has a dependency on it')
+  t.notOk(requireChain('bar', 'isexe'), 'workspace bar cannot require isexe because it only has a transitive dependency on it')
+
+  // workspace baz dependencies
+  // TODO: should workspaces always be able to resolve themselves or only when they are dependencies of the root? For now will will assume that the answer is the latter.
+  const requireChainFromBaz = setupRequire(path.join(projectDir, 'baz'))
+  t.ok(requireChainFromBaz('bar'), 'workspace baz can require workspace bar because it is a root dependency')
+  t.notOk(requireChainFromBaz('baz'), 'workspace bar cannot require itself because it is not a root dependency')
+  t.notOk(requireChainFromBaz('cat'), 'workspace baz cannot require workspace cat because neither baz nor the root has a dependency on it')
+  t.notOk(requireChainFromBaz('fish'), 'workspace baz cannot require workspace fish because neither baz nor the root has a dependency on it')
+  t.notOk(requireChainFromBaz('catfish'), 'workspace baz cannot require workspace fish because neither baz nor the root has a dependency on it')
+  t.ok(requireChainFromBaz('which'), 'workspace baz can require which because it has a dependency on it')
+  t.notOk(requireChainFromBaz('isexe'), 'workspace baz cannot require isexe because it only has a transitive dependency on it')
+
+  // workspace cat dependencies
+  const requireChainFromCat = setupRequire(path.join(projectDir, 'cat'))
+  t.ok(requireChainFromCat('bar'), 'workspace cat can require workspace bar because it is a root dependency')
+  t.notOk(requireChainFromCat('baz'), 'workspace bar cannot require workspace baz because neither cat nor the root has a dependency on it')
+  t.notOk(requireChainFromCat('cat'), 'workspace cat cannot require itself because it is not a root dependency')
+  t.notOk(requireChainFromCat('fish'), 'workspace cat cannot require workspace fish because neither cat nor the root has a dependency on it')
+  t.notOk(requireChainFromCat('catfish'), 'workspace cat cannot require workspace fish because neither cat nor the root has a dependency on it')
+  t.ok(requireChainFromCat('which'), 'workspace cat can require which because it has a dependency on it')
+  t.notOk(requireChainFromCat('isexe'), 'workspace cat cannot require isexe because it only has a transitive dependency on it')
+
+  // workspace fish dependencies
+  const requireChainFromFish = setupRequire(path.join(projectDir, 'fish'))
+  t.ok(requireChainFromFish('bar'), 'workspace fish can require workspace bar because it is a root dependency')
+  t.notOk(requireChainFromFish('baz'), 'workspace fish cannot require workspace baz because neither fish nor the root has a dependency on it')
+  t.notOk(requireChainFromFish('cat'), 'workspace fish cannot require workspace cat because neither fish nor the root has a dependency on it')
+  t.notOk(requireChainFromFish('fish'), 'workspace fish cannot require itself because it is not a root dependency')
+  t.notOk(requireChainFromFish('catfish'), 'workspace fish cannot require workspace fish because neither fish nor the root has a dependency on it')
+  t.ok(requireChainFromFish('which'), 'workspace fish can require which because it has a dependency on it')
+  t.notOk(requireChainFromFish('isexe'), 'workspace fish cannot require isexe because it only has a transitive dependency on it')
+
+  // workspace catfish dependencies
+  const requireChainFromCatfish = setupRequire(path.join(projectDir, 'catfish'))
+  t.ok(requireChainFromCatfish('bar'), 'workspace catfish can require workspace bar because it is a root dependency')
+  t.notOk(requireChainFromCatfish('baz'), 'workspace catfish cannot require workspace baz because neither catfish nor the root has a dependency on it')
+  t.notOk(requireChainFromCatfish('cat'), 'workspace catfish cannot require workspace cat because neither catfish nor the root has a dependency on it')
+  t.notOk(requireChainFromCatfish('fish'), 'workspace catfish cannot require itself because neither catfish nor the root has a dependency on it')
+  t.notOk(requireChainFromCatfish('catfish'), 'workspace catfish cannot require itself because it is not a root dependency')
+  t.notOk(requireChainFromCatfish('which'), 'workspace catfish cannot require which because it does not have a dependency on it')
+  t.notOk(requireChainFromCatfish('isexe'), 'workspace catfish cannot require isexe because it only has a transitive dependency on it')
+
+  // versions of which are correctly shared
+  t.same(requireChain('bar', 'which'), requireChainFromBaz('which'), 'bar and baz resolve to the same instance of which')
+  t.same(requireChainFromCat('which'), requireChainFromFish('which'), 'cat and fish resolve to the same instance of which')
+  t.noSame(requireChain('bar', 'which'), requireChainFromFish('which'), 'bar and fish resolve to the a different instance of which')
+
+  // both versions of which can require isexe
+  t.ok(requireChain('bar', 'which', 'isexe'),'bar\'s version of which can require its dependency isexe')
+  t.ok(requireChainFromCat('which', 'isexe'),'cat\'s version of which can require its dependency isexe')
+  t.same(requireChain('bar', 'which', 'isexe'), requireChainFromCat('which', 'isexe'), 'both versions of which share the same instance of their dependency isexe')
+})
+
+function setupRequire(cwd) {
+  return function requireChain(...chain) {
+    return chain.reduce((path, name) => {
+      if (path === undefined) {
+        return undefined
+      }
+      try {
+        return require.resolve(name, { paths: [ path ] })
+      } catch (_) {
+        return undefined
+      }
+    }, cwd)
+  }
+}
+
+/*
+  t.doesNotThrow(() => require.resolve('ws', { paths: [ bufferutilPath ] }), 'bufferutil should be able to require its parent because it is a root dependency')
+  t.throws(() => require.resolve('utf-8-validate', { paths: [ bufferutilPath ] }), 'bufferutil should not be able to require its sibling')
+*/
 /*
   * TO TEST:
   * - chain of peer dependencies
   * - dependency graph with two different versions
   * - failed optional dependency
-  * - workspaces
   * - shinkwrapped dependency
   * - bundled dependencies
   * - deduplication that happen in isolated mode but not in hoisted

--- a/test/isolated-mode.js
+++ b/test/isolated-mode.js
@@ -120,6 +120,7 @@ tap.test('basic workspaces setup', async t => {
       }
     }),
     bar: {
+      'index.js': 'console.log(\'okay\')',
       'package.json': JSON.stringify({
         name: 'bar',
         dependencies: {
@@ -128,6 +129,7 @@ tap.test('basic workspaces setup', async t => {
       })
     },
     baz: {
+      'index.js': 'console.log(\'okay\')',
       'package.json': JSON.stringify({
         name: 'baz',
         dependencies: {
@@ -137,6 +139,7 @@ tap.test('basic workspaces setup', async t => {
       }),
     },
     cat: {
+      'index.js': 'console.log(\'okay\')',
       'package.json': JSON.stringify({
         name: 'cat',
         dependencies: {
@@ -145,6 +148,7 @@ tap.test('basic workspaces setup', async t => {
       })
     },
     fish: {
+      'index.js': 'console.log(\'okay\')',
       'package.json': JSON.stringify({
         name: 'fish',
         dependencies: {
@@ -154,6 +158,7 @@ tap.test('basic workspaces setup', async t => {
       })
     },
     catfish: {
+      'index.js': 'console.log(\'okay\')',
       'package.json': JSON.stringify({
         name: 'catfish'
       })
@@ -231,7 +236,7 @@ tap.test('basic workspaces setup', async t => {
   // versions of which are correctly shared
   t.same(requireChain('bar', 'which'), requireChainFromBaz('which'), 'bar and baz resolve to the same instance of which')
   t.same(requireChainFromCat('which'), requireChainFromFish('which'), 'cat and fish resolve to the same instance of which')
-  t.noSame(requireChain('bar', 'which'), requireChainFromFish('which'), 'bar and fish resolve to the a different instance of which')
+  t.notSame(requireChain('bar', 'which'), requireChainFromFish('which'), 'bar and fish resolve to the a different instance of which')
 
   // both versions of which can require isexe
   t.ok(requireChain('bar', 'which', 'isexe'),'bar\'s version of which can require its dependency isexe')

--- a/test/isolated-mode.js
+++ b/test/isolated-mode.js
@@ -255,10 +255,6 @@ function setupRequire(cwd) {
 }
 
 /*
-  t.doesNotThrow(() => require.resolve('ws', { paths: [ bufferutilPath ] }), 'bufferutil should be able to require its parent because it is a root dependency')
-  t.throws(() => require.resolve('utf-8-validate', { paths: [ bufferutilPath ] }), 'bufferutil should not be able to require its sibling')
-*/
-/*
   * TO TEST:
   * - chain of peer dependencies
   * - dependency graph with two different versions

--- a/test/isolated-mode.js
+++ b/test/isolated-mode.js
@@ -264,7 +264,7 @@ tap.only('Lock file is same in hoisted and in isolated mode', async t => {
   t.same(hoistedModeLockFile, isolatedModeLockFile, 'hoited mode and isolated mode produce the same lockfile')
 })
 
-tap.test('Basic workspaces setup', async t => {
+tap.only('Basic workspaces setup', async t => {
   const graph = {
     registry: [
         { name: 'which', version: '1.0.0', dependencies: { isexe: '^1.0.0' } },
@@ -433,6 +433,7 @@ tap.test('Basic workspaces setup', async t => {
   t.ok(requireChain('bar', 'which', 'isexe'),'bar\'s version of which can require its dependency isexe')
   t.ok(requireChainFromCat('which', 'isexe'),'cat\'s version of which can require its dependency isexe')
   t.same(requireChain('bar', 'which', 'isexe'), requireChainFromCat('which', 'isexe'), 'both versions of which share the same instance of their dependency isexe')
+    */
 })
 
 function setupRequire(cwd) {

--- a/test/isolated-mode.js
+++ b/test/isolated-mode.js
@@ -69,19 +69,19 @@ tap.test('simple peer dependencies scenarios', async t => {
   t.doesNotThrow(() => require.resolve('ws', { paths: [ wsPath ] }), 'ws should be able to require itself')
   t.throws(() => require.resolve('node-gyp-build', { paths: [ wsPath ] }), 'ws should not be able to require transitive dependency to node-gyp-build')
 
-  // bufferutil can resolve its deps and only that
+  // bufferutil can resolve its deps and dependencies of the root
   const bufferutilPath = path.dirname(require.resolve('bufferutil', { paths: [ wsPath ] }))
   t.doesNotThrow(() => require.resolve('node-gyp-build', { paths: [ bufferutilPath ] }), 'bufferutil should be able to require its own dependency to node-gyp-build')
   t.doesNotThrow(() => require.resolve('bufferutil', { paths: [ bufferutilPath ] }), 'bufferutil should be able to require itself')
-  t.throws(() => require.resolve('ws', { paths: [ bufferutilPath ] }), 'bufferutil should not be able to require its parent')
+  t.doesNotThrow(() => require.resolve('ws', { paths: [ bufferutilPath ] }), 'bufferutil should be able to require its parent because it is a root dependency')
   t.throws(() => require.resolve('utf-8-validate', { paths: [ bufferutilPath ] }), 'bufferutil should not be able to require its sibling')
 
-  // utf-8-validate can resolve its deps and only that
+  // utf-8-validate can resolve its deps and dependencies of the root
   const utf8validatePaty = path.dirname(require.resolve('utf-8-validate', { paths: [ wsPath ] }))
   t.doesNotThrow(() => require.resolve('node-gyp-build', { paths: [ utf8validatePaty ] }), 'utf-8-validate should be able to require its own dependency to node-gyp-build')
   t.doesNotThrow(() => require.resolve('utf-8-validate', { paths: [ utf8validatePaty ] }), 'utf-8-validate should be able to require itself')
-  t.throws(() => require.resolve('ws', { paths: [ utf8validatePaty ] }), 'utf-8-validate should not be able to require its parent')
-  t.throws(() => require.resolve('bufferutil', { paths: [ utf8validatePaty ] }), 'utf-8-validate should not be able to require its sibling')
+  t.doesNotThrow(() => require.resolve('ws', { paths: [ utf8validatePaty ] }), 'utf-8-validate should be able to require ws because it is a root dependency')
+  t.doesNotThrow(() => require.resolve('bufferutil', { paths: [ utf8validatePaty ] }), 'utf-8-validate should be able to require bufferutil because it is a root dependency')
 
   // foo and ws share the same instance of bufferutil (due to it being a peer dependency)
   t.same(require.resolve('bufferutil', { paths: [ cwd ] }), require.resolve('bufferutil', { paths: [ wsPath ] }), 'peer dependencies are correctly shared with the parents')

--- a/test/isolated-mode.js
+++ b/test/isolated-mode.js
@@ -86,3 +86,24 @@ tap.test('simple peer dependencies scenarios', async t => {
   // foo and ws share the same instance of bufferutil (due to it being a peer dependency)
   t.same(require.resolve('bufferutil', { paths: [ cwd ] }), require.resolve('bufferutil', { paths: [ wsPath ] }), 'peer dependencies are correctly shared with the parents')
 })
+
+
+/*
+  * TO TEST:
+  * - chain of peer dependencies
+  * - dependency graph with two different versions
+  * - failed optional dependency
+  * - workspaces
+  * - shinkwrapped dependency
+  * - bundled dependencies
+  * - deduplication that happen in isolated mode but not in hoisted
+  * - circular dependencies
+  * - circular peer dependencies
+  * - peer dependencies on the parent
+  * - maybe some more convoluted cases copied from other existing tests
+  * - case that result in a ERESOLVE error
+  * - repos that are already partially installed (the case of `npm install --save-dev react`)
+  * - the lock file is the same in hoisting and isolated mode
+  * - the versions resolved in isolated mode are the same that would have been resolved in hoisting mode
+  *
+  */

--- a/test/isolated-mode.js
+++ b/test/isolated-mode.js
@@ -795,7 +795,7 @@ tap.test('circular dependencies', async t => {
   rule7.apply(t, dir, resolved, asserted)
 })
 
-tap.only('circular peer dependencies', async t => {
+tap.test('circular peer dependencies', async t => {
 
   // Input of arborist
   const graph = {
@@ -837,6 +837,44 @@ tap.only('circular peer dependencies', async t => {
   rule7.apply(t, dir, resolved, asserted)
 })
 
+tap.test('peer dependency on parent', async t => {
+
+  // Input of arborist
+  const graph = {
+    registry: [
+      { name: 'cat', version: '1.0.0', dependencies: { bar: '*' } },
+      { name: 'bar', version: '1.0.0', peerDependencies: { cat: '*' } }
+    ] ,
+    root: {
+      name: 'foo', version: '1.2.3', dependencies: { cat: '1.0.0' }
+    }
+  }
+
+  // expected output
+  const resolved = {
+    'foo@1.2.3 (root)': {
+      'cat@1.0.0': {
+        'bar@1.0.0': '(back 1)' 
+      }
+    }
+  }
+
+  const { dir, registry } = await getRepo(graph)
+
+  // Note that we override this cache to prevent interference from other tests
+  const cache = fs.mkdtempSync(`${os.tmpdir}/test-`)
+  const arborist = new Arborist({ path: dir, registry, packumentCache: new Map(), cache  })
+  await arborist.reify({ isolated: true })
+
+  const asserted = new Set()
+  rule1.apply(t, dir, resolved, asserted)
+  rule2.apply(t, dir, resolved, asserted)
+  rule3.apply(t, dir, resolved, asserted)
+  rule4.apply(t, dir, resolved, asserted)
+  rule5.apply(t, dir, resolved, asserted)
+  rule6.apply(t, dir, resolved, asserted)
+  rule7.apply(t, dir, resolved, asserted)
+})
 function setupRequire(cwd) {
   return function requireChain(...chain) {
     return chain.reduce((path, name) => {
@@ -954,7 +992,6 @@ function parseGraphRecursive(key, deps) {
 
 /*
   * TO TEST:
-  * - peer dependencies on the parent
   * - scoped packages
   * - optional peer dependency
   * - virtual packages

--- a/test/isolated-mode.js
+++ b/test/isolated-mode.js
@@ -4,7 +4,7 @@ const path = require('path')
 const Arborist = require('../lib/arborist')
 
 tap.test('most simple happy scenario', async t => {
-  const package = { name: 'foo', dependencies: { 'which': '*' } }
+  const package = { name: 'foo', dependencies: { 'which': '2.0.2' } }
 
   const cwd = t.testdir({
     'package.json': JSON.stringify(package)

--- a/test/isolated-mode.js
+++ b/test/isolated-mode.js
@@ -568,6 +568,50 @@ tap.test('bundled dependencies', async t => {
   rule7.apply(t, dir, resolved, asserted)
 })
 
+tap.only('adding a dependency', async t => {
+  // Input of arborist
+  const graph = {
+    registry: [
+      { name: 'which', version: '1.0.0', dependencies: { isexe: '^1.0.0' } },
+      { name: 'isexe', version: '1.0.0' },
+      { name: 'bar', version: '2.2.0' }
+    ] ,
+    root: {
+      name: 'foo', version: '1.2.3', dependencies: { which: '1.0.0' }
+    }
+  }
+
+  // expected output
+  const resolved = {
+    'foo@1.2.3 (root)': {
+      'which@1.0.0': {
+        'isexe@1.0.0': {}
+      },
+      'bar@2.2.0': {}
+    }
+  }
+
+  const { dir, registry } = await getRepo(graph)
+
+  // Note that we override this cache to prevent interference from other tests
+  const cache = fs.mkdtempSync(`${os.tmpdir}/test-`)
+  const arborist = new Arborist({ path: dir, registry, packumentCache: new Map(), cache  })
+  await arborist.reify({ isolated: true })
+
+  // Add a new dependency
+
+  const cache2 = fs.mkdtempSync(`${os.tmpdir}/test-`)
+  const arborist2 = new Arborist({ path: dir, registry, packumentCache: new Map(), cache: cache2, add: [ 'bar@^2.0.0' ]  })
+  await arborist2.reify({ isolated: true })
+
+  const asserted = new Set()
+  rule1.apply(t, dir, resolved, asserted)
+  rule2.apply(t, dir, resolved, asserted)
+  rule3.apply(t, dir, resolved, asserted)
+  rule4.apply(t, dir, resolved, asserted)
+  rule7.apply(t, dir, resolved, asserted)
+
+})
 function setupRequire(cwd) {
   return function requireChain(...chain) {
     return chain.reduce((path, name) => {

--- a/test/isolated-mode.js
+++ b/test/isolated-mode.js
@@ -6,6 +6,14 @@ const Arborist = require('../lib/arborist')
 tap.test('most simple happy scenario', async t => {
   const package = { name: 'foo', dependencies: { 'which': '2.0.2' } }
 
+  /*
+    *
+    * Dependency graph:
+    * 
+    * foo -> which -> isexe
+    *
+    */
+
   const cwd = t.testdir({
     'package.json': JSON.stringify(package)
   })
@@ -21,4 +29,60 @@ tap.test('most simple happy scenario', async t => {
   const whichPath = path.dirname(require.resolve("which", { paths: [ cwd ] }))
   t.doesNotThrow(() => require.resolve('isexe', { paths: [ whichPath ] }), 'external dependencies should be able to require their own dependencies')
 
+  const isexePath = require.resolve('isexe', { paths: [ whichPath ] })
+  t.throws(() => require.resolve('which', { paths: [ isexePath ] }), 'dependencies are not able to require their parents')
+})
+
+tap.test('simple peer dependencies scenarios', async t => {
+  const package = { name: 'foo', dependencies: { 'ws': '7.5.2', 'bufferutil': '4.0.1' } }
+
+  /*
+    * Dependencies:
+    *
+    * foo -> ws
+    *        ws -> bufferutil (peer dep)
+    *              bufferutil -> node-gyp-build
+    *        ws -> utf-8-validate (peer dep)
+    *              utf8-validate -> node-gyp-build
+    * foo -> bufferutil
+    *        bufferutil -> node-gyp-build
+    *
+    */
+
+  const cwd = t.testdir({
+    'package.json': JSON.stringify(package)
+  })
+
+  const arborist = new Arborist({ path: cwd })
+  await arborist.reify({ isolated: true })
+
+  // Only direct dependencies are accessible by the node-module resolution algorithm
+  t.doesNotThrow(() => require.resolve('ws', { paths: [ cwd ] }), 'repo should be able to require direct dependency to ws')
+  t.doesNotThrow(() => require.resolve('bufferutil', { paths: [ cwd ] }), 'repo should be able to require direct dependency to bufferutil')
+  t.throws(() => require.resolve('node-gyp-build', { paths: [ cwd ] }), 'repo should not be able to require transitive dependency to node-gyp-build')
+  t.throws(() => require.resolve('utf-8-validate', { paths: [ cwd ] }), 'repo should not be able to require transitive dependency to utf-8-validate')
+
+  // ws can only require its direct dependencies
+  const wsPath = path.dirname(require.resolve('ws', { paths: [ cwd ] }))
+  t.doesNotThrow(() => require.resolve('bufferutil', { paths: [ wsPath ] }), 'ws should be able to require its own peer dependency to bufferutil')
+  t.doesNotThrow(() => require.resolve('utf-8-validate', { paths: [ wsPath ] }), 'ws should be able to require its own peer dependency to utf-8-validate')
+  t.doesNotThrow(() => require.resolve('ws', { paths: [ wsPath ] }), 'ws should be able to require itself')
+  t.throws(() => require.resolve('node-gyp-build', { paths: [ wsPath ] }), 'ws should not be able to require transitive dependency to node-gyp-build')
+
+  // bufferutil can resolve its deps and only that
+  const bufferutilPath = path.dirname(require.resolve('bufferutil', { paths: [ wsPath ] }))
+  t.doesNotThrow(() => require.resolve('node-gyp-build', { paths: [ bufferutilPath ] }), 'bufferutil should be able to require its own dependency to node-gyp-build')
+  t.doesNotThrow(() => require.resolve('bufferutil', { paths: [ bufferutilPath ] }), 'bufferutil should be able to require itself')
+  t.throws(() => require.resolve('ws', { paths: [ bufferutilPath ] }), 'bufferutil should not be able to require its parent')
+  t.throws(() => require.resolve('utf-8-validate', { paths: [ bufferutilPath ] }), 'bufferutil should not be able to require its sibling')
+
+  // utf-8-validate can resolve its deps and only that
+  const utf8validatePaty = path.dirname(require.resolve('utf-8-validate', { paths: [ wsPath ] }))
+  t.doesNotThrow(() => require.resolve('node-gyp-build', { paths: [ utf8validatePaty ] }), 'utf-8-validate should be able to require its own dependency to node-gyp-build')
+  t.doesNotThrow(() => require.resolve('utf-8-validate', { paths: [ utf8validatePaty ] }), 'utf-8-validate should be able to require itself')
+  t.throws(() => require.resolve('ws', { paths: [ utf8validatePaty ] }), 'utf-8-validate should not be able to require its parent')
+  t.throws(() => require.resolve('bufferutil', { paths: [ utf8validatePaty ] }), 'utf-8-validate should not be able to require its sibling')
+
+  // foo and ws share the same instance of bufferutil (due to it being a peer dependency)
+  t.same(require.resolve('bufferutil', { paths: [ cwd ] }), require.resolve('bufferutil', { paths: [ wsPath ] }), 'peer dependencies are correctly shared with the parents')
 })

--- a/test/isolated-mode.js
+++ b/test/isolated-mode.js
@@ -72,7 +72,7 @@ const rule3 = {
         if (alreadyAsserted.has(key)) { return }
         alreadyAsserted.add(key)
         t.ok(path.join(dir, p.initialDir),
-          `Rule 3: ${p.chain.length === 0 && p.initialDir === '.' ? "The root" : `Package "${[p.initialDir, ...p.chain].join(" => ")}"`} should have access to "${d}" because it is a root dependency.`)
+          `Rule 3: ${p.chain.length === 0 && p.initialDir === '.' ? "The root" : `Package "${[p.initialDir.replace('packages/',''), ...p.chain].join(" => ")}"`} should have access to "${d}" because it is a root dependency.`)
       })
     })
   }
@@ -358,7 +358,7 @@ tap.only('Basic workspaces setup', async t => {
   const asserted = new Set()
   rule1.apply(t, dir, resolved, asserted)
   rule2.apply(t, dir, resolved, asserted)
-//  rule3.apply(t, dir, resolved, asserted)
+  rule3.apply(t, dir, resolved, asserted)
 //  rule4.apply(t, dir, resolved, asserted)
 
 
@@ -374,7 +374,6 @@ tap.only('Basic workspaces setup', async t => {
 
   // workspace bar dependencies
   // TODO: should workspaces always be able to resolve themselves or only when they are dependencies of the root? For now will will assume that the answer is the latter.
-  t.ok(requireChain('bar', 'bar'), 'workspace bar can require itself because it is a root dependency')
   t.notOk(requireChain('bar', 'cat'), 'workspace bar cannot require workspace cat because neither bar nor the root has a dependency on it')
   t.notOk(requireChain('bar', 'fish'), 'workspace bar cannot require workspace fish because neither bar nor the root has a dependency on it')
   t.notOk(requireChain('bar', 'catfish'), 'workspace bar cannot require workspace fish because neither bar nor the root has a dependency on it')
@@ -383,7 +382,6 @@ tap.only('Basic workspaces setup', async t => {
   // workspace baz dependencies
   // TODO: should workspaces always be able to resolve themselves or only when they are dependencies of the root? For now will will assume that the answer is the latter.
   const requireChainFromBaz = setupRequire(path.join(projectDir, 'baz'))
-  t.ok(requireChainFromBaz('bar'), 'workspace baz can require workspace bar because it is a root dependency')
   t.notOk(requireChainFromBaz('baz'), 'workspace bar cannot require itself because it is not a root dependency')
   t.notOk(requireChainFromBaz('cat'), 'workspace baz cannot require workspace cat because neither baz nor the root has a dependency on it')
   t.notOk(requireChainFromBaz('fish'), 'workspace baz cannot require workspace fish because neither baz nor the root has a dependency on it')
@@ -392,7 +390,6 @@ tap.only('Basic workspaces setup', async t => {
 
   // workspace cat dependencies
   const requireChainFromCat = setupRequire(path.join(projectDir, 'cat'))
-  t.ok(requireChainFromCat('bar'), 'workspace cat can require workspace bar because it is a root dependency')
   t.notOk(requireChainFromCat('baz'), 'workspace bar cannot require workspace baz because neither cat nor the root has a dependency on it')
   t.notOk(requireChainFromCat('cat'), 'workspace cat cannot require itself because it is not a root dependency')
   t.notOk(requireChainFromCat('fish'), 'workspace cat cannot require workspace fish because neither cat nor the root has a dependency on it')
@@ -401,7 +398,6 @@ tap.only('Basic workspaces setup', async t => {
 
   // workspace fish dependencies
   const requireChainFromFish = setupRequire(path.join(projectDir, 'fish'))
-  t.ok(requireChainFromFish('bar'), 'workspace fish can require workspace bar because it is a root dependency')
   t.notOk(requireChainFromFish('baz'), 'workspace fish cannot require workspace baz because neither fish nor the root has a dependency on it')
   t.notOk(requireChainFromFish('cat'), 'workspace fish cannot require workspace cat because neither fish nor the root has a dependency on it')
   t.notOk(requireChainFromFish('fish'), 'workspace fish cannot require itself because it is not a root dependency')
@@ -410,7 +406,6 @@ tap.only('Basic workspaces setup', async t => {
 
   // workspace catfish dependencies
   const requireChainFromCatfish = setupRequire(path.join(projectDir, 'catfish'))
-  t.ok(requireChainFromCatfish('bar'), 'workspace catfish can require workspace bar because it is a root dependency')
   t.notOk(requireChainFromCatfish('baz'), 'workspace catfish cannot require workspace baz because neither catfish nor the root has a dependency on it')
   t.notOk(requireChainFromCatfish('cat'), 'workspace catfish cannot require workspace cat because neither catfish nor the root has a dependency on it')
   t.notOk(requireChainFromCatfish('fish'), 'workspace catfish cannot require itself because neither catfish nor the root has a dependency on it')

--- a/test/isolated-mode.js
+++ b/test/isolated-mode.js
@@ -138,8 +138,6 @@ const rule6 = {
 }
 
 tap.only('most simple happy scenario', async t => {
-  const package = { name: 'foo', dependencies: { 'which': '2.0.2' } }
-
   /*
     *
     * Dependency graph:
@@ -382,6 +380,7 @@ tap.only('Basic workspaces setup', async t => {
   rule2.apply(t, dir, resolved, asserted)
   rule3.apply(t, dir, resolved, asserted)
   rule4.apply(t, dir, resolved, asserted)
+  rule5.apply(t, dir, resolved, asserted)
   rule6.apply(t, dir, resolved, asserted)
 
   /*
@@ -455,13 +454,13 @@ function withRequireChainRecursive(resolvedGraph, chain, initialDir) {
   * - failed optional dependency
   * - shinkwrapped dependency
   * - bundled dependencies
-  * - deduplication that happen in isolated mode but not in hoisted
   * - circular dependencies
   * - circular peer dependencies
   * - peer dependencies on the parent
   * - maybe some more convoluted cases copied from other existing tests
   * - case that result in a ERESOLVE error
   * - repos that are already partially installed (the case of `npm install --save-dev react`)
+  * - scoped installs
   * - the versions resolved in isolated mode are the same that would have been resolved in hoisting mode
   *
   */

--- a/test/isolated-mode.js
+++ b/test/isolated-mode.js
@@ -88,6 +88,31 @@ tap.test('simple peer dependencies scenarios', async t => {
 })
 
 
+tap.test('lock file is same in hoisted and in isolatedMode', async t => {
+  const package = { name: 'foo', dependencies: { 'which': '2.0.2' } }
+
+  const hoistedModeDir = t.testdir({
+    'package.json': JSON.stringify(package)
+  })
+  const isolatedModeDir = t.testdir({
+    'package.json': JSON.stringify(package)
+  })
+  const arboristHoisted = new Arborist({ path: hoistedModeDir })
+  const arboristIsolated = new Arborist({ path: isolatedModeDir })
+
+  await Promise.all([
+    arboristHoisted.reify({ isolated: false }),
+    arboristIsolated.reify({ isolated: true }),
+  ])
+
+  const [hoistedModeLockFile, isolatedModeLockFile] = await Promise.all([
+    fs.promises.readFile(path.join(hoistedModeDir, 'package-lock.json'), { encoding: 'utf8' }),
+    fs.promises.readFile(path.join(isolatedModeDir, 'package-lock.json'), { encoding: 'utf8' }),
+  ])
+
+  t.same(hoistedModeLockFile, isolatedModeLockFile, 'hoited mode and isolated mode produce the same lockfile')
+})
+
 /*
   * TO TEST:
   * - chain of peer dependencies
@@ -103,7 +128,6 @@ tap.test('simple peer dependencies scenarios', async t => {
   * - maybe some more convoluted cases copied from other existing tests
   * - case that result in a ERESOLVE error
   * - repos that are already partially installed (the case of `npm install --save-dev react`)
-  * - the lock file is the same in hoisting and isolated mode
   * - the versions resolved in isolated mode are the same that would have been resolved in hoisting mode
   *
   */

--- a/test/nock.js
+++ b/test/nock.js
@@ -1,0 +1,54 @@
+const nock = require('nock')
+const tar = require('tar-stream')
+const Stream = require('stream')
+
+const packument = {
+  name: 'foo',
+  'dist-tags': {
+    latest: '1.0.0',
+  },
+  versions: {
+    '1.0.0': {
+      'name': 'foo',
+      'version': '1.0.0'
+    }
+  }
+}
+
+nock('registry.npmjs.org')
+  .persist()
+  .get(`/foo`)
+  .reply(200, packument)
+
+const pack = tar.pack()
+
+pack.entry({ name: 'package.json' }, JSON.stringify({
+  name: 'foo',
+  version: '1.0.0'
+}))
+pack.entry({ name: 'index.js' }, 'console.log("Hello World!")')
+
+
+class ToBuffer extends Stream.Writable {
+  constructor(opts) {
+    super(opts)
+    this.bufferArray = []
+  }
+  _write(chunk, encoding, callback) {
+    this.bufferArray.push(chunk)
+    callback()
+  }
+  _final(callback) {
+    this.finalBuffer = Buffer.concat(this.bufferArray)
+    callback()
+  }
+}
+
+pack.finalize()
+
+const tarBuffer = pack.pipe(new ToBuffer())
+tarBuffer.on('close', () => {
+  console.log('the buffer is closed')
+  console.log(tarBuffer.finalBuffer.toString('utf-8'))
+})
+

--- a/test/nock.js
+++ b/test/nock.js
@@ -39,19 +39,19 @@ function packPackageToStream (manifest, reg) {
     ...rest
   })
   const index = `console.log('Hello from ${name}@${version}!')`
-
-  pack.entry({ name, type: 'directory' })
-  pack.entry({ name: `${name}/package.json` }, manifestString)
-  pack.entry({ name: `${name}/index.js` }, index)
+  const unscopedName = name.replace(/^@[^\/]*\//,'')
+  pack.entry({ name: unscopedName, type: 'directory' })
+  pack.entry({ name: `${unscopedName}/package.json` }, manifestString)
+  pack.entry({ name: `${unscopedName}/index.js` }, index)
   if (shrinkwrap) {
-    pack.entry({ name: `${name}/npm-shrinkwrap.json` }, shrinkwrap.replace(/##REG##/g, reg))
+    pack.entry({ name: `${unscopedName}/npm-shrinkwrap.json` }, shrinkwrap.replace(/##REG##/g, reg))
   }
   if (bundledDeps) {
-    pack.entry({ name: `${name}/node_modules`, type: 'directory' })
+    pack.entry({ name: `${unscopedName}/node_modules`, type: 'directory' })
     bundledDeps.forEach(d => {
-      pack.entry({ name: `${name}/node_modules/${d.name}`, type: 'directory' })
-      pack.entry({ name: `${name}/node_modules/${d.name}/package.json` }, JSON.stringify(d))
-      pack.entry({ name: `${name}/node_modules/${d.name}/index.js` }, `console.log('Hello from ${d.name}@${d.version}!')`
+      pack.entry({ name: `${unscopedName}/node_modules/${d.name}`, type: 'directory' })
+      pack.entry({ name: `${unscopedName}/node_modules/${d.name}/package.json` }, JSON.stringify(d))
+      pack.entry({ name: `${unscopedName}/node_modules/${d.name}/index.js` }, `console.log('Hello from ${d.name}@${d.version}!')`
 )
     })
   }

--- a/test/nock.js
+++ b/test/nock.js
@@ -1,54 +1,140 @@
 const nock = require('nock')
 const tar = require('tar-stream')
 const Stream = require('stream')
+const tap = require('tap')
+const fs = require('fs')
 
-const packument = {
-  name: 'foo',
-  'dist-tags': {
-    latest: '1.0.0',
-  },
-  versions: {
-    '1.0.0': {
-      'name': 'foo',
-      'version': '1.0.0'
+/* Utility to extract a buffer out of a stream */
+class StreamToBuffer extends Stream.Writable {
+  constructor (opts) {
+    super(opts)
+    this._bufferArray = []
+  }
+
+  _write (chunk, encoding, callback) {
+    this._bufferArray.push(chunk)
+    callback()
+  }
+
+  _final (callback) {
+    this.buffer = Buffer.concat(this._bufferArray)
+    callback()
+  }
+}
+
+/**
+ * packPackageToStream
+ * Uses 'tar-stream' to create the tar stream without touching the file system.
+ */
+function packPackageToStream (name, version, dependencies) {
+  const pack = tar.pack()
+  const manifest = JSON.stringify({
+    name,
+    version,
+    dependencies
+  })
+  const index = `console.log('Hello from ${name}@${version}!')`
+
+  pack.entry({ name, type: 'directory' })
+  pack.entry({ name: `${name}/package.json` }, manifest)
+  pack.entry({ name: `${name}/index.js` }, index)
+
+  pack.finalize()
+  return pack
+}
+
+
+/**
+ * Pack a package for publish.
+ * Returns a buffer containing a tarball of the package.
+ */
+async function packPackage (name, version, dependencies) {
+  const packStream = packPackageToStream(name, version, dependencies)
+
+  const tarBuffer = packStream.pipe(new StreamToBuffer())
+
+  return new Promise((resolve, reject) => {
+    tarBuffer.on('close', () => {
+      resolve(tarBuffer.buffer)
+    })
+    tarBuffer.on('error', reject)
+  })
+}
+
+/**
+ * Publish the given package to the given registry.
+ */
+async function publishPackage (registry, name, version, dependencies) {
+  const packument = {
+    name,
+    'dist-tags': {
+      latest: version
+    },
+    versions: {
+      [version]: {
+        name,
+        version,
+        dependencies,
+        dist: {
+          tarball: `${registry}/${name}/${version}.tar`
+        }
+      }
     }
   }
+
+  const tarball = await packPackage(name, version, dependencies)
+
+  nock(registry)
+    .get(`/${name}`)
+    .reply(200, packument)
+    .get(`/${name}/${version}.tar`)
+    .reply(200, tarball)
 }
 
-nock('registry.npmjs.org')
-  .persist()
-  .get(`/foo`)
-  .reply(200, packument)
+/**
+ * Given an object decribing a dependency graph, this funcion will materialize
+ * this dependency graph on disk and in a registry.
+ * 
+ * The input has the following shape:
+ * {
+ *   registry: [ package1, package2,... ],
+ *   root: { name: <name>, version: <version>, dependencies: <dependencies> }
+ * }
+ * package# represent a registry package and is of the following shape: 
+ * { name: <name>, version: <version>, dependencies?: <dependencies> }
+ *
+ * The return value is of the form { dir, registry } where:
+ * - dir is the location on disk of the root package
+ * - registry is the url of the registry which has the necessary packages
+ *
+ * Only simple graphs are currenly supported, the following features will come in further iterations:
+ * - workspaces
+ * - dev and peer dependencies
+ * - multiple versions of the same package
+ * - lockfile
+ * - shinkwrap
+ * - bundled dependencies
+ *
+ * The API of this function is not stable and is likely to evolve as we add more features.  
+ */
+async function getRepo (graph) {
+  // Generate a new random registry every time to prevent interference between tests
+  const registry = `https://${Math.random().toString(36).substring(2)}.test`
+  
+  // Publish all the registery packages
+  await Promise.all(graph.registry.map(o => 
+    publishPackage(registry, o.name, o.version, o.dependencies)))
 
-const pack = tar.pack()
-
-pack.entry({ name: 'package.json' }, JSON.stringify({
-  name: 'foo',
-  version: '1.0.0'
-}))
-pack.entry({ name: 'index.js' }, 'console.log("Hello World!")')
-
-
-class ToBuffer extends Stream.Writable {
-  constructor(opts) {
-    super(opts)
-    this.bufferArray = []
-  }
-  _write(chunk, encoding, callback) {
-    this.bufferArray.push(chunk)
-    callback()
-  }
-  _final(callback) {
-    this.finalBuffer = Buffer.concat(this.bufferArray)
-    callback()
-  }
+  // Generate the root of the graph on disk
+  const root = graph.root
+  const dir = tap.testdir({
+    'package.json': JSON.stringify({
+      name: root.name,
+      version: root.version,
+      dependencies: root.dependencies
+    })
+  })
+  return { dir, registry }
 }
 
-pack.finalize()
-
-const tarBuffer = pack.pipe(new ToBuffer())
-tarBuffer.on('close', () => {
-  console.log('the buffer is closed')
-  console.log(tarBuffer.finalBuffer.toString('utf-8'))
-})
-
+exports.getRepo = getRepo

--- a/test/nock.js
+++ b/test/nock.js
@@ -136,9 +136,6 @@ async function publishPackage (registry, manifest, packuments) {
  * - registry is the url of the registry which has the necessary packages
  *
  * Only simple graphs are currenly supported, the following features will come in further iterations:
- * - workspaces
- * - dev and peer dependencies
- * - multiple versions of the same package
  * - lockfile
  * - shinkwrap
  * - bundled dependencies

--- a/test/nock.js
+++ b/test/nock.js
@@ -92,7 +92,7 @@ async function publishPackage (registry, manifest, packuments) {
     packuments.get(name).versions[version] = {
       ...rest,
       dist: {
-        tarball: `${registry}/${name}/${version}.tar`
+        tarball: `${registry}/${name.replace(/\//g,'-')}/${version}.tar`
       }
     }
   } else {
@@ -105,7 +105,7 @@ async function publishPackage (registry, manifest, packuments) {
         [version]: {
           ...rest,
           dist: {
-            tarball: `${registry}/${name}/${version}.tar`
+            tarball: `${registry}/${name.replace(/\//g,'-')}/${version}.tar`
           }
         }
       }
@@ -117,7 +117,7 @@ async function publishPackage (registry, manifest, packuments) {
 
   nock(registry)
     .persist()
-    .get(`/${name}/${version}.tar`)
+    .get(`/${name.replace(/\//g,'-')}/${version}.tar`)
     .reply(200, tarball)
 }
 
@@ -155,7 +155,7 @@ async function getRepo (graph) {
 
   packuments.forEach((packument, name) => {
     nock(registry)
-      .get(`/${name}`)
+      .get(`/${name.replace(/\//g,'%2f')}`)
       .reply(200, packument)
   })
 

--- a/test/nock.js
+++ b/test/nock.js
@@ -180,6 +180,7 @@ async function getRepo (graph) {
         version: wp.version,
         dependencies: wp.dependencies
       }),
+      'index.js': `console.log('Hello from workspace ${wp.name}')`
     }
   })
   const dir = tap.testdir(repo)

--- a/test/nock.js
+++ b/test/nock.js
@@ -142,7 +142,7 @@ async function publishPackage (registry, manifest, packuments) {
  *
  * The API of this function is not stable and is likely to evolve as we add more features.  
  */
-async function getRepo (graph) {
+async function getRepo (t, graph) {
   // Generate a new random registry every time to prevent interference between tests
   const registry = `https://${Math.random().toString(36).substring(2)}.test`
   
@@ -180,7 +180,7 @@ async function getRepo (graph) {
       'index.js': `console.log('Hello from workspace ${wp.name}')`
     }
   })
-  const dir = tap.testdir(repo)
+  const dir = t.testdir(repo)
   return { dir, registry }
 }
 


### PR DESCRIPTION
This PR only aims to get early feedback on the new "graph mocking" utility.

The goal of this utility is to make it easy to declaratively create a dependency graph to run tests against.
This aims at replacing the flow of manually publishing testing packages to the npmjs registry.