### PR TITLE
fix: _findMissingEdges missing dependency due to inconsistent path separators

### DIFF
--- a/lib/arborist/load-actual.js
+++ b/lib/arborist/load-actual.js
@@ -430,7 +430,7 @@ module.exports = cls => class ActualLoader extends cls {
           if (d.dummy) {
             // it's a placeholder, so likely would not have loaded this dep,
             // unless another dep in the tree also needs it.
-            const depPath = `${p}/node_modules/${name}`
+            const depPath = normalize(`${p}/node_modules/${name}`)
             const cached = this[_cache].get(depPath)
             if (!cached || cached.dummy) {
               depPromises.push(this[_loadFSNode]({

--- a/test/arborist/load-actual.js
+++ b/test/arborist/load-actual.js
@@ -422,3 +422,48 @@ t.test('load global space with link deps', async t => {
     },
   })
 })
+
+t.test('no edge errors for nested deps', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'a',
+      version: '1.0.0',
+      dependencies: {
+        b: '1.0.0',
+      },
+    }),
+    node_modules: {
+      b: {
+        'package.json': JSON.stringify({
+          name: 'b',
+          version: '1.0.0',
+          dependencies: {
+            c: '1.0.0',
+          },
+        }),
+      },
+      c: {
+        'package.json': JSON.stringify({
+          name: 'c',
+          version: '1.0.0',
+        }),
+      },
+    },
+  })
+
+  // disable treeCheck since it prevents the original issue from occuring
+  const ArboristNoTreeCheck = t.mock('../../lib/arborist', {
+    '../../lib/tree-check.js': tree => tree,
+  })
+  const loadActualNoTreeCheck = (path, opts) =>
+    new ArboristNoTreeCheck({ path, ...opts }).loadActual(opts)
+
+  const tree = await loadActualNoTreeCheck(path)
+
+  // assert that no outgoing edges have errors
+  for (const node of tree.inventory.values()) {
+    for (const [name, edge] of node.edgesOut.entries()) {
+      t.equal(edge.error, null, `node ${node.name} has outgoing edge to ${name} with error ${edge.error}`)
+    }
+  }
+})


### PR DESCRIPTION
When installing a package with bundled dependencies with npm it can end up missing some dependencies that were bundled and attempt to fetch from the remote registry (see https://github.com/npm/cli/issues/2757). This issue only happens on Windows and it's caused by `_findMissingEdges` missing one of the bundled dependencies. The reason it only happens on Windows is because of this lookup in `this[_cache]` with a path that contains mixed path separators:
https://github.com/npm/arborist/blob/02f295f2d0caa6de2d3235c6eb1c180a8afa0f6f/lib/arborist/load-actual.js#L433-L435

On macOS we get a result back and avoid creating a new node. On Windows we get no result since the key in the cache is using backslashes but the lookup key has both backslashes and forward slashes. This results in a new node being created with the path of an existing node which in turn removes the existing node and its children from the tree. The children are however not loaded from the file system again because of this check:
https://github.com/npm/arborist/blob/02f295f2d0caa6de2d3235c6eb1c180a8afa0f6f/lib/arborist/load-actual.js#L353-L357

The end result is an unmet dependency and npm attempting to fetch it from the registry instead of using the bundled dependency.

I've changed the cache key by normalizing the path to avoid replacing existing nodes. I've setup a minimal test case where the difference in behavior (with and without normalization) shows up as an error on the outgoing edge of a node.

## References
Fixes https://github.com/npm/cli/issues/2757
