### PR TITLE
feat: add logfile option to bin

### DIFF
--- a/bin/funding.js
+++ b/bin/funding.js
@@ -1,34 +1,38 @@
-const options = require('./lib/options.js')
-require('./lib/logging.js')
-require('./lib/timers.js')
-
 const Arborist = require('../')
-const a = new Arborist(options)
-const query = options._.shift()
-const start = process.hrtime()
-a.loadVirtual().then(tree => {
-  // only load the actual tree if the virtual one doesn't have modern metadata
-  if (!tree.meta || !(tree.meta.originalLockfileVersion >= 2)) {
-    console.error('old metadata, load actual')
-    throw 'load actual'
-  } else {
-    console.error('meta ok, return virtual tree')
-    return tree
-  }
-}).catch(() => a.loadActual()).then(tree => {
-  const end = process.hrtime(start)
-  if (!query) {
-    for (const node of tree.inventory.values()) {
-      if (node.package.funding) {
-        console.log(node.name, node.location, node.package.funding)
+
+const log = require('./lib/logging.js')
+
+module.exports = (options, time) => {
+  const query = options._.shift()
+  const a = new Arborist(options)
+  return a
+    .loadVirtual()
+    .then(tree => {
+      // only load the actual tree if the virtual one doesn't have modern metadata
+      if (!tree.meta || !(tree.meta.originalLockfileVersion >= 2)) {
+        log.error('old metadata, load actual')
+        throw 'load actual'
+      } else {
+        log.error('meta ok, return virtual tree')
+        return tree
       }
-    }
-  } else {
-    for (const node of tree.inventory.query('name', query)) {
-      if (node.package.funding) {
-        console.log(node.name, node.location, node.package.funding)
+    })
+    .catch(() => a.loadActual())
+    .then(time)
+    .then(({ timing, result: tree }) => {
+      if (!query) {
+        for (const node of tree.inventory.values()) {
+          if (node.package.funding) {
+            log.info(node.name, node.location, node.package.funding)
+          }
+        }
+      } else {
+        for (const node of tree.inventory.query('name', query)) {
+          if (node.package.funding) {
+            log.info(node.name, node.location, node.package.funding)
+          }
+        }
       }
-    }
-  }
-  console.error(`read ${tree.inventory.size} deps in ${end[0] * 1000 + end[1] / 1e6}ms`)
-})
+      return `read ${tree.inventory.size} deps in ${timing.ms}`
+    })
+}

--- a/bin/ideal.js
+++ b/bin/ideal.js
@@ -1,21 +1,14 @@
 const Arborist = require('../')
 
-const { inspect } = require('util')
-const options = require('./lib/options.js')
-const print = require('./lib/print-tree.js')
-require('./lib/logging.js')
-require('./lib/timers.js')
+const printTree = require('./lib/print-tree.js')
 
-const start = process.hrtime()
-new Arborist(options).buildIdealTree(options).then(tree => {
-  const end = process.hrtime(start)
-  print(tree)
-  console.error(`resolved ${tree.inventory.size} deps in ${end[0] + end[1] / 10e9}s`)
-  if (tree.meta && options.save) {
-    tree.meta.save()
-  }
-}).catch(er => {
-  const opt = { depth: Infinity, color: true }
-  console.error(er.code === 'ERESOLVE' ? inspect(er, opt) : er)
-  process.exitCode = 1
-})
+module.exports = (options, time) => new Arborist(options)
+  .buildIdealTree(options)
+  .then(time)
+  .then(async ({ timing, result: tree }) => {
+    printTree(tree)
+    if (tree.meta && options.save) {
+      await tree.meta.save()
+    }
+    return `resolved ${tree.inventory.size} deps in ${timing.seconds}`
+  })

--- a/bin/lib/options.js
+++ b/bin/lib/options.js
@@ -1,7 +1,10 @@
+const [cmd] = process.argv.splice(2, 1)
+
 const options = module.exports = {
   path: undefined,
   cache: `${process.env.HOME}/.npm/_cacache`,
   _: [],
+  cmd,
 }
 
 for (const arg of process.argv.slice(2)) {
@@ -55,5 +58,3 @@ for (const arg of process.argv.slice(2)) {
 if (options.path === undefined) {
   options.path = '.'
 }
-
-console.error(options)

--- a/bin/lib/print-tree.js
+++ b/bin/lib/print-tree.js
@@ -1,5 +1,4 @@
 const { inspect } = require('util')
-const { quiet } = require('./options.js')
+const log = require('./logging.js')
 
-module.exports = quiet ? () => {}
-  : tree => console.log(inspect(tree.toJSON(), { depth: Infinity }))
+module.exports = tree => log.info(inspect(tree.toJSON(), { depth: Infinity }))

--- a/bin/lib/timers.js
+++ b/bin/lib/timers.js
@@ -1,6 +1,7 @@
 const timers = Object.create(null)
 const { format } = require('util')
 const options = require('./options.js')
+const log = require('./logging.js')
 
 process.on('time', name => {
   if (timers[name]) {
@@ -9,23 +10,20 @@ process.on('time', name => {
   timers[name] = process.hrtime()
 })
 
-const dim = process.stderr.isTTY ? msg => `\x1B[2m${msg}\x1B[22m` : m => m
-const red = process.stderr.isTTY ? msg => `\x1B[31m${msg}\x1B[39m` : m => m
 process.on('timeEnd', name => {
   if (!timers[name]) {
     throw new Error('timer not started! ' + name)
   }
   const res = process.hrtime(timers[name])
   delete timers[name]
-  const msg = format(`${process.pid} ${name}`, res[0] * 1e3 + res[1] / 1e6)
   if (options.timers !== false) {
-    console.error(dim(msg))
+    log.info('timeEnd', format(`${name}`, res[0] * 1e3 + res[1] / 1e6) + 's')
   }
 })
 
 process.on('exit', () => {
   for (const name of Object.keys(timers)) {
-    console.error(red('Dangling timer:'), name)
+    log.error('timeError', 'Dangling timer:', name)
     process.exitCode = 1
   }
 })

--- a/bin/license.js
+++ b/bin/license.js
@@ -1,38 +1,48 @@
 const Arborist = require('../')
-const options = require('./lib/options.js')
-require('./lib/logging.js')
-require('./lib/timers.js')
 
-const a = new Arborist(options)
-const query = options._.shift()
+const log = require('./lib/logging.js')
 
-a.loadVirtual().then(tree => {
-  // only load the actual tree if the virtual one doesn't have modern metadata
-  if (!tree.meta || !(tree.meta.originalLockfileVersion >= 2)) {
-    throw 'load actual'
-  } else {
-    return tree
-  }
-}).catch((er) => {
-  console.error('loading actual tree', er)
-  return a.loadActual()
-}).then(tree => {
-  if (!query) {
-    const set = []
-    for (const license of tree.inventory.query('license')) {
-      set.push([tree.inventory.query('license', license).size, license])
-    }
+module.exports = (options, time) => {
+  const query = options._.shift()
+  const a = new Arborist(options)
+  return a
+    .loadVirtual()
+    .then(tree => {
+      // only load the actual tree if the virtual one doesn't have modern metadata
+      if (!tree.meta || !(tree.meta.originalLockfileVersion >= 2)) {
+        throw 'load actual'
+      } else {
+        return tree
+      }
+    }).catch((er) => {
+      log.error('loading actual tree', er)
+      return a.loadActual()
+    })
+    .then(time)
+    .then(({ result: tree }) => {
+      const output = []
+      if (!query) {
+        const set = []
+        for (const license of tree.inventory.query('license')) {
+          set.push([tree.inventory.query('license', license).size, license])
+        }
 
-    for (const [count, license] of set.sort((a, b) =>
-      a[1] && b[1] ? b[0] - a[0] || a[1].localeCompare(b[1], 'en')
-      : a[1] ? -1
-      : b[1] ? 1
-      : 0)) {
-      console.log(count, license)
-    }
-  } else {
-    for (const node of tree.inventory.query('license', query === 'undefined' ? undefined : query)) {
-      console.log(`${node.name} ${node.location} ${node.package.description || ''}`)
-    }
-  }
-})
+        for (const [count, license] of set.sort((a, b) =>
+          a[1] && b[1] ? b[0] - a[0] || a[1].localeCompare(b[1], 'en')
+          : a[1] ? -1
+          : b[1] ? 1
+          : 0)) {
+          output.push(`${count} ${license}`)
+          log.info(count, license)
+        }
+      } else {
+        for (const node of tree.inventory.query('license', query === 'undefined' ? undefined : query)) {
+          const msg = `${node.name} ${node.location} ${node.package.description || ''}`
+          output.push(msg)
+          log.info(msg)
+        }
+      }
+
+      return output.join('\n')
+    })
+}

--- a/bin/prune.js
+++ b/bin/prune.js
@@ -1,9 +1,7 @@
 const Arborist = require('../')
 
-const options = require('./lib/options.js')
-const print = require('./lib/print-tree.js')
-require('./lib/logging.js')
-require('./lib/timers.js')
+const printTree = require('./lib/print-tree.js')
+const log = require('./lib/logging.js')
 
 const printDiff = diff => {
   const { depth } = require('treeverse')
@@ -15,13 +13,13 @@ const printDiff = diff => {
       }
       switch (d.action) {
         case 'REMOVE':
-          console.error('REMOVE', d.actual.location)
+          log.info('REMOVE', d.actual.location)
           break
         case 'ADD':
-          console.error('ADD', d.ideal.location, d.ideal.resolved)
+          log.info('ADD', d.ideal.location, d.ideal.resolved)
           break
         case 'CHANGE':
-          console.error('CHANGE', d.actual.location, {
+          log.info('CHANGE', d.actual.location, {
             from: d.actual.resolved,
             to: d.ideal.resolved,
           })
@@ -32,18 +30,19 @@ const printDiff = diff => {
   })
 }
 
-const start = process.hrtime()
-process.emit('time', 'install')
-const arb = new Arborist(options)
-arb.prune(options).then(tree => {
-  process.emit('timeEnd', 'install')
-  const end = process.hrtime(start)
-  print(tree)
-  if (options.dryRun) {
-    printDiff(arb.diff)
-  }
-  console.error(`resolved ${tree.inventory.size} deps in ${end[0] + end[1] / 1e9}s`)
-  if (tree.meta && options.save) {
-    tree.meta.save()
-  }
-}).catch(er => console.error(require('util').inspect(er, { depth: Infinity })))
+module.exports = (options, time) => {
+  const arb = new Arborist(options)
+  return arb
+    .prune(options)
+    .then(time)
+    .then(async ({ timing, result: tree }) => {
+      printTree(tree)
+      if (options.dryRun) {
+        printDiff(arb.diff)
+      }
+      if (tree.meta && options.save) {
+        await tree.meta.save()
+      }
+      return `resolved ${tree.inventory.size} deps in ${timing.seconds}`
+    })
+}

--- a/bin/reify.js
+++ b/bin/reify.js
@@ -1,9 +1,7 @@
 const Arborist = require('../')
 
-const options = require('./lib/options.js')
-const print = require('./lib/print-tree.js')
-require('./lib/logging.js')
-require('./lib/timers.js')
+const printTree = require('./lib/print-tree.js')
+const log = require('./lib/logging.js')
 
 const printDiff = diff => {
   const { depth } = require('treeverse')
@@ -15,13 +13,13 @@ const printDiff = diff => {
       }
       switch (d.action) {
         case 'REMOVE':
-          console.error('REMOVE', d.actual.location)
+          log.info('REMOVE', d.actual.location)
           break
         case 'ADD':
-          console.error('ADD', d.ideal.location, d.ideal.resolved)
+          log.info('ADD', d.ideal.location, d.ideal.resolved)
           break
         case 'CHANGE':
-          console.error('CHANGE', d.actual.location, {
+          log.info('CHANGE', d.actual.location, {
             from: d.actual.resolved,
             to: d.ideal.resolved,
           })
@@ -32,18 +30,19 @@ const printDiff = diff => {
   })
 }
 
-const start = process.hrtime()
-process.emit('time', 'install')
-const arb = new Arborist(options)
-arb.reify(options).then(tree => {
-  process.emit('timeEnd', 'install')
-  const end = process.hrtime(start)
-  print(tree)
-  if (options.dryRun) {
-    printDiff(arb.diff)
-  }
-  console.error(`resolved ${tree.inventory.size} deps in ${end[0] + end[1] / 1e9}s`)
-  if (tree.meta && options.save) {
-    tree.meta.save()
-  }
-}).catch(er => console.error(require('util').inspect(er, { depth: Infinity })))
+module.exports = (options, time) => {
+  const arb = new Arborist(options)
+  return arb
+    .reify(options)
+    .then(time)
+    .then(async ({ timing, result: tree }) => {
+      printTree(tree)
+      if (options.dryRun) {
+        printDiff(arb.diff)
+      }
+      if (tree.meta && options.save) {
+        await tree.meta.save()
+      }
+      return `resolved ${tree.inventory.size} deps in ${timing.seconds}`
+    })
+}

--- a/bin/shrinkwrap.js
+++ b/bin/shrinkwrap.js
@@ -1,12 +1,7 @@
 const Shrinkwrap = require('../lib/shrinkwrap.js')
-const options = require('./lib/options.js')
-require('./lib/logging.js')
-require('./lib/timers.js')
 
-const { quiet } = options
-Shrinkwrap.load(options)
-  .then(s => quiet || console.log(JSON.stringify(s.commit(), 0, 2)))
-  .catch(er => {
-    console.error('shrinkwrap load failure', er)
-    process.exit(1)
-  })
+module.exports = (options, time) => Shrinkwrap
+  .load(options)
+  .then((s) => s.commit())
+  .then(time)
+  .then(({ result: s }) => JSON.stringify(s, 0, 2))

--- a/bin/virtual.js
+++ b/bin/virtual.js
@@ -1,18 +1,14 @@
 const Arborist = require('../')
 
-const print = require('./lib/print-tree.js')
-const options = require('./lib/options.js')
-require('./lib/logging.js')
-require('./lib/timers.js')
+const printTree = require('./lib/print-tree.js')
 
-const start = process.hrtime()
-new Arborist(options).loadVirtual().then(tree => {
-  const end = process.hrtime(start)
-  if (!options.quiet) {
-    print(tree)
-  }
-  if (options.save) {
-    tree.meta.save()
-  }
-  console.error(`read ${tree.inventory.size} deps in ${end[0] * 1000 + end[1] / 1e6}ms`)
-}).catch(er => console.error(er))
+module.exports = (options, time) => new Arborist(options)
+  .loadVirtual()
+  .then(time)
+  .then(({ timing, result: tree }) => {
+    printTree(tree)
+    if (options.save) {
+      tree.meta.save()
+    }
+    return `read ${tree.inventory.size} deps in ${timing.ms}`
+  })


### PR DESCRIPTION
Also refactors bin script to use consistent timing and logging.

This fell out of removing `npmlog` progress from arborist. It was help to easily write logfiles for arborist runs to compare output.

This could also help with benchmarking in the future as it initiates time/timeEnd events and reports timing output more consistently.